### PR TITLE
[#25] Enable flamelet scalar calculations.

### DIFF
--- a/src/stanshock/physics/cantera_interface.py
+++ b/src/stanshock/physics/cantera_interface.py
@@ -7,10 +7,9 @@ from stanshock.physics.fluid_base import FluidPhysics, FluidState
 
 
 class CanteraInterface(FluidPhysics):
-    def __init__(self, gas: ct.Solution):
-        super().__init__(gas)
+    def __init__(self, gas: ct.Solution, ox_def=None, fuel_def=None, prog_def=None):
+        super().__init__(gas, ox_def, fuel_def, prog_def)
         self._cached_solutions: dict[int, ct.SolutionArray] = {}
-        self._cache_valid: dict[int, bool] = {}
 
     def set_state(self, state: FluidState) -> FluidState:
         """Sets up a Cantera SolutionArray with the current fluid state.

--- a/src/stanshock/physics/flamelet.py
+++ b/src/stanshock/physics/flamelet.py
@@ -70,7 +70,7 @@ class FPVTable(FluidPhysics):
         self.initialize_bilger_mixture_fraction()
 
         if self.prog_def is not None:
-            self.initialize_progress_variable(prog_def)
+            self.initialize_progress_variable(self.prog_def)
 
     def get_fuel_and_oxidizer_definitions(self, cutoff=1e-6):
         """Get the fuel and oxidizer composition from the table."""

--- a/src/stanshock/physics/thermotable.py
+++ b/src/stanshock/physics/thermotable.py
@@ -85,14 +85,14 @@ class ThermoTable(CanteraInterface):
     relevant methods
     """
 
-    def __init__(self, gas: ct.Solution):
+    def __init__(self, gas: ct.Solution, ox_def=None, fuel_def=None, prog_def=None):
         """
         This method initializes the temperature table. The table uses a
         piecewise linear function for the constant pressure specific heat
         coefficients. The coefficients are selected to retain the exact
         enthalpies at the table points.
         """
-        super().__init__(gas)
+        super().__init__(gas, ox_def, fuel_def, prog_def)
         nSp = gas.n_species
         self.TMin = 50.0
         self.dT = 100.0


### PR DESCRIPTION
In the recent push I forgot to propagate the fuel, oxidizer, and progress variable definitions from CanteraInterface and ThermoTable to the FluidPhysics base class. This is a quick fix which simplifies the process of computing mixture fraction and progress variable for non-FPVTable physics.

Closes #25.