### PR TITLE
[#38] Fully define Array and Index type aliases.

### DIFF
--- a/src/stanshock/physics/fluid_base.py
+++ b/src/stanshock/physics/fluid_base.py
@@ -13,23 +13,23 @@ from stanshock.system.backend import Array
 class FluidState:
     shape: tuple[int, ...]
 
-    density: np.ndarray | None = None
-    temperature: np.ndarray | None = None
-    pressure: np.ndarray | None = None
-    mass_fractions: np.ndarray | None = None
-    mole_fractions: np.ndarray | None = None
-    mixture_fraction: np.ndarray | None = None
-    progress_variable: np.ndarray | None = None
-    normalized_progress_variable: np.ndarray | None = None
-    composition: np.ndarray | None = None
+    density: Array | None = None
+    temperature: Array | None = None
+    pressure: Array | None = None
+    mass_fractions: Array | None = None
+    mole_fractions: Array | None = None
+    mixture_fraction: Array | None = None
+    progress_variable: Array | None = None
+    normalized_progress_variable: Array | None = None
+    composition: Array | None = None
 
-    cp: np.ndarray | None = None
-    gamma: np.ndarray | None = None
-    viscosity: np.ndarray | None = None
-    thermal_conductivity: np.ndarray | None = None
-    sound_speed: np.ndarray | None = None
+    cp: Array | None = None
+    gamma: Array | None = None
+    viscosity: Array | None = None
+    thermal_conductivity: Array | None = None
+    sound_speed: Array | None = None
 
-    velocity: np.ndarray | None = None
+    velocity: Array | None = None
 
     _cache_valid: bool = False
 

--- a/src/stanshock/system/backend.py
+++ b/src/stanshock/system/backend.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import sys
 from typing import Union
 
 import numpy as np
-from typing_extensions import TypeAlias
+
+if sys.version_info >= (3, 13):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
 __all__ = ["Array", "Index", "np"]
 

--- a/src/stanshock/system/backend.py
+++ b/src/stanshock/system/backend.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+from typing import Union
+
 import numpy as np
+from typing_extensions import TypeAlias
+
+__all__ = ["Array", "Index", "np"]
 
 # Define the Array type for use in type hints to make future changes easier
-Array = np.ndarray
+Array: TypeAlias = np.ndarray[tuple[int, ...], np.dtype[np.float64]]
+# Note: Must use Union instead of |, but only in Python <3.10 and only in TypeAlias
+Index: TypeAlias = Union[np.ndarray[tuple[int, ...], np.dtype[np.int64]], slice]


### PR DESCRIPTION
Closes #38 by fixing the Array type alias, and adding a new Index type alias.