### PR TITLE
Generalize boundary conditions

### DIFF
--- a/examples/hyshot_ii.py
+++ b/examples/hyshot_ii.py
@@ -109,9 +109,7 @@ initState = gas_init, U_in
 W_in = gas_init.mean_molecular_weight
 
 # Define the boundary conditions
-BC_inlet = Inflow(
-    reference_state=(gas_init.density, U_in, gas_init.P, (1.0, *gas_init.Y))
-)
+BC_inlet = Inflow(reference_state=(gas_init.density, U_in, gas_init.P, gas_init.Y))
 BC_outlet = "outflow"
 BCs = (BC_inlet, BC_outlet)
 

--- a/examples/hyshot_ii.py
+++ b/examples/hyshot_ii.py
@@ -8,6 +8,7 @@ import numpy as np
 from scipy import interpolate
 
 from stanshock.components.combustor import Combustor
+from stanshock.numerics.boundary_conditions import Inflow
 
 plt.rcParams.update(
     {
@@ -108,7 +109,9 @@ initState = gas_init, U_in
 W_in = gas_init.mean_molecular_weight
 
 # Define the boundary conditions
-BC_inlet = gas_init.density, U_in, gas_init.P, gas_init.Y
+BC_inlet = Inflow(
+    reference_state=(gas_init.density, U_in, gas_init.P, (1.0, *gas_init.Y))
+)
 BC_outlet = "outflow"
 BCs = (BC_inlet, BC_outlet)
 

--- a/examples/hyshot_ii_jic/hyshot_ii_jic.py
+++ b/examples/hyshot_ii_jic/hyshot_ii_jic.py
@@ -9,6 +9,7 @@ import numpy as np
 from scipy import interpolate, optimize
 
 from stanshock.components.combustor import Combustor
+from stanshock.numerics.boundary_conditions import Inflow
 from stanshock.physics.flamelet import FPVTable
 from stanshock.physics.jicf import JICModel
 from stanshock.processing.plot import XTDiagram
@@ -244,7 +245,7 @@ gas_init.TPX = T_in, P_in, "O2:1,N2:3.76"
 initState = gas_init, U_in
 
 # Define the boundary conditions
-BC_inlet = gas_init.density, U_in, gas_init.P, (0.0, 0.0)
+BC_inlet = Inflow(reference_state=(gas_init.density, U_in, gas_init.P, (1.0, 0.0, 0.0)))
 BC_outlet = "outflow"
 BCs = (BC_inlet, BC_outlet)
 

--- a/examples/laminar_flame.py
+++ b/examples/laminar_flame.py
@@ -80,15 +80,13 @@ def main(
     # interpolate flame solution
     Y = ss.state.composition
     for iSp in range(gas.n_species):
-        Y[:, iSp] = np.interp(ss.geometry.x, flame.grid, flame.Y[iSp, :])
+        Y[ss.idx_cells, iSp] = np.interp(ss.geometry.x, flame.grid, flame.Y[iSp, :])
 
-    ss.state = FluidState(
-        shape=(nX,),
-        density=np.interp(ss.geometry.x, flame.grid, flame.density),
-        velocity=np.interp(ss.geometry.x, flame.grid, flame.velocity),
-        pressure=flame.P * np.ones(ss.geometry.n),
-        composition=Y,
-    )
+    ss.state.density[ss.idx_cells] = np.interp(ss.geometry.x, flame.grid, flame.density)
+    ss.state.velocity[ss.idx_cells] = np.interp(ss.geometry.x, flame.grid, flame.velocity)
+    ss.state.pressure[ss.idx_cells] = flame.P * np.ones(ss.geometry.n)
+    ss.state.composition = Y
+
     T = ss.state.temperature = ss.physics.get_temperature(ss.state)
     ss.state.gamma = ss.physics.get_gamma(ss.state)
 
@@ -104,7 +102,7 @@ def main(
 
     # plot setup
     if plot_results:
-        T = ss.physics.get_temperature(ss.state)
+        T = ss.physics.get_temperature(ss.state)[ss.idx_cells]
         state = ss.physics.set_state(ss.state)
 
         plt.close("all")
@@ -131,7 +129,7 @@ def main(
         )
         plt.plot(
             (ss.geometry.x - flame_center) / flameThickness,
-            state.mass_fractions[:, iOH] * 10,
+            state.mass_fractions[ss.idx_cells, iOH] * 10,
             "k--s",
         )
         iO2 = gas.species_index("O2")
@@ -143,7 +141,7 @@ def main(
         )
         plt.plot(
             (ss.geometry.x - flame_center) / flameThickness,
-            state.mass_fractions[:, iO2],
+            state.mass_fractions[ss.idx_cells, iO2],
             "g--s",
         )
         iH2 = gas.species_index("H2")
@@ -155,7 +153,7 @@ def main(
         )
         plt.plot(
             (ss.geometry.x - flame_center) / flameThickness,
-            state.mass_fractions[:, iH2],
+            state.mass_fractions[ss.idx_cells, iH2],
             "b--s",
         )
         plt.xlabel(r"$x/\delta_\mathrm{F}$")
@@ -169,7 +167,7 @@ def main(
 
     results = {
         "position": ss.geometry.x,
-        "temperature": T,
+        "temperature": T[ss.idx_cells],
     }
     if results_location is not None:
         results_location = Path(results_location)

--- a/examples/laminar_flame.py
+++ b/examples/laminar_flame.py
@@ -10,7 +10,6 @@ from matplotlib import pyplot as plt
 
 from stanshock.components.combustor import Combustor
 from stanshock.physics.cantera_interface import CanteraInterface
-from stanshock.physics.fluid_base import FluidState
 from stanshock.physics.thermotable import ThermoTable
 
 
@@ -83,7 +82,9 @@ def main(
         Y[ss.idx_cells, iSp] = np.interp(ss.geometry.x, flame.grid, flame.Y[iSp, :])
 
     ss.state.density[ss.idx_cells] = np.interp(ss.geometry.x, flame.grid, flame.density)
-    ss.state.velocity[ss.idx_cells] = np.interp(ss.geometry.x, flame.grid, flame.velocity)
+    ss.state.velocity[ss.idx_cells] = np.interp(
+        ss.geometry.x, flame.grid, flame.velocity
+    )
     ss.state.pressure[ss.idx_cells] = flame.P * np.ones(ss.geometry.n)
     ss.state.composition = Y
 

--- a/examples/validation/case4.py
+++ b/examples/validation/case4.py
@@ -177,6 +177,7 @@ def main(
     VNorms = V / VDriver
     # get gas properties
     iHE, iN2 = gas4.species_index("HE"), gas4.species_index("N2")
+    mt = ssbl.n_ghost_layers
     for iX, VNorm in enumerate(VNorms):
         if VNorm <= 1.0:
             # nitrogen and helium
@@ -185,9 +186,9 @@ def main(
             XHE = 1.0 - XN2
             X[[iHE, iN2]] = XHE, XN2
             gas4.TPX = T4, p4, X
-            ssbl.state.density[iX] = gas4.density
-            ssbl.state.composition[iX, :] = gas4.Y
-            ssbl.state.gamma[iX] = gas4.cp / gas4.cv
+            ssbl.state.density[iX + mt] = gas4.density
+            ssbl.state.composition[iX + mt, :] = gas4.Y
+            ssbl.state.gamma[iX + mt] = gas4.cp / gas4.cv
 
     # Solve
     t0 = time.perf_counter()
@@ -234,6 +235,7 @@ def main(
     VNorms = V / VDriver
     # get gas properties
     iHE, iN2 = gas4.species_index("HE"), gas4.species_index("N2")
+    mt = ssnbl.n_ghost_layers
     for iX, VNorm in enumerate(VNorms):
         if VNorm <= 1.0:
             # nitrogen and helium
@@ -242,9 +244,9 @@ def main(
             XHE = 1.0 - XN2
             X[[iHE, iN2]] = XHE, XN2
             gas4.TPX = T4, p4, X
-            ssnbl.state.density[iX] = gas4.density
-            ssnbl.state.composition[iX, :] = gas4.Y
-            ssnbl.state.gamma[iX] = gas4.cp / gas4.cv
+            ssnbl.state.density[iX + mt] = gas4.density
+            ssnbl.state.composition[iX + mt, :] = gas4.Y
+            ssnbl.state.gamma[iX + mt] = gas4.cp / gas4.cv
 
     # Solve
     t0 = time.perf_counter()

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -4,8 +4,18 @@ import cantera as ct
 import numpy as np
 
 from stanshock.models.boundary_layer import BoundaryLayer
-from stanshock.numerics.face_extrapolation import FifthOrderWeno, FirstOrder
-from stanshock.numerics.inviscid_flux import InviscidFlux, hllc_flux
+from stanshock.numerics.boundary_conditions import (
+    BCNamesType,
+    BCType,
+    BoundaryConditions,
+    set_boundary_conditions,
+)
+from stanshock.numerics.face_extrapolation import (
+    FaceExtrapolator,
+    FifthOrderWeno,
+    FirstOrder,
+)
+from stanshock.numerics.inviscid_flux import InviscidFlux, RiemannSolver, hllc_flux
 from stanshock.numerics.viscous_flux import ViscousFlux
 from stanshock.physics.flamelet import FPVTable
 from stanshock.physics.fluid_base import FluidPhysics, FluidState
@@ -15,6 +25,7 @@ from stanshock.processing.initialize import (
     initialize_riemann_problem,
 )
 from stanshock.processing.plot import plot_state
+from stanshock.system.backend import Index
 from stanshock.system.base import RightHandSide
 from stanshock.system.geometry import Geometry
 
@@ -36,13 +47,13 @@ class Combustor:
         allow the user to initialize the state
         """
         # initialize the class
-        self.mt = 3  # number of ghost nodes
-        self.mn = 3  # number of 1D Euler equations
-
         self.cfl = 1.0  # stability condition
         self.dx = 1.0  # grid spacing
         self.n = n  # grid size
-        self.boundary_conditions = ["outflow", "outflow"]
+        self.boundary_conditions: BoundaryConditions | list[BCNamesType | BCType] = [
+            "outflow",
+            "outflow",
+        ]
         self.x = np.linspace(0.0, self.dx * (self.n - 1), self.n)
         self.F = np.ones(self.n)  # thickening
         self.t = 0.0  # time
@@ -64,7 +75,9 @@ class Combustor:
         self.wall_temperature = None  # wall temperature (needed for BL)
         self.source_terms: RightHandSide | None = None  # source term function
         self.injector = None  # injector model
-        self.flux_function = hllc_flux
+        self.flux_function: RiemannSolver = hllc_flux
+        self.inviscid_face_extrapolator: FaceExtrapolator = FifthOrderWeno
+        self.viscous_face_extrapolator: FaceExtrapolator = FirstOrder
         self.initialization = None  # initialization options
         self.probes = []  # list of probe objects
         self.xt_diagrams = []  # list of XT diagram objects
@@ -100,6 +113,18 @@ class Combustor:
             msg = "JIC injector model requires FPVTable physics."
             raise Exception(msg)
 
+        # Determine the number of ghost layers required by the spatial scheme
+        self.n_ghost_layers: int = self.inviscid_face_extrapolator.minimum_ghost_layers
+        if self.include_diffusion:
+            self.n_ghost_layers = max(
+                self.n_ghost_layers, self.viscous_face_extrapolator.minimum_ghost_layers
+            )
+
+        # Set up boundary conditions
+        self.boundary_conditions: BoundaryConditions = set_boundary_conditions(
+            self.boundary_conditions, self.n_ghost_layers
+        )
+
         # initialize the state
         if self.initialization is None:
             msg = "No initialization method selected"
@@ -119,20 +144,22 @@ class Combustor:
 
         # Initialize the key physics
         self.inviscid_flux = InviscidFlux(
-            face_extrapolator=FifthOrderWeno(
-                n_scalars_rho_sum=self.physics.n_scalars_rho_sum
+            face_extrapolator=self.inviscid_face_extrapolator(
+                n_scalars_rho_sum=self.physics.n_scalars_rho_sum,
+                n_ghost_layers=self.n_ghost_layers,
             ),
-            boundary_conditions=self.apply_boundary_conditions,
+            boundary_conditions=self.boundary_conditions,
             riemann_solver=self.flux_function,
             dx=self.geometry.dx,
         )
 
         if self.include_diffusion:
             self.viscous_flux = ViscousFlux(
-                face_extrapolator=FirstOrder(
-                    n_scalars_rho_sum=self.physics.n_scalars_rho_sum
+                face_extrapolator=self.viscous_face_extrapolator(
+                    n_scalars_rho_sum=self.physics.n_scalars_rho_sum,
+                    n_ghost_layers=self.n_ghost_layers,
                 ),
-                boundary_conditions=self.apply_boundary_conditions,
+                boundary_conditions=self.boundary_conditions,
                 dx=self.geometry.dx,
             )
 
@@ -144,6 +171,11 @@ class Combustor:
                 wall_temperature=self.wall_temperature,
                 skin_friction_coefficient=self.skin_friction_coefficient,
             )
+
+        # Extend the domain to include the ghost layers
+        self.state = self.inviscid_flux.face_extrapolator.add_ghost_layers(self.state)
+        self.idx_cells: Index = np.s_[self.n_ghost_layers : -self.n_ghost_layers]
+        self.F = np.pad(self.F, self.n_ghost_layers, mode="edge")
 
     def get_wave_speed(self):
         """
@@ -176,60 +208,6 @@ class Combustor:
             local_timescale = np.minimum(local_timescale, viscous_timescale)
         return self.cfl * min(local_timescale)
 
-    def apply_boundary_conditions(self, face_states: FluidState):
-        """
-        This method applies the prescribed BCs declared by the user.
-        Currently, only reflecting (adiabatic wall) and outflow (symmetry)
-        boundary conditions are supported. The user may include Dirichlet
-        condition as well. This method returns the updated primitives.
-            inputs:
-                rLR=density on left and right face [2,n+1]
-                uLR=velocity on left and right face [2,n+1]
-                pLR=pressure on left and right face [2,n+1]
-                YLR=scalar on left and right face [2,n+1,nsp]
-            outputs:
-                rLR=density on left and right face [2,n+1]
-                uLR=velocity on left and right face [2,n+1]
-                pLR=pressure on left and right face [2,n+1]
-                YLR=scalar on left and right face [2,n+1,nsp]
-        """
-        rLR = face_states.density
-        uLR = face_states.velocity
-        pLR = face_states.pressure
-        YLR = face_states.composition
-
-        for ibc in [0, 1]:
-            NAssign = ibc
-            NUse = 1 - ibc
-            iX = -ibc
-            rLR[NAssign, iX] = rLR[NUse, iX]
-            uLR[NAssign, iX] = uLR[NUse, iX]
-            pLR[NAssign, iX] = pLR[NUse, iX]
-            YLR[NAssign, iX, :] = YLR[NUse, iX, :]
-            if type(self.boundary_conditions[ibc]) is str:
-                if (
-                    self.boundary_conditions[ibc].lower() == "reflecting"
-                    or self.boundary_conditions[ibc].lower() == "symmetry"
-                ):
-                    uLR[NAssign, iX] = 0.0
-                elif (
-                    self.verbose and self.boundary_conditions[ibc].lower() != "outflow"
-                ):
-                    print(
-                        """Unrecognized Boundary Condition. Applying outflow by default.\n"""
-                    )
-            else:
-                # assign Dirichlet conditions to (r,u,p,Y)
-                if self.boundary_conditions[ibc][0] is not None:
-                    rLR[NAssign, iX] = self.boundary_conditions[ibc][0]
-                if self.boundary_conditions[ibc][1] is not None:
-                    uLR[NAssign, iX] = self.boundary_conditions[ibc][1]
-                if self.boundary_conditions[ibc][2] is not None:
-                    pLR[NAssign, iX] = self.boundary_conditions[ibc][2]
-                if self.boundary_conditions[ibc][3] is not None:
-                    YLR[NAssign, iX, :] = self.boundary_conditions[ibc][3]
-        return face_states
-
     def advance_advection(self, dt):
         """
         This method advances the advection terms by the prescribed timestep.
@@ -237,29 +215,26 @@ class Combustor:
             inputs
                 dt=time step
         """
-        # Add ghost layers to the fluid state
-        face_extrapolator = self.inviscid_flux.face_extrapolator
-        mt = face_extrapolator.mt
-        state = face_extrapolator.add_ghost_layers(self.state)
-        y = self.physics.primitive_to_conservative(state)
-        gamma_star = state.gamma  # Double-flux gamma* held constant over time step
+        y = self.physics.primitive_to_conservative(self.state)
+        gamma_star = self.state.gamma  # Double-flux gamma* held constant over time step
 
         # 1st stage of RK3
         dydt = self.inviscid_flux.source(self.t, y, self.physics, gamma_star)
         y1 = y.copy()
-        y1[mt:-mt] += dt * dydt
+        y1[self.idx_cells] += dt * dydt
 
         # 2nd stage of RK3
         dydt = self.inviscid_flux.source(self.t, y1, self.physics, gamma_star)
         y2 = 0.75 * y + 0.25 * y1
-        y2[mt:-mt] += 0.25 * dt * dydt
+        y2[self.idx_cells] += 0.25 * dt * dydt
 
         # 3rd stage of RK3
         dydt = self.inviscid_flux.source(self.t, y2, self.physics, gamma_star)
-        y = (1.0 / 3.0) * y[mt:-mt] + (2.0 / 3.0) * y2[mt:-mt] + (2.0 / 3.0) * dt * dydt
+        y[self.idx_cells] /= 3.0
+        y[self.idx_cells] += (2.0 / 3.0) * y2[self.idx_cells] + (2.0 / 3.0) * dt * dydt
 
         # Remove ghost layers and update gamma
-        self.state = self.physics.conservative_to_primitive(y, gamma_star[mt:-mt])
+        self.state = self.physics.conservative_to_primitive(y, gamma_star)
         self.state.temperature = self.physics.get_temperature(self.state)
         self.state.gamma = self.physics.get_gamma(self.state)
 
@@ -269,12 +244,9 @@ class Combustor:
             inputs
                 dt=time step
         """
-        # Add ghost layers to the fluid state
-        face_extrapolator = self.viscous_flux.face_extrapolator
-        mt = face_extrapolator.mt
-        state = face_extrapolator.add_ghost_layers(self.state)
-        y = self.physics.primitive_to_conservative(state)
-        gamma_star = state.gamma  # Double-flux gamma* held constant over time step
+        mt: int = self.n_ghost_layers
+        y = self.physics.primitive_to_conservative(self.state)
+        gamma_star = self.state.gamma  # Double-flux gamma* held constant over time step
 
         if self.thickening is not None:
             self.F = self.thickening(self)
@@ -285,14 +257,15 @@ class Combustor:
         # 1st stage of RK2
         dydt = self.viscous_flux.source(self.t, y, self.physics, gamma_star)
         y1 = y.copy()
-        y1[mt:-mt] += dt * dydt
+        y1[self.idx_cells] += dt * dydt
 
         # 2nd stage of RK2
         dydt = self.viscous_flux.source(self.t, y1, self.physics, gamma_star)
-        y = 0.5 * (y[mt:-mt] + y1[mt:-mt] + dt * dydt)
+        y[self.idx_cells] *= 0.5
+        y[self.idx_cells] += 0.5 * (y1[self.idx_cells] + dt * dydt)
 
         # Remove ghost layers and update gamma
-        self.state = self.physics.conservative_to_primitive(y, gamma_star[mt:-mt])
+        self.state = self.physics.conservative_to_primitive(y, gamma_star)
         self.state.temperature = self.physics.get_temperature(self.state)
         self.state.gamma = self.physics.get_gamma(self.state)
 
@@ -335,7 +308,7 @@ class Combustor:
         # Using FPV
         # initialize
         y = self.physics.primitive_to_conservative(self.state)
-        (r, rZ, rC) = y[:, 2], y[:, 3], y[:, 4]
+        (r, rZ, rC) = y[self.idx_cells, 2], y[self.idx_cells, 3], y[self.idx_cells, 4]
         Z = rZ / r
         C = rC / r
         Q = np.zeros(self.geometry.n)
@@ -345,11 +318,11 @@ class Combustor:
         # 1st stage of RK2
         omegaC = r * self.injector.get_chemical_sources(Z, C)
         y1 = y.copy()
-        y1[:, 4] += dt * omegaC
-        C1 = y1[:, 4] / r
+        y1[self.idx_cells, 4] += dt * omegaC
+        C1 = y1[self.idx_cells, 4] / r
         L1 = self.physics.get_normalized_progress_variable(Z, C1)
         e_chem1 = r * self.physics.lookup_direct("E0_CHEM", Z, Q, L1)
-        y1[:, 1] += e_chem0 - e_chem1
+        y1[self.idx_cells, 1] += e_chem0 - e_chem1
         state1 = self.physics.conservative_to_primitive(y1, self.state.gamma)
         state1.gamma = self.state.gamma
 
@@ -358,10 +331,12 @@ class Combustor:
         omegaC1 = state1.density * self.injector.get_chemical_sources(
             state1.Z, state1.C
         )
-        rC = y[:, 4] = 0.5 * (y[:, 4] + y1[:, 4] + dt * omegaC1)
+        rC = y[:, 4] = 0.5 * (
+            y[self.idx_cells, 4] + y1[self.idx_cells, 4] + dt * omegaC1
+        )
         L = self.physics.get_normalized_progress_variable(Z, rC / r)
         e_chem2 = r * self.physics.lookup_direct("E0_CHEM", Z, Q, L)
-        y[:, 1] += e_chem0 - e_chem2
+        y[self.idx_cells, 1] += e_chem0 - e_chem2
         self.state = self.physics.conservative_to_primitive(y, self.state.gamma)
 
         # update properties
@@ -412,8 +387,8 @@ class Combustor:
 
         # get indices
         indices = [
-            k
-            for k in range(self.geometry.n)
+            k + self.n_ghost_layers
+            for k in range(self.n)
             if self.in_reacting_region(self.geometry.x[k], self.t)
         ]
         state_temp = FluidState(
@@ -461,10 +436,16 @@ class Combustor:
         """
         y = self.physics.primitive_to_conservative(self.state)
 
-        dydt = self.geometry.source(self.t, y, self.physics, self.state.gamma, dt)
+        dydt = self.geometry.source(
+            self.t,
+            y[self.idx_cells],
+            self.physics,
+            self.state.gamma[self.idx_cells],
+            dt,
+        )
 
         # Update
-        y += dt * dydt
+        y[self.idx_cells] += dt * dydt
         self.state = self.physics.conservative_to_primitive(y, self.state.gamma)
         self.state.temperature = self.physics.get_temperature(self.state)
         self.state.gamma = self.physics.get_gamma(self.state)
@@ -477,10 +458,12 @@ class Combustor:
         """
         y = self.physics.primitive_to_conservative(self.state)
 
-        dydt = self.boundary_layer.source(self.t, y, self.physics, self.state.gamma)
+        dydt = self.boundary_layer.source(
+            self.t, y[self.idx_cells], self.physics, self.state.gamma[self.idx_cells]
+        )
 
         # Update
-        y += dydt * dt
+        y[self.idx_cells] += dydt * dt
         self.state = self.physics.conservative_to_primitive(y, self.state.gamma)
         self.state.temperature = self.physics.get_temperature(self.state)
         self.state.gamma = self.physics.get_gamma(self.state)
@@ -495,13 +478,15 @@ class Combustor:
         y = self.physics.primitive_to_conservative(self.state)
 
         # 1st stage of RK2
-        dydt = self.source_terms(self.t, y, self.state.gamma, self.geometry.x)
-        y1 = y + dt * dydt
+        dydt = self.source_terms(
+            self.t, y[self.idx_cells], self.state.gamma, self.geometry.x
+        )
+        y1 = y[self.idx_cells] + dt * dydt
         # state1 = self.physics.conservative_to_primitive(y1, self.state.gamma)
 
         # 2nd stage of RK2
         dydt = self.source_terms(self.t + dt, y1, self.state.gamma, self.geometry.x)
-        y = 0.5 * (y + y1 + dt * dydt)
+        y[self.idx_cells] = 0.5 * (y[self.idx_cells] + y1 + dt * dydt)
         self.state = self.physics.conservative_to_primitive(y, self.state.gamma)
 
         # update
@@ -521,12 +506,20 @@ class Combustor:
 
         # initialize
         y = self.physics.primitive_to_conservative(self.state)
-        (ru, rE, r, rZ, rC) = y[:, 0], y[:, 1], y[:, 2], y[:, 3], y[:, 4]
-        self.injector.update_fluid_tip_positions(dt, self.t, self.state.velocity)
+        (ru, rE, r, rZ, rC) = (
+            y[self.idx_cells, 0],
+            y[self.idx_cells, 1],
+            y[self.idx_cells, 2],
+            y[self.idx_cells, 3],
+            y[self.idx_cells, 4],
+        )
+        self.injector.update_fluid_tip_positions(
+            dt, self.t, self.state.velocity[self.idx_cells]
+        )
 
         # 1st stage of RK2
         dydt = self.injector.get_injector_sources(
-            r, ru, rE, rZ, rC, self.state.gamma, self.t
+            r, ru, rE, rZ, rC, self.state.gamma[self.idx_cells], self.t
         )
         y1 = y + dt * dydt
         # state1 = self.physics.conservative_to_primitive(y1, self.state.gamma)
@@ -534,9 +527,9 @@ class Combustor:
         # 2nd stage of RK2
         (ru1, rE1, r1, rZ1, rC1) = y1[:, 0], y1[:, 1], y1[:, 2], y1[:, 3], y1[:, 4]
         dydt = self.injector.get_injector_sources(
-            r1, ru1, rE1, rZ1, rC1, self.state.gamma, self.t + dt
+            r1, ru1, rE1, rZ1, rC1, self.state.gamma[self.idx_cells], self.t + dt
         )
-        y = 0.5 * (y + y1 + dt * dydt)
+        y[self.idx_cells] = 0.5 * (y[self.idx_cells] + y1 + dt * dydt)
 
         # update
         self.state = self.physics.conservative_to_primitive(y, self.state.gamma)

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -230,8 +230,12 @@ class Combustor:
 
         # 3rd stage of RK3
         dydt = self.inviscid_flux.source(self.t, y2, self.physics, gamma_star)
-        y[self.idx_cells] /= 3.0
-        y[self.idx_cells] += (2.0 / 3.0) * y2[self.idx_cells] + (2.0 / 3.0) * dt * dydt
+
+        y[self.idx_cells] = (
+            (1.0 / 3.0) * y[self.idx_cells]
+            + (2.0 / 3.0) * y2[self.idx_cells]
+            + (2.0 / 3.0) * dt * dydt
+        )
 
         # Remove ghost layers and update gamma
         self.state = self.physics.conservative_to_primitive(y, gamma_star)
@@ -261,8 +265,7 @@ class Combustor:
 
         # 2nd stage of RK2
         dydt = self.viscous_flux.source(self.t, y1, self.physics, gamma_star)
-        y[self.idx_cells] *= 0.5
-        y[self.idx_cells] += 0.5 * (y1[self.idx_cells] + dt * dydt)
+        y[self.idx_cells] = 0.5 * (y[self.idx_cells] + y1[self.idx_cells] + dt * dydt)
 
         # Remove ghost layers and update gamma
         self.state = self.physics.conservative_to_primitive(y, gamma_star)
@@ -331,10 +334,11 @@ class Combustor:
         omegaC1 = state1.density * self.injector.get_chemical_sources(
             state1.Z, state1.C
         )
-        rC = y[:, 4] = 0.5 * (
+        y[self.idx_cells, 4] = 0.5 * (
             y[self.idx_cells, 4] + y1[self.idx_cells, 4] + dt * omegaC1
         )
-        L = self.physics.get_normalized_progress_variable(Z, rC / r)
+        C = y[self.idx_cells, 4] / r
+        L = self.physics.get_normalized_progress_variable(Z, C)
         e_chem2 = r * self.physics.lookup_direct("E0_CHEM", Z, Q, L)
         y[self.idx_cells, 1] += e_chem0 - e_chem2
         self.state = self.physics.conservative_to_primitive(y, self.state.gamma)

--- a/src/stanshock/components/shocktube.py
+++ b/src/stanshock/components/shocktube.py
@@ -117,11 +117,11 @@ class ShockTube(Combustor):
             )
             p5 = p5op1 * self.state.pressure[-1]
         # Get initial state for reinitialization
-        rInitial = np.copy(self.state.density)
-        uInitial = np.copy(self.state.velocity)
-        pInitial = np.copy(self.state.pressure)
-        YInitial = np.copy(self.state.composition)
-        gammaInitial = np.copy(self.state.gamma)
+        rInitial = np.copy(self.state.density[self.idx_cells])
+        uInitial = np.copy(self.state.velocity[self.idx_cells])
+        pInitial = np.copy(self.state.pressure[self.idx_cells])
+        YInitial = np.copy(self.state.composition[self.idx_cells])
+        gammaInitial = np.copy(self.state.gamma[self.idx_cells])
         dlnA_dx_initial = geometry.dlnA_dx
 
         def dd_outerdx(x):
@@ -215,6 +215,9 @@ class ShockTube(Combustor):
                 pressure=np.copy(pInitial),
                 composition=np.copy(YInitial),
                 gamma=np.copy(gammaInitial),
+            )
+            self.state = self.inviscid_flux.face_extrapolator.add_ghost_layers(
+                self.state
             )
             # delete previous probes and create an endwall probe
             self.probes = [

--- a/src/stanshock/numerics/boundary_conditions.py
+++ b/src/stanshock/numerics/boundary_conditions.py
@@ -262,7 +262,9 @@ def set_boundary_conditions(
                     bcs += [Periodic(mt, location=bc_loc)]
                 elif bc_specification == "outflow":
                     bcs += [Extrapolate(location=bc_loc)]
-                elif bc_specification in ["symmetry", "reflecting", "wall"]:
+                elif bc_specification in ["symmetry"]:
+                    bcs += [Symmetry(mt, location=bc_loc)]
+                elif bc_specification in ["reflecting", "wall"]:
                     bcs += [AdiabaticWall(location=bc_loc)]
             elif isinstance(bc_specification, BoundaryCondition):
                 bcs += [bc_specification]

--- a/src/stanshock/numerics/boundary_conditions.py
+++ b/src/stanshock/numerics/boundary_conditions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from typing import Generic, Literal, TypeVar, Union
 
 from stanshock.physics.fluid_base import FluidState
@@ -139,7 +140,7 @@ class Inflow(Extrapolate):
 
     def __init__(
         self,
-        reference_state: list[float | None],
+        reference_state: Sequence[float | Sequence[float] | None],
         location: Literal["left", "right"] = "left",
     ) -> None:
         super().__init__(location)
@@ -245,7 +246,7 @@ BCNamesType: TypeAlias = Literal[
 
 
 def set_boundary_conditions(
-    boundary_conditions: BoundaryConditions | list[BCNamesType | BCType],
+    boundary_conditions: BoundaryConditions | Sequence[BCNamesType | BCType],
     mt: int = 3,
 ) -> BoundaryConditions:
     """Convenience function to initialize different boundary conditions."""

--- a/src/stanshock/numerics/boundary_conditions.py
+++ b/src/stanshock/numerics/boundary_conditions.py
@@ -101,11 +101,11 @@ class Extrapolate(RiemannFlux):
     def __init__(self, location: Literal["left", "right"] = "left") -> None:
         super().__init__(location)
         if self.location == "left":
-            self.idx_internal: tuple[int, int] = (1, 0)
-            self.idx_external: tuple[int, int] = (0, 0)
+            self.idx_interior: tuple[int, int] = (1, 0)
+            self.idx_exterior: tuple[int, int] = (0, 0)
         elif location == "right":
-            self.idx_internal = (0, -1)
-            self.idx_external = (1, -1)
+            self.idx_interior = (0, -1)
+            self.idx_exterior = (1, -1)
 
     def update(self, time: float, target: FluidState) -> FluidState:
         _: float = time
@@ -114,11 +114,11 @@ class Extrapolate(RiemannFlux):
         assert target.pressure is not None
         assert target.composition is not None
 
-        target.density[self.idx_external] = target.density[self.idx_internal]
-        target.velocity[self.idx_external] = target.velocity[self.idx_internal]
-        target.pressure[self.idx_external] = target.pressure[self.idx_internal]
-        target.composition[self.idx_external, :] = target.composition[
-            self.idx_internal, :
+        target.density[self.idx_exterior] = target.density[self.idx_interior]
+        target.velocity[self.idx_exterior] = target.velocity[self.idx_interior]
+        target.pressure[self.idx_exterior] = target.pressure[self.idx_interior]
+        target.composition[self.idx_exterior, :] = target.composition[
+            self.idx_interior, :
         ]
 
         return target
@@ -130,7 +130,7 @@ class AdiabaticWall(Extrapolate):
     def update(self, time: float, target: FluidState) -> FluidState:
         target = super().update(time, target)
         assert target.velocity is not None
-        target.velocity[self.idx_external] = -target.velocity[self.idx_external]
+        target.velocity[self.idx_exterior] = -target.velocity[self.idx_exterior]
 
         return target
 
@@ -152,16 +152,16 @@ class Inflow(Extrapolate):
 
         if self.reference_state[0] is not None:
             assert target.density is not None
-            target.density[self.idx_external] = self.reference_state[0]
+            target.density[self.idx_exterior] = self.reference_state[0]
         if self.reference_state[1] is not None:
             assert target.velocity is not None
-            target.velocity[self.idx_external] = self.reference_state[1]
+            target.velocity[self.idx_exterior] = self.reference_state[1]
         if self.reference_state[2] is not None:
             assert target.pressure is not None
-            target.pressure[self.idx_external] = self.reference_state[2]
+            target.pressure[self.idx_exterior] = self.reference_state[2]
         if self.reference_state[3] is not None:
             assert target.composition is not None
-            target.composition[self.idx_external, :] = self.reference_state[3]
+            target.composition[self.idx_exterior, :] = self.reference_state[3]
 
         return target
 

--- a/src/stanshock/numerics/boundary_conditions.py
+++ b/src/stanshock/numerics/boundary_conditions.py
@@ -129,8 +129,7 @@ class AdiabaticWall(Extrapolate):
     def update(self, time: float, target: FluidState) -> FluidState:
         target = super().update(time, target)
         assert target.velocity is not None
-        # face_states.velocity[self.idx_external] = -face_states.velocity[self.idx_external]
-        target.velocity[self.idx_external] = 0.0
+        target.velocity[self.idx_external] = -target.velocity[self.idx_external]
 
         return target
 

--- a/src/stanshock/numerics/boundary_conditions.py
+++ b/src/stanshock/numerics/boundary_conditions.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Generic, Literal, TypeVar, Union
+
+from stanshock.physics.fluid_base import FluidState
+from stanshock.system.backend import Array, Index, TypeAlias, np
+
+T = TypeVar("T")
+
+
+class BoundaryCondition(ABC, Generic[T]):
+    def __init__(self, location: Literal["left", "right"] = "left") -> None:
+        self.location = location
+
+    @abstractmethod
+    def update(self, time: float, target: T) -> T:
+        """Update the target of the specific boundary condition type."""
+
+
+class GhostCell(BoundaryCondition[Array]):
+    """Update the conservative variables in the ghost layers."""
+
+
+class RiemannFlux(BoundaryCondition[FluidState]):
+    """Update the primitive variables at the boundary face (input to Riemann solver)."""
+
+
+class SpecifiedFlux(BoundaryCondition[Array]):
+    """Directly set the flux through the boundary face."""
+
+
+class PadCells(GhostCell):
+    """Extrapolates constant values from the last interior cell into the ghost layers."""
+
+    def __init__(
+        self, mt: int = 3, location: Literal["left", "right"] = "left"
+    ) -> None:
+        super().__init__(location)
+        if self.location == "left":
+            self.idx_interior: int = mt
+            self.idx_exterior: Index = np.s_[:mt]
+        else:
+            self.idx_interior = -mt - 1
+            self.idx_exterior = np.s_[-mt:]
+
+    def update(self, time: float, target: Array) -> Array:
+        _: float = time
+        target[self.idx_exterior, :] = target[self.idx_interior, :]
+
+        return target
+
+
+class Periodic(GhostCell):
+    """Replicates solution from opposite end of the domain into the ghost layers."""
+
+    def __init__(
+        self, mt: int = 3, location: Literal["left", "right"] = "left"
+    ) -> None:
+        super().__init__(location)
+        if self.location == "left":
+            self.idx_interior: Index = np.s_[-2 * mt : -mt]
+            self.idx_exterior: Index = np.s_[:mt]
+        else:
+            self.idx_interior = np.s_[mt : 2 * mt]
+            self.idx_exterior = np.s_[-mt:]
+
+    def update(self, time: float, target: Array) -> Array:
+        _: float = time
+        target[self.idx_exterior, :] = target[self.idx_interior, :]
+
+        return target
+
+
+class Symmetry(GhostCell):
+    """Mirrors interior solution into the ghost layers."""
+
+    def __init__(
+        self, mt: int = 3, location: Literal["left", "right"] = "left"
+    ) -> None:
+        super().__init__(location)
+        if self.location == "left":
+            self.idx_interior: Index = np.s_[mt : 2 * mt]
+            self.idx_exterior: Index = np.s_[mt - 1 :: -1]
+        else:
+            self.idx_interior = np.s_[-2 * mt : -mt]
+            self.idx_exterior = np.s_[: -mt - 1 : -1]
+
+    def update(self, time: float, target: Array) -> Array:
+        _: float = time
+        target[self.idx_exterior, :] = target[self.idx_interior, :]
+        target[self.idx_exterior, 1] = -target[self.idx_interior, 1]
+
+        return target
+
+
+class Extrapolate(RiemannFlux):
+    """Copy extrapolated fluid state from interior of the boundary face to the exterior side."""
+
+    def __init__(self, location: Literal["left", "right"] = "left") -> None:
+        super().__init__(location)
+        if self.location == "left":
+            self.idx_internal: tuple[int, int] = (1, 0)
+            self.idx_external: tuple[int, int] = (0, 0)
+        elif location == "right":
+            self.idx_internal = (0, -1)
+            self.idx_external = (1, -1)
+
+    def update(self, time: float, target: FluidState) -> FluidState:
+        _: float = time
+        assert target.density is not None
+        assert target.velocity is not None
+        assert target.pressure is not None
+        assert target.composition is not None
+
+        target.density[self.idx_external] = target.density[self.idx_internal]
+        target.velocity[self.idx_external] = target.velocity[self.idx_internal]
+        target.pressure[self.idx_external] = target.pressure[self.idx_internal]
+        target.composition[self.idx_external, :] = target.composition[
+            self.idx_internal, :
+        ]
+
+        return target
+
+
+class AdiabaticWall(Extrapolate):
+    """Set the velocity at the wall face to zero."""
+
+    def update(self, time: float, target: FluidState) -> FluidState:
+        target = super().update(time, target)
+        assert target.velocity is not None
+        # face_states.velocity[self.idx_external] = -face_states.velocity[self.idx_external]
+        target.velocity[self.idx_external] = 0.0
+
+        return target
+
+
+class Inflow(Extrapolate):
+    """Specify the fluid state at the wall face."""
+
+    def __init__(
+        self,
+        reference_state: list[float | None],
+        location: Literal["left", "right"] = "left",
+    ) -> None:
+        super().__init__(location)
+
+        self.reference_state = reference_state
+
+    def update(self, time: float, target: FluidState) -> FluidState:
+        target = super().update(time, target)
+
+        if self.reference_state[0] is not None:
+            assert target.density is not None
+            target.density[self.idx_external] = self.reference_state[0]
+        if self.reference_state[1] is not None:
+            assert target.velocity is not None
+            target.velocity[self.idx_external] = self.reference_state[1]
+        if self.reference_state[2] is not None:
+            assert target.pressure is not None
+            target.pressure[self.idx_external] = self.reference_state[2]
+        if self.reference_state[3] is not None:
+            assert target.composition is not None
+            target.composition[self.idx_external, :] = self.reference_state[3]
+
+        return target
+
+
+class DirichletInflow(SpecifiedFlux):
+    """Directly set the flux through the wall face."""
+
+    def __init__(
+        self, reference_flux: Array, location: Literal["left", "right"] = "left"
+    ) -> None:
+        super().__init__(location)
+        if self.location == "left":
+            self.idx_boundary_face = 0
+        else:
+            self.idx_boundary_face = -1
+
+        self.reference_flux = reference_flux
+
+    def update(self, time: float, target: Array) -> Array:
+        _: float = time
+        target[self.idx_boundary_face, :] = self.reference_flux
+
+        return target
+
+
+BCType: TypeAlias = Union[BoundaryCondition[FluidState], BoundaryCondition[Array]]
+
+
+class BoundaryConditions:
+    def __init__(self, boundary_conditions: list[BCType]) -> None:
+        self._boundary_conditions = boundary_conditions
+
+    def append(self, boundary_condition: BCType) -> None:
+        self._boundary_conditions += [boundary_condition]
+
+    @property
+    def ghost_cells(self) -> list[GhostCell]:
+        return [
+            boundary_condition
+            for boundary_condition in self._boundary_conditions
+            if isinstance(boundary_condition, GhostCell)
+        ]
+
+    @property
+    def riemann_fluxes(self) -> list[RiemannFlux]:
+        return [
+            boundary_condition
+            for boundary_condition in self._boundary_conditions
+            if isinstance(boundary_condition, RiemannFlux)
+        ]
+
+    @property
+    def specified_fluxes(self) -> list[SpecifiedFlux]:
+        return [
+            boundary_condition
+            for boundary_condition in self._boundary_conditions
+            if isinstance(boundary_condition, SpecifiedFlux)
+        ]
+
+    def update_ghost_layers(self, time: float, state_array: Array) -> Array:
+        for ghost_cell in self.ghost_cells:
+            state_array = ghost_cell.update(time, target=state_array)
+
+        return state_array
+
+    def update_face_states(self, time: float, face_states: FluidState) -> FluidState:
+        for riemann_flux in self.riemann_fluxes:
+            face_states = riemann_flux.update(time, target=face_states)
+
+        return face_states
+
+    def update_face_flux(self, time: float, face_flux: Array) -> Array:
+        for specified_flux in self.specified_fluxes:
+            face_flux = specified_flux.update(time, target=face_flux)
+
+        return face_flux
+
+
+BCNamesType: TypeAlias = Literal[
+    "outflow", "symmetry", "reflecting", "wall", "periodic"
+]
+
+
+def set_boundary_conditions(
+    boundary_conditions: BoundaryConditions | list[BCNamesType | BCType],
+    mt: int = 3,
+) -> BoundaryConditions:
+    """Convenience function to initialize different boundary conditions."""
+
+    # Convert lists into BoundaryConditions:
+    if not isinstance(boundary_conditions, BoundaryConditions):
+        bc_locs: list[Literal["left", "right"]] = ["left", "right"]
+        bcs: list[BCType] = []
+
+        for bc_loc, bc_specification in zip(bc_locs, boundary_conditions):
+            if isinstance(bc_specification, str):
+                if bc_specification == "periodic":
+                    bcs += [Periodic(mt, location=bc_loc)]
+                elif bc_specification == "outflow":
+                    bcs += [Extrapolate(location=bc_loc)]
+                elif bc_specification in ["symmetry", "reflecting", "wall"]:
+                    bcs += [AdiabaticWall(location=bc_loc)]
+            elif isinstance(bc_specification, BoundaryCondition):
+                bcs += [bc_specification]
+
+        boundary_conditions = BoundaryConditions(boundary_conditions=bcs)
+
+    # If ghost layer method not specified, default to simple padding
+    default_ghost_layers: dict[str, GhostCell] = {
+        "left": PadCells(mt, location="left"),
+        "right": PadCells(mt, location="right"),
+    }
+    for bc in boundary_conditions._boundary_conditions:
+        if isinstance(bc, Periodic):
+            default_ghost_layers = {}
+        elif isinstance(bc, GhostCell):
+            del default_ghost_layers[bc.location]
+
+    for _, bc in default_ghost_layers.items():
+        boundary_conditions.append(bc)
+
+    return boundary_conditions

--- a/src/stanshock/numerics/face_extrapolation.py
+++ b/src/stanshock/numerics/face_extrapolation.py
@@ -6,6 +6,7 @@ import numpy as np
 from numba import double, int16, njit
 
 from stanshock.physics.fluid_base import FluidState
+from stanshock.system.backend import Array, Index
 
 # Global variables (parameters) used by the solver
 mn = 2  # number of 1D Euler equations
@@ -17,9 +18,20 @@ double3D = double[:, :, :]
 
 
 class FaceExtrapolator(ABC):
-    def __init__(self, n_scalars_rho_sum: int):
+    minimum_ghost_layers: int = 1
+
+    def __init__(
+        self, n_scalars_rho_sum: int, n_ghost_layers: int = minimum_ghost_layers
+    ) -> None:
         """Initialize the face extrapolator with the number of ghost nodes."""
         self.n_scalars_rho_sum = n_scalars_rho_sum
+        self.n_ghost_layers = n_ghost_layers
+
+        # Set up slices relating faces to the cells on their left and right
+        mt: int = n_ghost_layers
+        self.index_face_left: Index = np.s_[mt - 1 : -mt]
+        right: int | None = None if mt == 1 else -mt + 1
+        self.index_face_right: Index = np.s_[mt:right]
 
     @abstractmethod
     def __call__(self, state: FluidState) -> FluidState:
@@ -27,72 +39,87 @@ class FaceExtrapolator(ABC):
 
     def add_ghost_layers(self, state: FluidState) -> FluidState:
         """Add ghost layers to the primitive variables."""
+        assert state.density is not None
+        assert state.velocity is not None
+        assert state.pressure is not None
+        assert state.composition is not None
+        assert state.gamma is not None
+
+        mt: int = self.n_ghost_layers
         return FluidState(
-            shape=(state.shape[0] + 2 * self.mt,),
-            density=np.pad(
-                state.density, self.mt, mode="constant", constant_values=1.0
-            ),
-            velocity=np.pad(
-                state.velocity, self.mt, mode="constant", constant_values=1.0
-            ),
-            pressure=np.pad(
-                state.pressure, self.mt, mode="constant", constant_values=1.0
-            ),
+            shape=(state.shape[0] + 2 * mt,),
+            density=np.pad(state.density, mt, mode="edge"),
+            velocity=np.pad(state.velocity, mt, mode="edge"),
+            pressure=np.pad(state.pressure, mt, mode="edge"),
             composition=np.pad(
                 state.composition,
-                ((self.mt, self.mt), (0, 0)),
-                mode="constant",
-                constant_values=1.0,
+                ((mt, mt), (0, 0)),
+                mode="edge",
             ),
-            gamma=np.pad(state.gamma, self.mt, mode="edge"),
+            gamma=np.pad(state.gamma, mt, mode="edge"),
         )
 
 
 class FirstOrder(FaceExtrapolator):
-    def __init__(self, n_scalars_rho_sum: int):
-        """Initialize the face extrapolator with the number of ghost nodes."""
-        super().__init__(n_scalars_rho_sum)
-        self.mt = 1
+    minimum_ghost_layers: int = 1
 
     def __call__(self, state: FluidState) -> FluidState:
         """First order interpolation of primitive variables to the edge states."""
-        mt = self.mt
-        n = state.shape[0] - 2 * mt + 1
+        assert state.density is not None
+        assert state.velocity is not None
+        assert state.pressure is not None
+        assert state.composition is not None
+        assert state.gamma is not None
 
-        index_face_left = np.s_[mt - 1 : -mt]
-        right = state.shape[0] if mt == 1 else -mt + 1
-        index_face_right = np.s_[mt:right]
+        n_faces: int = state.shape[0] - 2 * self.n_ghost_layers + 1
 
         return FluidState(
-            shape=(2, n),
+            shape=(2, n_faces),
             density=np.stack(
-                (state.density[index_face_left], state.density[index_face_right]),
+                (
+                    state.density[self.index_face_left],
+                    state.density[self.index_face_right],
+                ),
                 axis=0,
             ),
             velocity=np.stack(
-                (state.velocity[index_face_left], state.velocity[index_face_right]),
+                (
+                    state.velocity[self.index_face_left],
+                    state.velocity[self.index_face_right],
+                ),
                 axis=0,
             ),
             pressure=np.stack(
-                (state.pressure[index_face_left], state.pressure[index_face_right]),
+                (
+                    state.pressure[self.index_face_left],
+                    state.pressure[self.index_face_right],
+                ),
                 axis=0,
             ),
             composition=np.stack(
                 (
-                    state.composition[index_face_left],
-                    state.composition[index_face_right],
+                    state.composition[self.index_face_left],
+                    state.composition[self.index_face_right],
                 ),
                 axis=0,
             ),
             gamma=np.stack(
-                (state.gamma[index_face_left], state.gamma[index_face_right]),
+                (state.gamma[self.index_face_left], state.gamma[self.index_face_right]),
                 axis=0,
             ),
         )
 
 
 @njit(double3D(double1D, double1D, double1D, double2D, double1D, int16, int16))
-def weno5(r, u, p, Y, gamma, mt, n_scalars_rho_sum):
+def weno5(
+    r: Array,
+    u: Array,
+    p: Array,
+    Y: Array,
+    gamma: Array,
+    n_ghost_layers: int,
+    n_scalars_rho_sum: int,
+) -> Array:
     """
     This method implements the fifth-order WENO interpolation. This method
     follows that of Houim and Kuo (JCP2011)
@@ -102,17 +129,17 @@ def weno5(r, u, p, Y, gamma, mt, n_scalars_rho_sum):
             p=pressure
             Y=scalar variables matrix [x,scalars]
             gamma=specific heat ratio
-            mt=number of ghost layers
+            n_ghost_layers=number of ghost layers
             n_scalars_rho_sum=number of scalars that are summed into density
         outputs:
             PLR=a matrix of the primitive variables [LR,]
     """
     nLR = 2
-    nCells = len(r) - 2 * mt
+    nCells = len(r) - 2 * n_ghost_layers
     nFaces = nCells + 1
     nSc = len(Y[0])  # number of scalars
     nVar = mn + nSc  # [rhou, rhoE, rhoY1, rhoY2, ...]
-    nStencil = 2 * mt
+    nStencil = 2 * n_ghost_layers
     epWENO = 1.0e-06
 
     # Cell weight (WL(i,j,k); i=left(1) or right(2) j=stencil#,k=weight#)
@@ -154,7 +181,7 @@ def weno5(r, u, p, Y, gamma, mt, n_scalars_rho_sum):
     B1 = 1.083333333333333
     B2 = 0.25
 
-    B = np.zeros(mt)
+    B = np.zeros(n_ghost_layers)
     PLR = np.empty((nLR, nFaces, nVar + 1))
     YAverage = np.empty(nSc)
     U = np.empty(nVar)
@@ -298,7 +325,7 @@ def weno5(r, u, p, Y, gamma, mt, n_scalars_rho_sum):
                 # Edge interpolation
                 ATOT = 0.0
                 CW = 0.0
-                for iStencil in range(mt):
+                for iStencil in range(n_ghost_layers):
                     iStencilO = NO - iStencil
                     CINT = (
                         W[N, iStencil, 0] * CStencil[0 + iStencilO, iVar]
@@ -330,14 +357,14 @@ def weno5(r, u, p, Y, gamma, mt, n_scalars_rho_sum):
 
     # First order at boundaries
     for N in range(nLR):
-        for iFace in range(mt):
+        for iFace in range(n_ghost_layers):
             iCell = iFace + 2
             PLR[N, iFace, 0] = r[iCell + N]
             PLR[N, iFace, 1] = u[iCell + N]
             PLR[N, iFace, 2] = p[iCell + N]
             for kSc in range(nSc):
                 PLR[N, iFace, 3 + kSc] = Y[iCell + N, kSc]
-        for iFace in range(nFaces - mt, nFaces):
+        for iFace in range(nFaces - n_ghost_layers, nFaces):
             iCell = iFace + 2
             PLR[N, iFace, 0] = r[iCell + N]
             PLR[N, iFace, 1] = u[iCell + N]
@@ -346,7 +373,7 @@ def weno5(r, u, p, Y, gamma, mt, n_scalars_rho_sum):
                 PLR[N, iFace, 3 + kSc] = Y[iCell + N, kSc]
 
     # Create primitive matrix for limiter
-    P = np.zeros((nCells + 2 * mt, nVar + 1))
+    P = np.zeros((nCells + 2 * n_ghost_layers, nVar + 1))
     P[:, 0] = r[:]
     P[:, 1] = u[:]
     P[:, 2] = p[:]
@@ -404,35 +431,36 @@ def weno5(r, u, p, Y, gamma, mt, n_scalars_rho_sum):
 
 
 class FifthOrderWeno(FaceExtrapolator):
-    def __init__(self, n_scalars_rho_sum: int):
-        """Initialize the face extrapolator with the number of ghost nodes."""
-        super().__init__(n_scalars_rho_sum)
-        self.mt = 3
+    minimum_ghost_layers: int = 3
 
     def __call__(self, state: FluidState) -> FluidState:
         """First order interpolation to the edge states."""
+        assert state.density is not None
+        assert state.velocity is not None
+        assert state.pressure is not None
+        assert state.composition is not None
+        assert state.gamma is not None
+
         face_states_array = weno5(
             state.density,
             state.velocity,
             state.pressure,
             state.composition,
             state.gamma,
-            self.mt,
+            self.n_ghost_layers,
             self.n_scalars_rho_sum,
         )
 
-        n = state.shape[0] - 2 * self.mt + 1
-        index_face_left = np.s_[self.mt - 1 : -self.mt]
-        index_face_right = np.s_[self.mt : -self.mt + 1]
+        n_faces: int = state.shape[0] - 2 * self.n_ghost_layers + 1
 
         return FluidState(
-            shape=(2, n),
+            shape=(2, n_faces),
             density=face_states_array[:, :, 0],
             velocity=face_states_array[:, :, 1],
             pressure=face_states_array[:, :, 2],
             composition=face_states_array[:, :, 3:],
             gamma=np.stack(
-                (state.gamma[index_face_left], state.gamma[index_face_right]),
+                (state.gamma[self.index_face_left], state.gamma[self.index_face_right]),
                 axis=0,
             ),
         )

--- a/src/stanshock/numerics/inviscid_flux.py
+++ b/src/stanshock/numerics/inviscid_flux.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from typing import Callable, cast
+
 import numpy as np
 from numba import double, njit
 
+from stanshock.numerics.boundary_conditions import BoundaryConditions
 from stanshock.numerics.face_extrapolation import FaceExtrapolator
 from stanshock.physics.fluid_base import FluidPhysics, FluidState
-from stanshock.system.backend import Array
+from stanshock.system.backend import Array, TypeAlias
 from stanshock.system.base import RightHandSide
 
 # Global variables (parameters) used by the solver
@@ -16,9 +19,14 @@ double1D = double[:]
 double2D = double[:, :]
 double3D = double[:, :, :]
 
+# Signature for Riemann solvers
+RiemannSolver: TypeAlias = Callable[[Array, Array, Array, Array, Array], Array]
+
 
 @njit(double2D(double2D, double2D, double2D, double3D, double1D))
-def lax_friedrichs_flux(rLR, uLR, pLR, YLR, gamma):
+def lax_friedrichs_flux(
+    rLR: Array, uLR: Array, pLR: Array, YLR: Array, gamma: Array
+) -> Array:
     """
     This method computes the flux at each interface
         inputs:
@@ -79,7 +87,7 @@ def lax_friedrichs_flux(rLR, uLR, pLR, YLR, gamma):
 
 
 @njit(double2D(double2D, double2D, double2D, double3D, double1D))
-def hllc_flux(rLR, uLR, pLR, YLR, gamma):
+def hllc_flux(rLR: Array, uLR: Array, pLR: Array, YLR: Array, gamma: Array) -> Array:
     """
     This method computes the flux at each interface
         inputs:
@@ -200,9 +208,9 @@ class InviscidFlux(RightHandSide):
     def __init__(
         self,
         face_extrapolator: FaceExtrapolator,
-        boundary_conditions,
-        riemann_solver,
-        dx,
+        boundary_conditions: BoundaryConditions,
+        riemann_solver: RiemannSolver,
+        dx: float,
     ) -> None:
         self.face_extrapolator = face_extrapolator
         self.boundary_conditions = boundary_conditions
@@ -210,27 +218,35 @@ class InviscidFlux(RightHandSide):
         self.dx = dx
 
     def source(
-        self, _time: float, state_array: Array, physics: FluidPhysics, gamma_star: Array
+        self, time: float, state_array: Array, physics: FluidPhysics, gamma_star: Array
     ) -> Array:
-        state = physics.conservative_to_primitive(state_array, gamma_star)
+        state_array = self.boundary_conditions.update_ghost_layers(time, state_array)
+
+        state: FluidState = physics.conservative_to_primitive(state_array, gamma_star)
         state.gamma = gamma_star
 
-        face_states = self.face_extrapolator(state)
-        face_states = self.boundary_conditions(face_states)
+        face_states: FluidState = self.face_extrapolator(state)
+        face_states = self.boundary_conditions.update_face_states(time, face_states)
 
-        return self.source_from_primitives(_time, face_states, physics)
+        return self.source_from_primitives(time, face_states, physics)
 
     def source_from_primitives(
         self, _time: float, face_states: FluidState, _physics: FluidPhysics
     ) -> Array:
-        left_face_flux = self.riemann_solver(
+        assert face_states.density is not None
+        assert face_states.velocity is not None
+        assert face_states.pressure is not None
+        assert face_states.composition is not None
+        assert face_states.gamma is not None
+
+        left_face_flux: Array = self.riemann_solver(
             face_states.density,
             face_states.velocity,
             face_states.pressure,
             face_states.composition,
             face_states.gamma[1, :],
         )
-        right_face_flux = self.riemann_solver(
+        right_face_flux: Array = self.riemann_solver(
             face_states.density,
             face_states.velocity,
             face_states.pressure,
@@ -238,6 +254,8 @@ class InviscidFlux(RightHandSide):
             face_states.gamma[0, :],
         )
 
-        return (
-            left_face_flux[:-1, :] - right_face_flux[1:, :]
-        ) / self.dx  # Central difference
+        return cast(
+            Array,
+            (left_face_flux[:-1, :] - right_face_flux[1:, :])
+            / self.dx,  # Central difference
+        )

--- a/src/stanshock/numerics/viscous_flux.py
+++ b/src/stanshock/numerics/viscous_flux.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from stanshock.numerics.boundary_conditions import BoundaryConditions
 from stanshock.numerics.face_extrapolation import FaceExtrapolator
 from stanshock.physics.fluid_base import FluidPhysics, FluidState
 from stanshock.system.backend import Array
@@ -10,7 +11,10 @@ from stanshock.system.base import RightHandSide
 
 class ViscousFlux(RightHandSide):
     def __init__(
-        self, face_extrapolator: FaceExtrapolator, boundary_conditions, dx
+        self,
+        face_extrapolator: FaceExtrapolator,
+        boundary_conditions: BoundaryConditions,
+        dx: float,
     ) -> None:
         self.face_extrapolator = face_extrapolator
         self.boundary_conditions = boundary_conditions
@@ -18,15 +22,17 @@ class ViscousFlux(RightHandSide):
         self.F = 1.0
 
     def source(
-        self, _time: float, state_array: Array, physics: FluidPhysics, gamma_star: Array
+        self, time: float, state_array: Array, physics: FluidPhysics, gamma_star: Array
     ) -> Array:
-        state = physics.conservative_to_primitive(state_array, gamma_star)
+        state_array = self.boundary_conditions.update_ghost_layers(time, state_array)
+
+        state: FluidState = physics.conservative_to_primitive(state_array, gamma_star)
         state.gamma = gamma_star
 
-        face_states = self.face_extrapolator(state)
-        face_states = self.boundary_conditions(face_states)
+        face_states: FluidState = self.face_extrapolator(state)
+        face_states = self.boundary_conditions.update_face_states(time, face_states)
 
-        return self.source_from_primitives(_time, face_states, physics)
+        return self.source_from_primitives(time, face_states, physics)
 
     def source_from_primitives(
         self, _time: float, face_states: FluidState, physics: FluidPhysics

--- a/src/stanshock/processing/plot.py
+++ b/src/stanshock/processing/plot.py
@@ -48,26 +48,33 @@ class XTDiagram:
         variable = self.name
         state = domain.state
         geometry = domain.geometry
+        idx_cells = domain.idx_cells
 
         if variable in ["density", "r", "rho"]:
-            self.variable.append(np.interp(self.x, geometry.x, state.density))
+            self.variable.append(
+                np.interp(self.x, geometry.x, state.density[idx_cells])
+            )
         elif variable in ["velocity", "u"]:
-            self.variable.append(np.interp(self.x, geometry.x, state.velocity))
+            self.variable.append(
+                np.interp(self.x, geometry.x, state.velocity[idx_cells])
+            )
         elif variable in ["pressure", "p"]:
-            self.variable.append(np.interp(self.x, geometry.x, state.pressure))
+            self.variable.append(
+                np.interp(self.x, geometry.x, state.pressure[idx_cells])
+            )
         elif variable in ["temperature", "t"]:
             T = domain.physics.get_temperature(state)
-            self.variable.append(np.interp(self.x, geometry.x, T))
+            self.variable.append(np.interp(self.x, geometry.x, T[idx_cells]))
         elif variable in ["gamma", "g", "specific heat ratio", "heat capacity ratio"]:
-            self.variable.append(np.interp(self.x, geometry.x, state.gamma))
+            self.variable.append(np.interp(self.x, geometry.x, state.gamma[idx_cells]))
         elif variable in domain.physics.scalar_names:
             scalarIndex = domain.physics.scalar_names.index(variable)
             self.variable.append(
-                np.interp(self.x, geometry.x, state.composition[:, scalarIndex])
+                np.interp(self.x, geometry.x, state.composition[idx_cells, scalarIndex])
             )
         elif variable in ["mach", "m"]:
             M = np.abs(state.velocity) / domain.physics.get_sound_speed(state)
-            self.variable.append(np.interp(self.x, self.x, M))
+            self.variable.append(np.interp(self.x, self.x, M[idx_cells]))
         else:
             msg = f"Invalid Variable Name: {variable}"
             raise Exception(msg)
@@ -144,35 +151,36 @@ def plot_state(domain, filename):
     physics = domain.physics
     state = domain.state
     geometry = domain.geometry
+    idx_cells = domain.idx_cells
     T = physics.get_temperature(state)
 
     fig, ax = plt.subplots(7, 1, sharex=True, figsize=(6, 9))
-    ax[0].plot(geometry.x * xscale, state.density)
+    ax[0].plot(geometry.x * xscale, state.density[idx_cells])
     ax[0].set_ymargin(0.1)
     ax[0].set_ylabel(r"$\rho$ [kg/m$^3$]")
     if geometry.h is not None:
         add_h_plot(domain, ax[0], scale=xscale)
 
-    ax[1].plot(geometry.x * xscale, state.velocity)
+    ax[1].plot(geometry.x * xscale, state.velocity[idx_cells])
     ax[1].set_ymargin(0.1)
     ax[1].set_ylabel(r"$u$ [m/s]")
     if geometry.h is not None:
         add_h_plot(domain, ax[1], scale=xscale)
 
-    ax[2].plot(geometry.x * xscale, state.pressure)
+    ax[2].plot(geometry.x * xscale, state.pressure[idx_cells])
     ax[2].set_ymargin(0.1)
     ax[2].set_ylabel(r"$p$ [Pa]")
     if geometry.h is not None:
         add_h_plot(domain, ax[2], scale=xscale)
 
-    ax[3].plot(geometry.x * xscale, T)
+    ax[3].plot(geometry.x * xscale, T[idx_cells])
     ax[3].set_ymargin(0.1)
     ax[3].set_ylabel(r"$T$ [K]")
     if geometry.h is not None:
         add_h_plot(domain, ax[3], scale=xscale)
 
     M = np.abs(state.velocity) / physics.get_sound_speed(state)
-    ax[4].plot(geometry.x * xscale, M)
+    ax[4].plot(geometry.x * xscale, M[idx_cells])
     ax[4].axhline(1.0, color="r", linestyle="--")
     ax[4].set_ymargin(0.1)
     ax[4].set_ylabel(r"$M$ [-]")
@@ -181,11 +189,11 @@ def plot_state(domain, filename):
 
     if physics.is_flamelet:
         state = physics.set_state(state)
-        Y_H2 = physics.lookup("H2", state)
-        Y_OH = physics.lookup("OH", state)
-        Y_H2O = physics.lookup("H2O", state)
+        Y_H2 = physics.lookup("H2", state)[idx_cells]
+        Y_OH = physics.lookup("OH", state)[idx_cells]
+        Y_H2O = physics.lookup("H2O", state)[idx_cells]
     else:
-        Y = state.mass_fractions
+        Y = state.mass_fractions[idx_cells]
         Y_H2 = Y[:, physics.gas.species_index("H2")]
         Y_OH = Y[:, physics.gas.species_index("OH")]
         Y_H2O = Y[:, physics.gas.species_index("H2O")]

--- a/src/stanshock/processing/probe.py
+++ b/src/stanshock/processing/probe.py
@@ -41,14 +41,29 @@ class Probe:
     def update(self, domain):
         state = domain.state
         geometry = domain.geometry
+        idx_cells = domain.idx_cells
         self.t.append(domain.t)
-        self.r.append(interpolate(geometry.x, state.density, self.probeLocation))
-        self.u.append(interpolate(geometry.x, state.velocity, self.probeLocation))
-        self.p.append(interpolate(geometry.x, state.pressure, self.probeLocation))
-        self.gamma.append(interpolate(geometry.x, state.gamma, self.probeLocation))
+        self.r.append(
+            interpolate(geometry.x, state.density[idx_cells], self.probeLocation)
+        )
+        self.u.append(
+            interpolate(geometry.x, state.velocity[idx_cells], self.probeLocation)
+        )
+        self.p.append(
+            interpolate(geometry.x, state.pressure[idx_cells], self.probeLocation)
+        )
+        self.gamma.append(
+            interpolate(geometry.x, state.gamma[idx_cells], self.probeLocation)
+        )
         YProbe = np.array(
             [
-                (interpolate(geometry.x, state.composition[:, kSp], self.probeLocation))
+                (
+                    interpolate(
+                        geometry.x,
+                        state.composition[idx_cells, kSp],
+                        self.probeLocation,
+                    )
+                )
                 for kSp in range(domain.n_scalars)
             ]
         )

--- a/src/stanshock/system/backend.py
+++ b/src/stanshock/system/backend.py
@@ -10,7 +10,7 @@ if sys.version_info >= (3, 13):
 else:
     from typing_extensions import TypeAlias
 
-__all__ = ["Array", "Index", "np"]
+__all__ = ["Array", "Index", "TypeAlias", "np"]
 
 # Define the Array type for use in type hints to make future changes easier
 Array: TypeAlias = np.ndarray[tuple[int, ...], np.dtype[np.float64]]

--- a/tests/test_weno.py
+++ b/tests/test_weno.py
@@ -6,12 +6,12 @@ from stanshock.numerics.face_extrapolation import weno5
 
 weno5 = weno5.__wrapped__  # unwrap for test coverage
 
-mt = 3
+n_ghost_layers = 3
 
 
 def test_weno_interpolates_constant():
     num_interior_cells = 10
-    num_ghost_cells = 2 * mt
+    num_ghost_cells = 2 * n_ghost_layers
     num_cells = num_interior_cells + num_ghost_cells
     num_species = 2
     r = 1.0
@@ -25,7 +25,7 @@ def test_weno_interpolates_constant():
         p=p * np.ones(num_cells),
         Y=Y * np.ones((num_cells, num_species)),
         gamma=gamma * np.ones(num_cells),
-        mt=mt,
+        n_ghost_layers=n_ghost_layers,
         n_scalars_rho_sum=num_species,
     )
     num_sides = 2
@@ -39,7 +39,7 @@ def test_weno_interpolates_constant():
 
 def test_weno_interpolates_discontinuity():
     num_interior_cells = 2 * 5
-    num_ghost_cells = 2 * mt
+    num_ghost_cells = 2 * n_ghost_layers
     num_cells = num_interior_cells + num_ghost_cells
     num_species = 2
     r = (0.5, 2.0)
@@ -64,7 +64,7 @@ def test_weno_interpolates_discontinuity():
             ]
         ),
         gamma=gamma * np.ones(num_cells),
-        mt=mt,
+        n_ghost_layers=n_ghost_layers,
         n_scalars_rho_sum=num_species,
     )
     num_sides = 2


### PR DESCRIPTION
The boundary conditions have been pulled out of the `Combustor` class and into their own standalone class. There are now three distinct forms of boundary condition:

- `GhostCell`: Updates the conservative variables within the ghost layers.
- `RiemannFlux`: Sets the extrapolated fluid state on the external side of a boundary face, to be used as an input to the Riemann solver along with the extrapolated fluid state on the internal side set by the FaceExtrapolator.
- `SpecifiedFlux`: Directly sets the flux at the boundary face, overriding anything derived from the other approaches.

And a few concrete implementations which I think would be useful. Other changes include:

- Moving away from dynamically resizing the domain in favor of indexing into it with "idx_cells."
- Moving away from using "mt" in favor of "n_ghost_layers."
- There is now only one number of ghost layers to be used, which is determined as the maximum of the minimum required number for the FaceExtrapolators to be used by the inviscid and viscous flux routines.
- Several typing-related updates to routines touched by this pull request.
  - Currently using "assert ____ is not None" statements to type-narrow, but it is cumbersome when checking that several elements of FluidState have been set. I've looked for better ways, and tried creating a function like "assert state.is_initialized()", but that did not successfully narrow the types.
 - The computational mesh is not modified, so it is defined over the physical cells and not the ghost cells. This leads to several areas where we must extract the subset of a physical quantity, e.g. when plotting `state.pressure[idx_cells]` against `geometry.x`, and it's possible I did not address them all.

There appears to be a small performance hit, which may be due to the additional slicing operations sprinkled throughout. I hope that this will be offset by the streamlining coming in the time integration update.