### PR TITLE
Quick fix for get_composition.

### DIFF
--- a/src/stanshock/physics/flamelet.py
+++ b/src/stanshock/physics/flamelet.py
@@ -107,7 +107,7 @@ class FPVTable(FluidPhysics):
         Z = self.get_bilger_mixture_fraction(Y)
         C = self.get_progress_variable(Y)
 
-        return np.stack([Z, C], axis=1)
+        return np.stack([np.ones_like(Z), Z, C], axis=1)
 
     def get_normalized_progress_variable(self, Z, C):
         """


### PR DESCRIPTION
Quick fix so that get_composition returns 1, Z, and C instead of just Z and C.