### PR TITLE
Separate gradient calculations from viscous flux calculations.

### DIFF
--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -162,7 +162,7 @@ class Combustor:
                     n_ghost_layers=self.n_ghost_layers,
                 ),
                 geometry=self.geometry,
-                gradient=CentralDifference(),
+                gradient=CentralDifference(n_ghost_layers=self.n_ghost_layers),
             )
 
         if self.include_boundary_layer:

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from stanshock.models.boundary_layer import BoundaryLayer
 from stanshock.numerics.face_extrapolation import FifthOrderWeno, FirstOrder
+from stanshock.numerics.gradient import CentralDifference
 from stanshock.numerics.inviscid_flux import InviscidFlux, hllc_flux
 from stanshock.numerics.viscous_flux import ViscousFlux
 from stanshock.physics.fluid_base import FluidPhysics, FluidState
@@ -128,7 +129,7 @@ class Combustor:
             self.viscous_flux = ViscousFlux(
                 face_extrapolator=FirstOrder(),
                 boundary_conditions=self.apply_boundary_conditions,
-                dx=self.geometry.dx,
+                gradient=CentralDifference(),
             )
 
         if self.include_boundary_layer:
@@ -278,12 +279,12 @@ class Combustor:
             self.viscous_flux.F = np.pad(self.F, mt, mode="edge")
 
         # 1st stage of RK2
-        dydt = self.viscous_flux.source(self.t, y, self.physics, gamma_star)
+        dydt = self.viscous_flux.source(self.t, y, self.geometry, self.physics, gamma_star)
         y1 = y.copy()
         y1[mt:-mt] += dt * dydt
 
         # 2nd stage of RK2
-        dydt = self.viscous_flux.source(self.t, y1, self.physics, gamma_star)
+        dydt = self.viscous_flux.source(self.t, y1, self.geometry, self.physics, gamma_star)
         y = 0.5 * (y[mt:-mt] + y1[mt:-mt] + dt * dydt)
 
         # Remove ghost layers and update gamma

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -261,9 +261,7 @@ class Combustor:
             self.viscous_flux.F = np.pad(self.F, mt, mode="edge")
 
         # 1st stage of RK2
-        dydt = self.viscous_flux.source(
-            self.t, y, self.geometry, self.physics, gamma_star
-        )
+        dydt = self.viscous_flux.source(self.t, y, self.physics, gamma_star)
         y1 = y.copy()
         y1[self.idx_cells] += dt * dydt
 

--- a/src/stanshock/numerics/gradient.py
+++ b/src/stanshock/numerics/gradient.py
@@ -17,8 +17,8 @@ class Gradient(ABC):
 
 
 class CentralDifference:
-    def __init__(self, mt: int = 1) -> None:
-        self.mt = mt
+    def __init__(self, n_ghost_layers: int = 1) -> None:
+        self.n_ghost_layers = n_ghost_layers
 
     def face_gradients(
         self, cell_states: FluidState, geometry: Geometry, only: list[str] | None = None
@@ -27,7 +27,7 @@ class CentralDifference:
         if only is None:
             only = ["velocity", "temperature", "composition"]
 
-        mt = self.mt
+        mt: int = self.n_ghost_layers
 
         index_face_left = np.s_[mt - 1 : -mt]
         right = cell_states.shape[0] if mt == 1 else -mt + 1

--- a/src/stanshock/numerics/gradient.py
+++ b/src/stanshock/numerics/gradient.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+from stanshock.physics.fluid_base import FluidState
+from stanshock.system.geometry import Geometry
+
+
+class Gradient(ABC):
+    @abstractmethod
+    def face_gradients(
+        self, cell_states: FluidState, geometry: Geometry, only: list[str] | None = None
+    ) -> FluidState:
+        """Compute property gradients across the interior cell faces."""
+
+
+class CentralDifference:
+    def __init__(self, mt: int=1) -> None:
+        self.mt = mt
+
+    def face_gradients(
+        self, cell_states: FluidState, geometry: Geometry, only: list[str] | None = None
+    ) -> FluidState:
+        """Compute property gradients across faces using central difference on a uniform mesh."""
+        if only is None:
+            only = ["velocity", "temperature", "composition"]
+
+        mt = self.mt
+
+        index_face_left = np.s_[mt - 1 : -mt]
+        right = cell_states.shape[0] if mt == 1 else -mt + 1
+        index_face_right = np.s_[mt:right]
+
+        face_gradients = FluidState(shape=(cell_states.shape[0] + 1,))
+
+        for var_name in only:
+            var = getattr(cell_states, var_name)
+            grad_var = (
+                var[index_face_right] - var[index_face_left]
+            ) / geometry.dx
+            setattr(face_gradients, var_name, grad_var)
+
+        return face_gradients

--- a/src/stanshock/numerics/viscous_flux.py
+++ b/src/stanshock/numerics/viscous_flux.py
@@ -3,22 +3,32 @@ from __future__ import annotations
 import numpy as np
 
 from stanshock.numerics.face_extrapolation import FaceExtrapolator
+from stanshock.numerics.gradient import Gradient
 from stanshock.physics.fluid_base import FluidPhysics, FluidState
 from stanshock.system.backend import Array
 from stanshock.system.base import RightHandSide
+from stanshock.system.geometry import Geometry
 
 
 class ViscousFlux(RightHandSide):
     def __init__(
-        self, face_extrapolator: FaceExtrapolator, boundary_conditions, dx
+        self,
+        face_extrapolator: FaceExtrapolator,
+        boundary_conditions,
+        gradient: Gradient,
     ) -> None:
         self.face_extrapolator = face_extrapolator
         self.boundary_conditions = boundary_conditions
-        self.dx = dx
+        self.gradient = gradient
         self.F = 1.0
 
     def source(
-        self, _time: float, state_array: Array, physics: FluidPhysics, gamma_star: Array
+        self,
+        _time: float,
+        state_array: Array,
+        geometry: Geometry,
+        physics: FluidPhysics,
+        gamma_star: Array,
     ) -> Array:
         state = physics.conservative_to_primitive(state_array, gamma_star)
         state.gamma = gamma_star
@@ -26,13 +36,20 @@ class ViscousFlux(RightHandSide):
         face_states = self.face_extrapolator(state)
         face_states = self.boundary_conditions(face_states)
 
-        return self.source_from_primitives(_time, face_states, physics)
+        state.temperature = physics.get_temperature(state)
+        face_gradients = self.gradient.face_gradients(state, geometry)
+
+        return self.source_from_primitives(_time, geometry, physics, face_states, face_gradients)
 
     def source_from_primitives(
-        self, _time: float, face_states: FluidState, physics: FluidPhysics
+        self,
+        _time: float,
+        geometry: Geometry,
+        physics: FluidPhysics,
+        face_states: FluidState,
+        face_gradients: FluidState,
     ) -> Array:
         # Compute properties at the extrapolated cell faces
-        face_states.temperature = physics.get_temperature(face_states)
         viscosity = physics.get_mu(face_states)
         conductivity = physics.get_thermal_conductivity(face_states) * self.F
         diffusivities = physics.get_mass_diffusivity(face_states) * self.F
@@ -43,12 +60,10 @@ class ViscousFlux(RightHandSide):
         conductivity = 0.5 * (conductivity[0, :] + conductivity[1, :])
         diffusivities = 0.5 * (diffusivities[0, :, :] + diffusivities[1, :, :])
 
-        # Compute gradients across the faces via central difference
-        dudx = (face_states.velocity[1, :] - face_states.velocity[0, :]) / self.dx
-        dTdx = (face_states.temperature[1, :] - face_states.temperature[0, :]) / self.dx
-        dYdx = (
-            face_states.composition[1, :, :] - face_states.composition[0, :, :]
-        ) / self.dx
+        # Get gradients across the faces
+        dudx = face_gradients.velocity
+        dTdx = face_gradients.temperature
+        dYdx = face_gradients.composition
 
         # Compute the fluxes
         face_flux = np.concatenate(
@@ -62,4 +77,4 @@ class ViscousFlux(RightHandSide):
         )
 
         # Apply central difference
-        return (face_flux[1:, :] - face_flux[:-1, :]) / self.dx
+        return (face_flux[1:, :] - face_flux[:-1, :]) / geometry.dx

--- a/src/stanshock/numerics/viscous_flux.py
+++ b/src/stanshock/numerics/viscous_flux.py
@@ -41,7 +41,7 @@ class ViscousFlux(RightHandSide):
         face_states = self.boundary_conditions.update_face_states(time, face_states)
 
         state.temperature = physics.get_temperature(state)
-        face_gradients = self.gradient.face_gradients(state, self.geometry)
+        face_gradients: FluidState = self.gradient.face_gradients(state, self.geometry)
 
         return self.source_implementation(physics, face_states, face_gradients)
 

--- a/src/stanshock/system/base.py
+++ b/src/stanshock/system/base.py
@@ -15,5 +15,6 @@ class RightHandSide:
     def source_from_primitives(
         self, time: float, state: FluidState, physics: FluidPhysics
     ) -> Array:
+        assert state.gamma is not None
         state_array = physics.primitive_to_conservative(state)
         return self.source(time, state_array, physics, state.gamma)


### PR DESCRIPTION
Closes #29.

This update pulls the gradient calculations into their own class. A simple central difference scheme for uniform meshes is implemented to compute the gradients across the cell faces. Face gradients are now computed from the bordering cell center values rather than from the extrapolated values at the faces, which is the correct approach.

This framework could be built upon to add higher-order schemes, support for non-uniform meshes, cell-centered gradients, and limiters if there is interest.