### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.10", "3.13"]
         runs-on: [ubuntu-latest, windows-latest, macos-14]
 
         # include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,17 +12,17 @@ authors = [
 ]
 description = "Quasi-1D gas dynamics solver designed to model shock tube experiments and scramjet engines."
 readme = "README.md"
-requires-python = ">=3.9"
+license = "LGPL-3.0"
+license-files = ["LICENSE"]
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 1 - Planning",
   "Intended Audience :: Science/Research",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -109,7 +109,7 @@ report.exclude_also = [
 
 [tool.mypy]
 files = ["src", "tests"]
-python_version = "3.9"
+python_version = "3.10"
 warn_unused_configs = true
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
@@ -167,7 +167,7 @@ isort.required-imports = ["from __future__ import annotations"]
 
 
 [tool.pylint]
-py-version = "3.9"
+py-version = "3.10"
 ignore-paths = [".*/_version.py"]
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"

--- a/src/stanshock/components/shocktube.py
+++ b/src/stanshock/components/shocktube.py
@@ -131,7 +131,7 @@ class ShockTube(Combustor):
 
         # Determine geometry from pressure
         dpAbs = np.abs(pInitial[1:] - pInitial[:-1])
-        xShock = max(zip(dpAbs, geometry.x[1:]))[
+        xShock = max(zip(dpAbs, geometry.x[1:], strict=False))[
             1
         ]  # maximum pressure gradient corresponds to shock
         (xMin, xMax, probeLocation) = (geometry.x[0], xShock, geometry.x[-1])

--- a/src/stanshock/numerics/boundary_conditions.py
+++ b/src/stanshock/numerics/boundary_conditions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Generic, Literal, TypeVar, Union
+from typing import Generic, Literal, TypeVar
 
 from stanshock.physics.fluid_base import FluidState
 from stanshock.system.backend import Array, Index, TypeAlias, np
@@ -187,7 +187,7 @@ class DirichletInflow(SpecifiedFlux):
         return target
 
 
-BCType: TypeAlias = Union[BoundaryCondition[FluidState], BoundaryCondition[Array]]
+BCType: TypeAlias = BoundaryCondition[FluidState] | BoundaryCondition[Array]
 
 
 class BoundaryConditions:

--- a/src/stanshock/numerics/boundary_conditions.py
+++ b/src/stanshock/numerics/boundary_conditions.py
@@ -256,7 +256,7 @@ def set_boundary_conditions(
         bc_locs: list[Literal["left", "right"]] = ["left", "right"]
         bcs: list[BCType] = []
 
-        for bc_loc, bc_specification in zip(bc_locs, boundary_conditions):
+        for bc_loc, bc_specification in zip(bc_locs, boundary_conditions, strict=False):
             if isinstance(bc_specification, str):
                 if bc_specification == "periodic":
                     bcs += [Periodic(mt, location=bc_loc)]

--- a/src/stanshock/numerics/inviscid_flux.py
+++ b/src/stanshock/numerics/inviscid_flux.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Callable, cast
+from collections.abc import Callable
+from typing import cast
 
 import numpy as np
 from numba import double, njit

--- a/src/stanshock/system/backend.py
+++ b/src/stanshock/system/backend.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import sys
-from typing import Union
 
 import numpy as np
 
@@ -10,9 +9,8 @@ if sys.version_info >= (3, 13):
 else:
     from typing_extensions import TypeAlias
 
-__all__ = ["Array", "Index", "TypeAlias", "np"]
+__all__: list[str] = ["Array", "Index", "TypeAlias", "np"]
 
 # Define the Array type for use in type hints to make future changes easier
 Array: TypeAlias = np.ndarray[tuple[int, ...], np.dtype[np.float64]]
-# Note: Must use Union instead of |, but only in Python <3.10 and only in TypeAlias
-Index: TypeAlias = Union[np.ndarray[tuple[int, ...], np.dtype[np.int64]], slice]
+Index: TypeAlias = np.ndarray[tuple[int, ...], np.dtype[np.int64]] | slice

--- a/src/stanshock/system/backend.py
+++ b/src/stanshock/system/backend.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-import sys
+from typing import TypeAlias
 
 import numpy as np
-
-if sys.version_info >= (3, 13):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
 
 __all__: list[str] = ["Array", "Index", "TypeAlias", "np"]
 

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -28,7 +28,7 @@ def test_table_computes_correct_temperatures():
     densities = np.logspace(-1, 1)
     pressures = np.logspace(6, 4)
     actual_temperatures = []
-    for state in zip(densities, pressures, mass_fractions):
+    for state in zip(densities, pressures, mass_fractions, strict=False):
         gas.DPY = state
         actual_temperatures.append(gas.T)
     actual_temperatures = np.array(actual_temperatures)


### PR DESCRIPTION
Python 3.9 requires some additional workarounds for various type annotations which were finalized in 3.10, and is reaching end of life this October. This update drops support for 3.9, including removing the deprecated `Union` types and bumping up the minimum tested version for the CI to 3.10.

Additionally, an erroneous reference to the BSD license was removed from `pyproject.toml`.

Closes #49.