### PR TITLE
Update mesh for consistency and convenience

### DIFF
--- a/examples/hyshot_ii.py
+++ b/examples/hyshot_ii.py
@@ -136,7 +136,7 @@ class HydrogenInjection(RightHandSide):
         index = np.where(np.logical_and(xf >= x_inj, xf < x_inj + L_src))[0]
 
         nsp = gas.n_species
-        self.rhs = np.zeros([geometry.n, 2 + nsp])
+        self.rhs = np.zeros([geometry.n_cells, 2 + nsp])
         self.rhs[index, 0] = rho_f
         self.rhs[index, 1] = rhoE_f
         self.rhs[index, 2 + gas.species_index("H2")] = rhoYH2_f
@@ -177,9 +177,8 @@ ss.advance_simulation(t_end)
 
 # Plot the results
 def plot_sim(ss: Combustor) -> None:
-    xc = ss.geometry.xc
-
-    idx = ss.idx_cells
+    idx = ss.geometry.idx_cells
+    xc = ss.geometry.xc[idx] * scale
     rho = ss.state.density[idx]
     u = ss.state.velocity[idx]
     p = ss.state.pressure[idx]
@@ -189,37 +188,37 @@ def plot_sim(ss: Combustor) -> None:
     M = u / c
 
     fig, ax = plt.subplots(7, 1, sharex=True, figsize=(6, 8))
-    ax[0].plot(xc * scale, rho)
+    ax[0].plot(xc, rho)
     ax[0].set_ymargin(0.1)
     ax[0].set_ylabel(r"$\rho$ [kg/m$^3$]")
     add_h_plot(ax[0])
 
-    ax[1].plot(xc * scale, u)
+    ax[1].plot(xc, u)
     ax[1].set_ymargin(0.1)
     ax[1].set_ylabel(r"$u$ [m/s]")
     add_h_plot(ax[1])
 
-    ax[2].plot(xc * scale, p)
+    ax[2].plot(xc, p)
     ax[2].set_ymargin(0.1)
     ax[2].set_ylabel(r"$p$ [Pa]")
     add_h_plot(ax[2])
 
-    ax[3].plot(xc * scale, T)
+    ax[3].plot(xc, T)
     ax[3].set_ymargin(0.1)
     ax[3].set_ylabel(r"$T$ [K]")
     add_h_plot(ax[3])
 
-    ax[4].plot(xc * scale, M)
+    ax[4].plot(xc, M)
     ax[4].set_ymargin(0.1)
     ax[4].set_ylabel(r"$M$ [-]")
     add_h_plot(ax[4])
 
-    ax[5].plot(xc * scale, Y[:, gas.species_index("H2")])
+    ax[5].plot(xc, Y[:, gas.species_index("H2")])
     ax[5].set_ymargin(0.1)
     ax[5].set_ylabel(r"$Y_{\mathrm{H}_2}$ [-]")
     add_h_plot(ax[5])
 
-    ax[6].plot(xc * scale, Y[:, gas.species_index("H2O")])
+    ax[6].plot(xc, Y[:, gas.species_index("H2O")])
     ax[6].set_ymargin(0.1)
     ax[6].set_ylabel(r"$Y_{\mathrm{H}_2\mathrm{O}}$ [-]")
     add_h_plot(ax[6])

--- a/examples/hyshot_ii.py
+++ b/examples/hyshot_ii.py
@@ -8,9 +8,11 @@ import numpy as np
 
 from stanshock.components.combustor import Combustor
 from stanshock.numerics.boundary_conditions import Inflow
+from stanshock.physics.fluid_base import FluidPhysics
 from stanshock.physics.thermotable import ThermoTable
+from stanshock.system.backend import Array
 from stanshock.system.base import RightHandSide
-from stanshock.system.geometry import Box
+from stanshock.system.geometry import Box, Geometry
 
 plt.rcParams.update(
     {
@@ -41,7 +43,7 @@ scale = 1e3
 
 def add_h_plot(ax):
     ax1 = ax.twinx()
-    ax1.plot(x * scale, h * scale, "k", linestyle="--")
+    ax1.plot(xf * scale, h * scale, "k", linestyle="--")
     ax1.axhline(0, color="k", linestyle="--")
     ax1.set_aspect("equal")
     ax1.set_ylabel("h [mm]")
@@ -73,11 +75,11 @@ mdot_a = rho_in * U_in * h_const * w
 
 # Define the grid
 N_x = 200
-x = np.linspace(0, L_const + L_exhaust, N_x)
-h = np.zeros_like(x)
-h[x < L_const] = h_const
-h[x >= L_const] = h_const + (x[x >= L_const] - L_const) * np.tan(theta_exhaust)
-geometry = Box(x=x, h=h, w=w)
+xf = np.linspace(0, L_const + L_exhaust, N_x + 1)
+h = np.zeros_like(xf)
+h[xf < L_const] = h_const
+h[xf >= L_const] = h_const + (xf[xf >= L_const] - L_const) * np.tan(theta_exhaust)
+geometry = Box(xf=xf, h=h, w=w)
 
 # Time parameters
 tau = L / U_in
@@ -99,9 +101,7 @@ BCs = (BC_inlet, BC_outlet)
 
 # Define the fuel inflow
 class HydrogenInjection(RightHandSide):
-    def __init__(self, gas, geometry):
-        self.geometry = geometry
-
+    def __init__(self, gas: ct.Solution, geometry: Geometry) -> None:
         # Injector area
         r_f = 0.2e-3  # m
         N_f = 4  # -
@@ -123,43 +123,45 @@ class HydrogenInjection(RightHandSide):
         P_f = gas.P
         # W_f = gas.mean_molecular_weight
 
-        self.rho_f = rho_f
-        self.rhoE_f = P_f / (gamma_f - 1) + 0.5 * rho_f * U_f**2
-        self.rhoYH2_f = rho_f * gas.Y[gas.species_index("H2")]
-        self.U_f = U_f
-        self.A_f = A_f_tot
+        rhoE_f = P_f / (gamma_f - 1) + 0.5 * rho_f * U_f**2
+        rhoYH2_f = rho_f * gas.Y[gas.species_index("H2")]
+        A_f = A_f_tot
 
         # Define the source terms
-        self.L_src = 30.0e-3
-        self.scale_factor = 3.960715337483353
+        L_src = 30.0e-3
+        scale_factor = 3.960715337483353
 
-    def source(self, t, _state_array, _physics, _gamma_star, _e0_star):
-        x = self.geometry.x
-        rho_f = self.rho_f
-        U_f = self.U_f
-        A_f = self.A_f
-        rhoE_f = self.rhoE_f
-        rhoYH2_f = self.rhoYH2_f
-        L_src = self.L_src
-        scale_factor = self.scale_factor
+        # Get geometry information
+        xf = geometry.xf
+        index = np.where(np.logical_and(xf >= x_inj, xf < x_inj + L_src))[0]
 
         nsp = gas.n_species
-        rhs = np.zeros([len(x), 2 + nsp])
-        index = np.logical_and(x >= x_inj, x < x_inj + L_src)
-        dx = x[1] - x[0]
-        area = self.geometry.area(t, x[index])
+        self.rhs = np.zeros([geometry.n, 2 + nsp])
+        self.rhs[index, 0] = rho_f
+        self.rhs[index, 1] = rhoE_f
+        self.rhs[index, 2 + gas.species_index("H2")] = rhoYH2_f
+        self.rhs[index, :] *= U_f * A_f / L_src * scale_factor
 
-        rhs[index, 0] = rho_f * U_f * A_f / L_src * dx / (dx * area) * scale_factor
-        rhs[index, 1] = rhoE_f * U_f * A_f / L_src * dx / (dx * area) * scale_factor
-        rhs[index, 2 + gas.species_index("H2")] = (
-            rhoYH2_f * U_f * A_f / L_src * dx / (dx * area) * scale_factor
-        )
+        self.xc = geometry.xc[index]
+        self.geometry = geometry
+        self.index = index
+
+    def source(
+        self,
+        time: float,
+        _state_array: Array,
+        _physics: FluidPhysics,
+        _gamma_star: Array | None = None,
+        _e0_star: Array | None = None,
+    ) -> Array:
+        rhs = self.rhs.copy()
+        rhs[self.index, :] /= self.geometry.area(time, self.xc)[:, None]
         return rhs
 
 
 # Initialize and run the simulation
 ss = Combustor(
-    x=x,
+    xf=xf,
     geometry=geometry,
     initialization=("constant", gas_init, U_in),
     boundary_conditions=BCs,
@@ -174,8 +176,8 @@ ss.advance_simulation(t_end)
 
 
 # Plot the results
-def plot_sim(ss):
-    x = ss.geometry.x
+def plot_sim(ss: Combustor) -> None:
+    xc = ss.geometry.xc
 
     idx = ss.idx_cells
     rho = ss.state.density[idx]
@@ -187,37 +189,37 @@ def plot_sim(ss):
     M = u / c
 
     fig, ax = plt.subplots(7, 1, sharex=True, figsize=(6, 8))
-    ax[0].plot(x * scale, rho)
+    ax[0].plot(xc * scale, rho)
     ax[0].set_ymargin(0.1)
     ax[0].set_ylabel(r"$\rho$ [kg/m$^3$]")
     add_h_plot(ax[0])
 
-    ax[1].plot(x * scale, u)
+    ax[1].plot(xc * scale, u)
     ax[1].set_ymargin(0.1)
     ax[1].set_ylabel(r"$u$ [m/s]")
     add_h_plot(ax[1])
 
-    ax[2].plot(x * scale, p)
+    ax[2].plot(xc * scale, p)
     ax[2].set_ymargin(0.1)
     ax[2].set_ylabel(r"$p$ [Pa]")
     add_h_plot(ax[2])
 
-    ax[3].plot(x * scale, T)
+    ax[3].plot(xc * scale, T)
     ax[3].set_ymargin(0.1)
     ax[3].set_ylabel(r"$T$ [K]")
     add_h_plot(ax[3])
 
-    ax[4].plot(x * scale, M)
+    ax[4].plot(xc * scale, M)
     ax[4].set_ymargin(0.1)
     ax[4].set_ylabel(r"$M$ [-]")
     add_h_plot(ax[4])
 
-    ax[5].plot(x * scale, Y[:, gas.species_index("H2")])
+    ax[5].plot(xc * scale, Y[:, gas.species_index("H2")])
     ax[5].set_ymargin(0.1)
     ax[5].set_ylabel(r"$Y_{\mathrm{H}_2}$ [-]")
     add_h_plot(ax[5])
 
-    ax[6].plot(x * scale, Y[:, gas.species_index("H2O")])
+    ax[6].plot(xc * scale, Y[:, gas.species_index("H2O")])
     ax[6].set_ymargin(0.1)
     ax[6].set_ylabel(r"$Y_{\mathrm{H}_2\mathrm{O}}$ [-]")
     add_h_plot(ax[6])

--- a/examples/hyshot_ii_jic/hyshot_ii_jic.py
+++ b/examples/hyshot_ii_jic/hyshot_ii_jic.py
@@ -22,9 +22,9 @@ BIGGER_SIZE = 18
 
 plt.rcParams.update(
     {
-        "text.usetex": True,
-        "font.family": "serif",
-        "font.serif": ["Computer Modern Roman"],
+        "text.usetex": False,
+        # "font.family": "serif",
+        # "font.serif": ["Computer Modern Roman"],
         "axes.xmargin": 0,
         "axes.ymargin": 0,
         "font.size": SMALL_SIZE,
@@ -43,7 +43,7 @@ scale = 1e3
 
 def add_h_plot(ax):
     ax1 = ax.twinx()
-    ax1.plot(x * scale, h * scale, "k", linestyle="--")
+    ax1.plot(xf * scale, h * scale, "k", linestyle="--")
     ax1.axhline(0, color="k", linestyle="--")
     ax1.set_aspect("equal")
     ax1.set_ylabel("h [mm]")
@@ -220,11 +220,12 @@ T_f = T_f[-1]
 
 # Define the grid
 N_x = 200
-x = np.linspace(0, L_const + L_exhaust, N_x)
-h = np.zeros_like(x)
-h[x < L_const] = h_const
-h[x >= L_const] = h_const + (x[x >= L_const] - L_const) * np.tan(theta_exhaust)
-geometry = Box(x=x, h=h, w=w)
+xf = np.linspace(0, L_const + L_exhaust, N_x + 1)
+xc = 0.5 * (xf[1:] + xf[:-1])
+h = np.zeros_like(xf)
+h[xf < L_const] = h_const
+h[xf >= L_const] = h_const + (xf[xf >= L_const] - L_const) * np.tan(theta_exhaust)
+geometry = Box(xf=xf, h=h, w=w)
 
 
 # PDF sampling parameters
@@ -256,21 +257,21 @@ fpv_table = FPVTable(
 
 # Build the injector model
 jic = JICModel(
-    "H2",
-    x,
-    x_inj,
-    L_const,
-    w,
-    h[0],
-    N_f,
-    2 * r_f,
-    t_f,
-    rho_f,
-    U_f,
-    T_f,
-    rho_in,
-    U_in,
-    T_in,
+    fuel="H2",
+    x=xc,
+    x_inj=x_inj,
+    x_noz=L_const,
+    w=w,
+    h=h[0],
+    n_inj=N_f,
+    d_inj=2 * r_f,
+    t_inj=t_f,
+    rho_inj=rho_f,
+    u_inj=U_f,
+    T_inj=T_f,
+    rho=rho_in,
+    u=U_in,
+    T=T_in,
     alpha=1e6,
     fpv_table=fpv_table,
     load_Z_3D=(datadir / "Z_3D.npy").exists(),
@@ -402,7 +403,7 @@ jic = JICModel(
 
 # Initialize and run the simulation
 ss = Combustor(
-    x=x,
+    xf=xf,
     geometry=geometry,
     wall_temperature=300.0,
     include_boundary_layer=True,

--- a/examples/laminar_flame.py
+++ b/examples/laminar_flame.py
@@ -64,7 +64,7 @@ def main(
         physics = CanteraInterface(gas)
 
     ss = Combustor(
-        n=nX,
+        n_cells=nX,
         xf=np.linspace(xLower, xUpper, nX + 1),
         dx=(xUpper - xLower) / nX,
         initialization=("Riemann", unburnedState, burnedState, flame_center),
@@ -79,15 +79,11 @@ def main(
     # interpolate flame solution
     Y = ss.state.composition
     for iSp in range(gas.n_species):
-        Y[ss.idx_cells, iSp] = np.interp(ss.geometry.xc, flame.grid, flame.Y[iSp, :])
+        Y[:, iSp] = np.interp(ss.geometry.xc, flame.grid, flame.Y[iSp, :])
 
-    ss.state.density[ss.idx_cells] = np.interp(
-        ss.geometry.xc, flame.grid, flame.density
-    )
-    ss.state.velocity[ss.idx_cells] = np.interp(
-        ss.geometry.xc, flame.grid, flame.velocity
-    )
-    ss.state.pressure[ss.idx_cells] = flame.P * np.ones(ss.geometry.n)
+    ss.state.density = np.interp(ss.geometry.xc, flame.grid, flame.density)
+    ss.state.velocity = np.interp(ss.geometry.xc, flame.grid, flame.velocity)
+    ss.state.pressure = flame.P * np.ones(ss.geometry.n_cells)
     ss.state.composition = Y
 
     T = ss.state.temperature = ss.physics.get_temperature(ss.state)
@@ -105,7 +101,10 @@ def main(
 
     # plot setup
     if plot_results:
-        T = ss.physics.get_temperature(ss.state)[ss.idx_cells]
+        idx = ss.geometry.idx_cells
+        x = (ss.geometry.xc[idx] - flame_center) / flameThickness
+        x_ct = (flame.grid - flame_center) / flameThickness
+        T = ss.physics.get_temperature(ss.state)[idx]
         state = ss.physics.set_state(ss.state)
 
         plt.close("all")
@@ -114,51 +113,17 @@ def main(
         mpl.rcParams["font.size"] = fontsize
         plt.rc("text", usetex=True)
         # plot
-        plt.plot(
-            (flame.grid - flame_center) / flameThickness,
-            flame.T / flame.T[-1],
-            "r",
-            label=r"$T/T_\mathrm{F}$",
-        )
-        plt.plot(
-            (ss.geometry.xc - flame_center) / flameThickness, T / flame.T[-1], "r--s"
-        )
+        plt.plot(x_ct, flame.T / flame.T[-1], "r", label=r"$T/T_\mathrm{F}$")
+        plt.plot(x, T / flame.T[-1], "r--s")
         iOH = gas.species_index("OH")
-        plt.plot(
-            (flame.grid - flame_center) / flameThickness,
-            flame.Y[iOH, :] * 10,
-            "k",
-            label=r"$Y_\mathrm{OH}\times 10$",
-        )
-        plt.plot(
-            (ss.geometry.xc - flame_center) / flameThickness,
-            state.mass_fractions[ss.idx_cells, iOH] * 10,
-            "k--s",
-        )
+        plt.plot(x_ct, flame.Y[iOH, :] * 10, "k", label=r"$Y_\mathrm{OH}\times 10$")
+        plt.plot(x, state.mass_fractions[idx, iOH] * 10, "k--s")
         iO2 = gas.species_index("O2")
-        plt.plot(
-            (flame.grid - flame_center) / flameThickness,
-            flame.Y[iO2, :],
-            "g",
-            label=r"$Y_\mathrm{O_2}$",
-        )
-        plt.plot(
-            (ss.geometry.xc - flame_center) / flameThickness,
-            state.mass_fractions[ss.idx_cells, iO2],
-            "g--s",
-        )
+        plt.plot(x_ct, flame.Y[iO2, :], "g", label=r"$Y_\mathrm{O_2}$")
+        plt.plot(x, state.mass_fractions[idx, iO2], "g--s")
         iH2 = gas.species_index("H2")
-        plt.plot(
-            (flame.grid - flame_center) / flameThickness,
-            flame.Y[iH2, :],
-            "b",
-            label=r"$Y_\mathrm{H_2}$",
-        )
-        plt.plot(
-            (ss.geometry.xc - flame_center) / flameThickness,
-            state.mass_fractions[ss.idx_cells, iH2],
-            "b--s",
-        )
+        plt.plot(x_ct, flame.Y[iH2, :], "b", label=r"$Y_\mathrm{H_2}$")
+        plt.plot(x, state.mass_fractions[idx, iH2], "b--s")
         plt.xlabel(r"$x/\delta_\mathrm{F}$")
         plt.legend(loc="best")
         if show_results:
@@ -169,8 +134,8 @@ def main(
             plt.savefig(results_location / "laminarFlame.pdf")
 
     results = {
-        "position": ss.geometry.xc,
-        "temperature": T[ss.idx_cells],
+        "position": ss.geometry.xc[idx],
+        "temperature": T[idx],
     }
     if results_location is not None:
         results_location = Path(results_location)

--- a/examples/laminar_flame.py
+++ b/examples/laminar_flame.py
@@ -65,8 +65,8 @@ def main(
 
     ss = Combustor(
         n=nX,
-        x=np.linspace(xLower, xUpper, nX),
-        dx=(xUpper - xLower) / (nX - 1),
+        xf=np.linspace(xLower, xUpper, nX + 1),
+        dx=(xUpper - xLower) / nX,
         initialization=("Riemann", unburnedState, burnedState, flame_center),
         physics=physics,
         boundary_conditions=boundary_conditions,
@@ -79,11 +79,13 @@ def main(
     # interpolate flame solution
     Y = ss.state.composition
     for iSp in range(gas.n_species):
-        Y[ss.idx_cells, iSp] = np.interp(ss.geometry.x, flame.grid, flame.Y[iSp, :])
+        Y[ss.idx_cells, iSp] = np.interp(ss.geometry.xc, flame.grid, flame.Y[iSp, :])
 
-    ss.state.density[ss.idx_cells] = np.interp(ss.geometry.x, flame.grid, flame.density)
+    ss.state.density[ss.idx_cells] = np.interp(
+        ss.geometry.xc, flame.grid, flame.density
+    )
     ss.state.velocity[ss.idx_cells] = np.interp(
-        ss.geometry.x, flame.grid, flame.velocity
+        ss.geometry.xc, flame.grid, flame.velocity
     )
     ss.state.pressure[ss.idx_cells] = flame.P * np.ones(ss.geometry.n)
     ss.state.composition = Y
@@ -119,7 +121,7 @@ def main(
             label=r"$T/T_\mathrm{F}$",
         )
         plt.plot(
-            (ss.geometry.x - flame_center) / flameThickness, T / flame.T[-1], "r--s"
+            (ss.geometry.xc - flame_center) / flameThickness, T / flame.T[-1], "r--s"
         )
         iOH = gas.species_index("OH")
         plt.plot(
@@ -129,7 +131,7 @@ def main(
             label=r"$Y_\mathrm{OH}\times 10$",
         )
         plt.plot(
-            (ss.geometry.x - flame_center) / flameThickness,
+            (ss.geometry.xc - flame_center) / flameThickness,
             state.mass_fractions[ss.idx_cells, iOH] * 10,
             "k--s",
         )
@@ -141,7 +143,7 @@ def main(
             label=r"$Y_\mathrm{O_2}$",
         )
         plt.plot(
-            (ss.geometry.x - flame_center) / flameThickness,
+            (ss.geometry.xc - flame_center) / flameThickness,
             state.mass_fractions[ss.idx_cells, iO2],
             "g--s",
         )
@@ -153,7 +155,7 @@ def main(
             label=r"$Y_\mathrm{H_2}$",
         )
         plt.plot(
-            (ss.geometry.x - flame_center) / flameThickness,
+            (ss.geometry.xc - flame_center) / flameThickness,
             state.mass_fractions[ss.idx_cells, iH2],
             "b--s",
         )
@@ -167,7 +169,7 @@ def main(
             plt.savefig(results_location / "laminarFlame.pdf")
 
     results = {
-        "position": ss.geometry.x,
+        "position": ss.geometry.xc,
         "temperature": T[ss.idx_cells],
     }
     if results_location is not None:

--- a/examples/optimization.py
+++ b/examples/optimization.py
@@ -167,7 +167,7 @@ def main(
             XTDiagram(ss, variable=variable, limits=limits)
             for variable, limits in diagram_settings
         ]
-    ss.probes.append(Probe(ss, max(ss.geometry.xc)))  # end wall probe
+    ss.probes.append(Probe(ss, max(ss.geometry.xf)))  # end wall probe
     t0 = time.perf_counter()
     ss.advance_simulation(tFinal)
     t1 = time.perf_counter()
@@ -202,7 +202,7 @@ def main(
             XTDiagram(ss, variable=variable, limits=limits)
             for variable, limits in diagram_settings
         ]
-    ss.probes.append(Probe(ss, max(ss.geometry.xc)))  # end wall probe
+    ss.probes.append(Probe(ss, max(ss.geometry.xf)))  # end wall probe
     t0 = time.perf_counter()
     ss.advance_simulation(tFinal)
     t1 = time.perf_counter()

--- a/examples/optimization.py
+++ b/examples/optimization.py
@@ -42,14 +42,14 @@ def main(
     if plot_results:
         plt.close("all")
         mpl.rcParams["font.size"] = fontsize
-        plt.rc("text", usetex=True)
+        # plt.rc("text", usetex=True)
 
     # set up geometry
     xLower = -LDriver
     xUpper = LDriven
     xShock = 0.0
     Delta = 10 * (xUpper - xLower) / float(nXFine)
-    x = np.linspace(xLower, xUpper, nXCoarse)
+    xf = np.linspace(xLower, xUpper, nXCoarse + 1)
 
     def d_inner(time: float, x: Array) -> Array:
         return np.zeros_like(x)
@@ -116,7 +116,7 @@ def main(
     physics_model = ThermoTable(gas1)
 
     ss = ShockTube(
-        x=x,
+        xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -141,11 +141,11 @@ def main(
     print("The process took ", t1 - t0)
 
     # recalculate at higher resolution with the insert
-    x = np.linspace(xLower, xUpper, nXFine)
+    xf = np.linspace(xLower, xUpper, nXFine + 1)
     gas1.TPX = T1, p1, "AR:1"
     gas4.TPX = T4, p4, "HE:1"
     ss = ShockTube(
-        x=x,
+        xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -167,7 +167,7 @@ def main(
             XTDiagram(ss, variable=variable, limits=limits)
             for variable, limits in diagram_settings
         ]
-    ss.probes.append(Probe(ss, max(ss.geometry.x)))  # end wall probe
+    ss.probes.append(Probe(ss, max(ss.geometry.xc)))  # end wall probe
     t0 = time.perf_counter()
     ss.advance_simulation(tFinal)
     t1 = time.perf_counter()
@@ -178,15 +178,15 @@ def main(
     for diagram in ss.xt_diagrams:
         diagram.plot()
 
-    xInsert = ss.geometry.x
-    d_outer_insert = ss.geometry.d_outer(0.0, ss.geometry.x)
-    d_inner_insert = ss.geometry.d_inner(0.0, ss.geometry.x)
+    xInsert = ss.geometry.xc
+    d_outer_insert = ss.geometry.d_outer(0.0, ss.geometry.xc)
+    d_inner_insert = ss.geometry.d_inner(0.0, ss.geometry.xc)
 
     # recalculate at higher resolution without the insert
     gas1.TPX = T1, p1, "AR:1"
     gas4.TPX = T4, p4, "HE:1"
     ss = ShockTube(
-        x=x,
+        xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -202,7 +202,7 @@ def main(
             XTDiagram(ss, variable=variable, limits=limits)
             for variable, limits in diagram_settings
         ]
-    ss.probes.append(Probe(ss, max(ss.geometry.x)))  # end wall probe
+    ss.probes.append(Probe(ss, max(ss.geometry.xc)))  # end wall probe
     t0 = time.perf_counter()
     ss.advance_simulation(tFinal)
     t1 = time.perf_counter()

--- a/examples/validation/case1.py
+++ b/examples/validation/case1.py
@@ -100,7 +100,7 @@ def main(
     physics_model = ThermoTable(gas1)
 
     ssbl = ShockTube(
-        n=nX,
+        n_cells=nX,
         xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
@@ -112,7 +112,7 @@ def main(
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
         dlnA_dx=dlnA_dx,
     )
-    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xc)))  # end wall probe
+    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xf)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()
@@ -126,7 +126,7 @@ def main(
     gas1.TP = T1, p1
     gas4.TP = T4, p4
     ssnbl = ShockTube(
-        n=nX,
+        n_cells=nX,
         xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
@@ -137,7 +137,7 @@ def main(
         d_outer=D,
         dlnA_dx=dlnA_dx,
     )
-    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xc)))  # end wall probe
+    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xf)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()

--- a/examples/validation/case1.py
+++ b/examples/validation/case1.py
@@ -65,7 +65,7 @@ def main(
     xLower = -LDriver
     xUpper = LDriven
     xShock = 0.0
-    x = np.linspace(xLower, xUpper, nX)
+    xf = np.linspace(xLower, xUpper, nX + 1)
     DeltaD = DDriven - DDriver
     DeltaX = (
         (xUpper - xLower) / float(nX) * 10
@@ -101,7 +101,7 @@ def main(
 
     ssbl = ShockTube(
         n=nX,
-        x=x,
+        xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -112,7 +112,7 @@ def main(
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
         dlnA_dx=dlnA_dx,
     )
-    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.x)))  # end wall probe
+    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xc)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()
@@ -127,7 +127,7 @@ def main(
     gas4.TP = T4, p4
     ssnbl = ShockTube(
         n=nX,
-        x=x,
+        xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -137,7 +137,7 @@ def main(
         d_outer=D,
         dlnA_dx=dlnA_dx,
     )
-    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.x)))  # end wall probe
+    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xc)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()

--- a/examples/validation/case2.py
+++ b/examples/validation/case2.py
@@ -101,7 +101,7 @@ def main(
     physics_model = ThermoTable(gas1)
 
     ssbl = ShockTube(
-        n=nX,
+        n_cells=nX,
         xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
@@ -113,7 +113,7 @@ def main(
         d_outer=D,
         dlnA_dx=dlnA_dx,
     )
-    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xc)))  # end wall probe
+    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xf)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()
@@ -127,7 +127,7 @@ def main(
     gas1.TP = T1, p1
     gas4.TP = T4, p4
     ssnbl = ShockTube(
-        n=nX,
+        n_cells=nX,
         xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
@@ -138,7 +138,7 @@ def main(
         d_outer=D,
         dlnA_dx=dlnA_dx,
     )
-    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xc)))  # end wall probe
+    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xf)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()

--- a/examples/validation/case2.py
+++ b/examples/validation/case2.py
@@ -65,7 +65,7 @@ def main(
     xLower = -LDriver
     xUpper = LDriven
     xShock = 0.0
-    x = np.linspace(xLower, xUpper, nX)
+    xf = np.linspace(xLower, xUpper, nX + 1)
     DeltaD = DDriven - DDriver
     DeltaX = (
         (xUpper - xLower) / float(nX) * 10
@@ -102,7 +102,7 @@ def main(
 
     ssbl = ShockTube(
         n=nX,
-        x=x,
+        xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -113,7 +113,7 @@ def main(
         d_outer=D,
         dlnA_dx=dlnA_dx,
     )
-    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.x)))  # end wall probe
+    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xc)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()
@@ -128,7 +128,7 @@ def main(
     gas4.TP = T4, p4
     ssnbl = ShockTube(
         n=nX,
-        x=x,
+        xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -138,7 +138,7 @@ def main(
         d_outer=D,
         dlnA_dx=dlnA_dx,
     )
-    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.x)))  # end wall probe
+    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xc)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()

--- a/examples/validation/case3.py
+++ b/examples/validation/case3.py
@@ -150,7 +150,7 @@ def main(
     physics_model = ThermoTable(gas1)
 
     ssbl = ShockTube(
-        n=nX,
+        n_cells=nX,
         xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
@@ -163,7 +163,7 @@ def main(
         d_outer=d_outer,
         dlnA_dx=dlnA_dx,
     )
-    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xc)))  # end wall probe
+    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xf)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()
@@ -177,7 +177,7 @@ def main(
     gas1.TP = T1, p1
     gas4.TP = T4, p4
     ssnbl = ShockTube(
-        n=nX,
+        n_cells=nX,
         xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
@@ -189,7 +189,7 @@ def main(
         d_outer=d_outer,
         dlnA_dx=dlnA_dx,
     )
-    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xc)))  # end wall probe
+    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xf)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()

--- a/examples/validation/case3.py
+++ b/examples/validation/case3.py
@@ -73,7 +73,7 @@ def main(
     xLower = -LDriver
     xUpper = LDriven
     xShock = 0.0
-    x = np.linspace(xLower, xUpper, nX)
+    xf = np.linspace(xLower, xUpper, nX + 1)
     # DeltaD = DDriven - DDriver
     # dd_outerInsertdx = (d_outerInsertFront - d_outerInsertBack) / LOuterInsert
     DeltaSmoothingFunction = (xUpper - xLower) / float(nX) * 10.0
@@ -151,7 +151,7 @@ def main(
 
     ssbl = ShockTube(
         n=nX,
-        x=x,
+        xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -163,7 +163,7 @@ def main(
         d_outer=d_outer,
         dlnA_dx=dlnA_dx,
     )
-    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.x)))  # end wall probe
+    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xc)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()
@@ -178,7 +178,7 @@ def main(
     gas4.TP = T4, p4
     ssnbl = ShockTube(
         n=nX,
-        x=x,
+        xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -189,7 +189,7 @@ def main(
         d_outer=d_outer,
         dlnA_dx=dlnA_dx,
     )
-    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.x)))  # end wall probe
+    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xc)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()

--- a/examples/validation/case4.py
+++ b/examples/validation/case4.py
@@ -86,7 +86,7 @@ def main(
     xLower = -LDriver
     xUpper = LDriven
     xShock = 0.0
-    x = np.linspace(xLower, xUpper, nX)
+    xf = np.linspace(xLower, xUpper, nX + 1)
     # arrays from HTGL
     xInterp = -0.0254 * np.array(
         [142, 140, 130, 120, 110, 100, 90, 80, 70, 60, 50, 40, 36, 37, 30, 20, 10, 0]
@@ -152,7 +152,7 @@ def main(
 
     ssbl = ShockTube(
         n=nX,
-        x=x,
+        xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -165,7 +165,7 @@ def main(
         dlnA_dx=dlnA_dx,
     )
     ssbl.state.gamma = ssbl.physics.get_gamma(ssbl.state)
-    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.x)))  # end wall probe
+    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xc)))  # end wall probe
     diagram_settings = [
         ("pressure", [p1 / 101325, p4 / 101325]),
         ("temperature", [T1, 800.0]),
@@ -178,9 +178,9 @@ def main(
     # adjust for partial filling strategy
     XN2Lower = 0.80  # assume smearing during fill
     XN2Upper = 1.5 - XN2Lower
-    dx = ssbl.geometry.x[1] - ssbl.geometry.x[0]
-    dV = A(0.0, ssbl.geometry.x) * dx
-    VDriver = np.sum(dV[ssbl.geometry.x < xShock])
+    dx = ssbl.geometry.dx
+    dV = A(0.0, ssbl.geometry.xc) * dx
+    VDriver = np.sum(dV[ssbl.geometry.xc < xShock])
     V = np.cumsum(dV)
     V -= V[0] / 2.0  # center
     VNorms = V / VDriver
@@ -215,7 +215,7 @@ def main(
     gas4.TP = T4, p4
     ssnbl = ShockTube(
         n=nX,
-        x=x,
+        xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -228,7 +228,7 @@ def main(
         dlnA_dx=dlnA_dx,
     )
     ssnbl.state.gamma = ssnbl.physics.get_gamma(ssnbl.state)
-    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.x)))  # end wall probe
+    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xc)))  # end wall probe
     ssnbl.xt_diagrams += [
         XTDiagram(ssnbl, variable=variable, limits=limits)
         for variable, limits in diagram_settings
@@ -237,9 +237,9 @@ def main(
     # adjust for partial filling strategy
     XN2Lower = 0.80  # assume smearing during fill
     XN2Upper = 1.5 - XN2Lower
-    dx = ssnbl.geometry.x[1] - ssnbl.geometry.x[0]
-    dV = A(0.0, ssnbl.geometry.x) * dx
-    VDriver = np.sum(dV[ssnbl.geometry.x < xShock])
+    dx = ssnbl.geometry.dx
+    dV = A(0.0, ssnbl.geometry.xc) * dx
+    VDriver = np.sum(dV[ssnbl.geometry.xc < xShock])
     V = np.cumsum(dV)
     V -= V[0] / 2.0  # center
     VNorms = V / VDriver

--- a/examples/validation/case4.py
+++ b/examples/validation/case4.py
@@ -151,7 +151,7 @@ def main(
     physics_model = ThermoTable(gas1)
 
     ssbl = ShockTube(
-        n=nX,
+        n_cells=nX,
         xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
@@ -165,7 +165,7 @@ def main(
         dlnA_dx=dlnA_dx,
     )
     ssbl.state.gamma = ssbl.physics.get_gamma(ssbl.state)
-    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xc)))  # end wall probe
+    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xf)))  # end wall probe
     diagram_settings = [
         ("pressure", [p1 / 101325, p4 / 101325]),
         ("temperature", [T1, 800.0]),
@@ -178,15 +178,16 @@ def main(
     # adjust for partial filling strategy
     XN2Lower = 0.80  # assume smearing during fill
     XN2Upper = 1.5 - XN2Lower
-    dx = ssbl.geometry.dx
-    dV = A(0.0, ssbl.geometry.xc) * dx
-    VDriver = np.sum(dV[ssbl.geometry.xc < xShock])
+    idx = ssbl.geometry.idx_cells
+    xc = ssbl.geometry.xc[idx]
+    dV = ssbl.geometry.volume(0.0, xc)
+    VDriver = np.sum(dV[xc < xShock])
     V = np.cumsum(dV)
     V -= V[0] / 2.0  # center
     VNorms = V / VDriver
     # get gas properties
     iHE, iN2 = gas4.species_index("HE"), gas4.species_index("N2")
-    mt = ssbl.n_ghost_layers
+    mt = ssbl.geometry.n_ghost_layers
     for iX, VNorm in enumerate(VNorms):
         if VNorm <= 1.0:
             # nitrogen and helium
@@ -214,7 +215,7 @@ def main(
     gas1.TP = T1, p1
     gas4.TP = T4, p4
     ssnbl = ShockTube(
-        n=nX,
+        n_cells=nX,
         xf=xf,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
@@ -228,7 +229,7 @@ def main(
         dlnA_dx=dlnA_dx,
     )
     ssnbl.state.gamma = ssnbl.physics.get_gamma(ssnbl.state)
-    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xc)))  # end wall probe
+    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xf)))  # end wall probe
     ssnbl.xt_diagrams += [
         XTDiagram(ssnbl, variable=variable, limits=limits)
         for variable, limits in diagram_settings
@@ -237,15 +238,16 @@ def main(
     # adjust for partial filling strategy
     XN2Lower = 0.80  # assume smearing during fill
     XN2Upper = 1.5 - XN2Lower
-    dx = ssnbl.geometry.dx
-    dV = A(0.0, ssnbl.geometry.xc) * dx
-    VDriver = np.sum(dV[ssnbl.geometry.xc < xShock])
+    idx = ssnbl.geometry.idx_cells
+    xc = ssnbl.geometry.xc[idx]
+    dV = ssnbl.geometry.volume(0.0, xc)
+    VDriver = np.sum(dV[xc < xShock])
     V = np.cumsum(dV)
     V -= V[0] / 2.0  # center
     VNorms = V / VDriver
     # get gas properties
     iHE, iN2 = gas4.species_index("HE"), gas4.species_index("N2")
-    mt = ssnbl.n_ghost_layers
+    mt = ssnbl.geometry.n_ghost_layers
     for iX, VNorm in enumerate(VNorms):
         if VNorm <= 1.0:
             # nitrogen and helium

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -57,9 +57,7 @@ class Combustor:
             "outflow",
             "outflow",
         ]
-        self.x: Array = np.linspace(
-            0.0, self.dx * (self.n - 1), self.n, dtype=np.float64
-        )
+        self.xf: Array = np.linspace(0.0, self.dx * self.n, self.n, dtype=np.float64)
         self.F = np.ones(self.n)  # thickening
         self.t = 0.0  # time
         self.verbose = True  # console output switch
@@ -94,8 +92,8 @@ class Combustor:
 
         # Initialize the geometry of the domain
         if geometry is None:
-            kwargs.pop("x")
-            self.geometry: Geometry = initialize_geometry(x=self.x, **kwargs)
+            kwargs.pop("xf")
+            self.geometry: Geometry = initialize_geometry(xf=self.xf, **kwargs)
         else:
             self.geometry = geometry
 
@@ -363,7 +361,7 @@ class Combustor:
         indices = [
             k + self.n_ghost_layers
             for k in range(self.n)
-            if self.in_reacting_region(self.geometry.x[k], self.t)
+            if self.in_reacting_region(self.geometry.xc[k], self.t)
         ]
         state_temp = FluidState(
             shape=(len(indices),),

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -27,7 +27,7 @@ from stanshock.processing.initialize import (
     initialize_riemann_problem,
 )
 from stanshock.processing.plot import plot_state
-from stanshock.system.backend import Array, Index
+from stanshock.system.backend import Array
 from stanshock.system.base import RightHandSide
 from stanshock.system.geometry import Geometry, initialize_geometry
 
@@ -41,7 +41,7 @@ class Combustor:
     def __init__(
         self,
         physics: FluidPhysics,
-        n: int = 10,
+        n_cells: int = 10,
         geometry: Geometry | None = None,
         **kwargs,
     ):
@@ -52,13 +52,14 @@ class Combustor:
         # initialize the class
         self.cfl = 1.0  # stability condition
         self.dx = 1.0  # grid spacing
-        self.n = n  # grid size
+        self.n_cells = n_cells  # grid size
         self.boundary_conditions: BoundaryConditions | list[BCNamesType | BCType] = [
             "outflow",
             "outflow",
         ]
-        self.xf: Array = np.linspace(0.0, self.dx * self.n, self.n, dtype=np.float64)
-        self.F = np.ones(self.n)  # thickening
+        self.xf: Array = np.linspace(
+            0.0, self.dx * self.n_cells, self.n_cells + 1, dtype=np.float64
+        )
         self.t = 0.0  # time
         self.verbose = True  # console output switch
         self.output_every = (
@@ -79,8 +80,8 @@ class Combustor:
         self.optimization_iteration = 0  # counter to keep track of optimization
         self.physics = physics  # Model handling all fluid property evaluations
         self.reacting = False  # flag to solver about whether to solve source terms
-        self.in_reacting_region = (
-            lambda _x, _t: True
+        self.in_reacting_region = lambda _t, x: np.ones_like(
+            x, dtype=bool
         )  # the reacting region of the shock tube.
         self.include_diffusion = False  # exclude diffusion
         self.thickening = None  # thickening function
@@ -90,12 +91,22 @@ class Combustor:
             if key in self.__dict__:
                 self.__dict__[key] = item
 
+        # Determine the number of ghost layers required by the spatial scheme
+        n_ghost_layers: int = self.inviscid_face_extrapolator.minimum_ghost_layers
+        if self.include_diffusion:
+            n_ghost_layers = max(
+                n_ghost_layers, self.viscous_face_extrapolator.minimum_ghost_layers
+            )
+
         # Initialize the geometry of the domain
         if geometry is None:
             kwargs.pop("xf")
-            self.geometry: Geometry = initialize_geometry(xf=self.xf, **kwargs)
+            self.geometry: Geometry = initialize_geometry(
+                xf=self.xf, n_ghost_layers=n_ghost_layers, **kwargs
+            )
         else:
             self.geometry = geometry
+            self.geometry.setup_ghost_layers(n_ghost_layers=n_ghost_layers)
 
         # Add area-change related source terms
         if self.geometry.dlnA_dt is not None or self.geometry.dlnA_dx is not None:
@@ -107,16 +118,9 @@ class Combustor:
             msg = "JIC injector model requires FPVTable physics."
             raise Exception(msg)
 
-        # Determine the number of ghost layers required by the spatial scheme
-        self.n_ghost_layers: int = self.inviscid_face_extrapolator.minimum_ghost_layers
-        if self.include_diffusion:
-            self.n_ghost_layers = max(
-                self.n_ghost_layers, self.viscous_face_extrapolator.minimum_ghost_layers
-            )
-
         # Set up boundary conditions
         self.boundary_conditions: BoundaryConditions = set_boundary_conditions(
-            self.boundary_conditions, self.n_ghost_layers
+            self.boundary_conditions, self.geometry.n_ghost_layers
         )
 
         # initialize the state
@@ -140,7 +144,7 @@ class Combustor:
         self.inviscid_flux = InviscidFlux(
             face_extrapolator=self.inviscid_face_extrapolator(
                 n_scalars_rho_sum=self.physics.n_scalars_rho_sum,
-                n_ghost_layers=self.n_ghost_layers,
+                n_ghost_layers=self.geometry.n_ghost_layers,
             ),
             boundary_conditions=self.boundary_conditions,
             riemann_solver=self.flux_function,
@@ -152,10 +156,10 @@ class Combustor:
                 boundary_conditions=self.boundary_conditions,
                 face_extrapolator=self.viscous_face_extrapolator(
                     n_scalars_rho_sum=self.physics.n_scalars_rho_sum,
-                    n_ghost_layers=self.n_ghost_layers,
+                    n_ghost_layers=self.geometry.n_ghost_layers,
                 ),
                 geometry=self.geometry,
-                gradient=CentralDifference(n_ghost_layers=self.n_ghost_layers),
+                gradient=CentralDifference(n_ghost_layers=self.geometry.n_ghost_layers),
             )
 
         if self.include_boundary_layer:
@@ -166,10 +170,7 @@ class Combustor:
                 skin_friction_coefficient=self.skin_friction_coefficient,
             )
 
-        # Extend the domain to include the ghost layers
-        self.state = self.inviscid_flux.face_extrapolator.add_ghost_layers(self.state)
-        self.idx_cells: Index = np.s_[self.n_ghost_layers : -self.n_ghost_layers]
-        self.F = np.pad(self.F, self.n_ghost_layers, mode="edge")
+        self.F = np.ones(self.geometry.n_cells)  # thickening
 
     def get_wave_speed(self):
         """
@@ -209,27 +210,24 @@ class Combustor:
             inputs
                 dt=time step
         """
+        idx = self.geometry.idx_cells
         y = self.physics.primitive_to_conservative(self.state)
         gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
 
         # 1st stage of RK3
         dydt = self.inviscid_flux.source(self.t, y, self.physics, gamma_star, e0_star)
         y1 = y.copy()
-        y1[self.idx_cells] += dt * dydt
+        y1[idx] += dt * dydt
 
         # 2nd stage of RK3
         dydt = self.inviscid_flux.source(self.t, y1, self.physics, gamma_star, e0_star)
         y2 = 0.75 * y + 0.25 * y1
-        y2[self.idx_cells] += 0.25 * dt * dydt
+        y2[idx] += 0.25 * dt * dydt
 
         # 3rd stage of RK3
         dydt = self.inviscid_flux.source(self.t, y2, self.physics, gamma_star, e0_star)
 
-        y[self.idx_cells] = (
-            (1.0 / 3.0) * y[self.idx_cells]
-            + (2.0 / 3.0) * y2[self.idx_cells]
-            + (2.0 / 3.0) * dt * dydt
-        )
+        y[idx] = (1.0 / 3.0) * y[idx] + (2.0 / 3.0) * y2[idx] + (2.0 / 3.0) * dt * dydt
 
         # Remove ghost layers and update gamma
         self.state = self.physics.conservative_to_primitive(y, gamma_star, e0_star)
@@ -240,7 +238,7 @@ class Combustor:
             inputs
                 dt=time step
         """
-        mt: int = self.n_ghost_layers
+        idx = self.geometry.idx_cells
         y = self.physics.primitive_to_conservative(self.state)
         gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
 
@@ -248,16 +246,18 @@ class Combustor:
             self.F = self.thickening(self)
 
             # No gradient in F at boundary
-            self.viscous_flux.F = np.pad(self.F, mt, mode="edge")
+            self.viscous_flux.F = np.pad(
+                self.F, self.geometry.n_ghost_layers, mode="edge"
+            )
 
         # 1st stage of RK2
         dydt = self.viscous_flux.source(self.t, y, self.physics, gamma_star, e0_star)
         y1 = y.copy()
-        y1[self.idx_cells] += dt * dydt
+        y1[idx] += dt * dydt
 
         # 2nd stage of RK2
         dydt = self.viscous_flux.source(self.t, y1, self.physics, gamma_star, e0_star)
-        y[self.idx_cells] = 0.5 * (y[self.idx_cells] + y1[self.idx_cells] + dt * dydt)
+        y[idx] = 0.5 * (y[idx] + y1[idx] + dt * dydt)
 
         # Remove ghost layers and update gamma
         self.state = self.physics.conservative_to_primitive(y, gamma_star, e0_star)
@@ -285,31 +285,30 @@ class Combustor:
                 dt=time step
         """
         # initialize
+        idx = self.geometry.idx_cells
         y = self.physics.primitive_to_conservative(self.state)
         gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
 
         # 1st stage of RK2
         omegaC = self.injector.get_chemical_sources(
             self.t,
-            y[self.idx_cells],
+            y[idx],
             self.physics,
-            gamma_star[self.idx_cells],
-            e0_star[self.idx_cells],
+            gamma_star[idx],
+            e0_star[idx],
         )
         y1 = y.copy()
-        y1[self.idx_cells, 4] += dt * omegaC
+        y1[idx, 4] += dt * omegaC
 
         # 2nd stage of RK2
         omegaC1 = self.injector.get_chemical_sources(
             self.t + dt,
-            y1[self.idx_cells],
+            y1[idx],
             self.physics,
-            gamma_star[self.idx_cells],
-            e0_star[self.idx_cells],
+            gamma_star[idx],
+            e0_star[idx],
         )
-        y[self.idx_cells, 4] = 0.5 * (
-            y[self.idx_cells, 4] + y1[self.idx_cells, 4] + dt * omegaC1
-        )
+        y[idx, 4] = 0.5 * (y[idx, 4] + y1[idx, 4] + dt * omegaC1)
 
         # update properties
         self.state = self.physics.conservative_to_primitive(y, gamma_star, e0_star)
@@ -358,11 +357,7 @@ class Combustor:
         from scipy import integrate
 
         # get indices
-        indices = [
-            k + self.n_ghost_layers
-            for k in range(self.n)
-            if self.in_reacting_region(self.geometry.xc[k], self.t)
-        ]
+        indices = np.where(self.in_reacting_region(self.t, self.geometry.xc))[0]
         state_temp = FluidState(
             shape=(len(indices),),
             density=self.state.density[indices].copy(),
@@ -405,20 +400,14 @@ class Combustor:
         the shock tube. The client must supply the functions dlnA_dt and dlnA_dx
         to the Combustor object.
         """
+        idx = self.geometry.idx_cells
         y = self.physics.primitive_to_conservative(self.state)
         gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
 
-        dydt = self.area_change.source(
-            self.t,
-            y[self.idx_cells],
-            self.physics,
-            gamma_star[self.idx_cells],
-            e0_star[self.idx_cells],
-            dt,
-        )
+        dydt = self.area_change.source(self.t, y, self.physics, gamma_star, e0_star, dt)
 
         # Update
-        y[self.idx_cells] += dt * dydt
+        y[idx] += dt * dydt
         self.state = self.physics.conservative_to_primitive(y, gamma_star, e0_star)
 
     def advance_boundary_layer(self, dt):
@@ -427,19 +416,20 @@ class Combustor:
             inputs
                 dt=time step
         """
+        idx = self.geometry.idx_cells
         y = self.physics.primitive_to_conservative(self.state)
         gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
 
         dydt = self.boundary_layer.source(
             self.t,
-            y[self.idx_cells],
+            y[idx],
             self.physics,
-            gamma_star[self.idx_cells],
-            e0_star[self.idx_cells],
+            gamma_star[idx],
+            e0_star[idx],
         )
 
         # Update
-        y[self.idx_cells] += dydt * dt
+        y[idx] += dydt * dt
         self.state = self.physics.conservative_to_primitive(y, gamma_star, e0_star)
 
     def advance_source_terms(self, dt):
@@ -449,18 +439,19 @@ class Combustor:
                 dt=time step
         """
         # initialize
+        idx = self.geometry.idx_cells
         y = self.physics.primitive_to_conservative(self.state)
         gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
 
         # 1st stage of RK2
         dydt = self.source_terms.source(
             self.t,
-            y[self.idx_cells],
+            y[idx],
             self.physics,
-            gamma_star[self.idx_cells],
-            e0_star[self.idx_cells],
+            gamma_star[idx],
+            e0_star[idx],
         )
-        y1 = y[self.idx_cells] + dt * dydt
+        y1 = y[idx] + dt * dydt
         # state1 = self.physics.conservative_to_primitive(y1, gamma_star, e0_Star)
 
         # 2nd stage of RK2
@@ -468,11 +459,11 @@ class Combustor:
             self.t + dt,
             y1,
             self.physics,
-            gamma_star[self.idx_cells],
-            e0_star[self.idx_cells],
+            gamma_star[idx],
+            e0_star[idx],
         )
 
-        y[self.idx_cells] = 0.5 * (y[self.idx_cells] + y1 + dt * dydt)
+        y[idx] = 0.5 * (y[idx] + y1 + dt * dydt)
         self.state = self.physics.conservative_to_primitive(y, gamma_star, e0_star)
 
     def advance_injector(self, dt):
@@ -487,32 +478,31 @@ class Combustor:
             raise Exception(msg)
 
         # initialize
+        idx = self.geometry.idx_cells
         y = self.physics.primitive_to_conservative(self.state)
         gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
 
-        self.injector.update_fluid_tip_positions(
-            dt, self.t, self.state.velocity[self.idx_cells]
-        )
+        self.injector.update_fluid_tip_positions(dt, self.t, self.state.velocity[idx])
 
         # 1st stage of RK2
         dydt = self.injector.source(
             self.t,
-            y[self.idx_cells],
+            y[idx],
             self.physics,
-            gamma_star[self.idx_cells],
-            e0_star[self.idx_cells],
+            gamma_star[idx],
+            e0_star[idx],
         )
-        y1 = y[self.idx_cells] + dt * dydt
+        y1 = y[idx] + dt * dydt
 
         # 2nd stage of RK2
         dydt = self.injector.source(
             self.t + dt,
             y1,
             self.physics,
-            gamma_star[self.idx_cells],
-            e0_star[self.idx_cells],
+            gamma_star[idx],
+            e0_star[idx],
         )
-        y[self.idx_cells] = 0.5 * (y[self.idx_cells] + y1 + dt * dydt)
+        y[idx] = 0.5 * (y[idx] + y1 + dt * dydt)
 
         # update
         self.state = self.physics.conservative_to_primitive(y, gamma_star, e0_star)

--- a/src/stanshock/components/shocktube.py
+++ b/src/stanshock/components/shocktube.py
@@ -137,11 +137,11 @@ class ShockTube(Combustor):
             )  # assume temporally constant area
 
         # Determine geometry from pressure
-        dpAbs = np.abs(pInitial[1:] - pInitial[:-1])
-        xShock = max(zip(dpAbs, geometry.x[1:], strict=False))[
-            1
+        dpAbs = np.abs(np.diff(pInitial))
+        xShock = geometry.xf[
+            np.argmax(dpAbs) + 1
         ]  # maximum pressure gradient corresponds to shock
-        (xMin, xMax, probeLocation) = (geometry.x[0], xShock, geometry.x[-1])
+        (xMin, xMax, probeLocation) = (geometry.xc[0], xShock, geometry.xc[-1])
         LMax = xMax - xMin  # maximum length of constrained optimization
         DMax = min(
             geometry.d_outer(0.0, np.linspace(xMin, xMax))

--- a/src/stanshock/components/shocktube.py
+++ b/src/stanshock/components/shocktube.py
@@ -124,11 +124,12 @@ class ShockTube(Combustor):
             )
             p5 = p5op1 * self.state.pressure[-1]
         # Get initial state for reinitialization
-        rInitial = np.copy(self.state.density[self.idx_cells])
-        uInitial = np.copy(self.state.velocity[self.idx_cells])
-        pInitial = np.copy(self.state.pressure[self.idx_cells])
-        YInitial = np.copy(self.state.composition[self.idx_cells])
-        gammaInitial = np.copy(self.state.gamma[self.idx_cells])
+        idx = self.geometry.idx_cells
+        rInitial = np.copy(self.state.density[idx])
+        uInitial = np.copy(self.state.velocity[idx])
+        pInitial = np.copy(self.state.pressure[idx])
+        YInitial = np.copy(self.state.composition[idx])
+        gammaInitial = np.copy(self.state.gamma[idx])
         dlnA_dx_initial = geometry.dlnA_dx
 
         def dd_outerdx(time: float, x: Array) -> Array:
@@ -141,7 +142,7 @@ class ShockTube(Combustor):
         xShock = geometry.xf[
             np.argmax(dpAbs) + 1
         ]  # maximum pressure gradient corresponds to shock
-        (xMin, xMax, probeLocation) = (geometry.xc[0], xShock, geometry.xc[-1])
+        (xMin, xMax, probeLocation) = (geometry.xf[0], xShock, geometry.xf[-1])
         LMax = xMax - xMin  # maximum length of constrained optimization
         DMax = min(
             geometry.d_outer(0.0, np.linspace(xMin, xMax))
@@ -223,7 +224,7 @@ class ShockTube(Combustor):
             geometry.dlnA_dx = lambda t, x: dA_dx(t, x) / A(t, x)
             geometry.d_inner = d_inner
             self.state = FluidState(
-                shape=(geometry.n,),
+                shape=(geometry.n_cells_interior,),
                 density=np.copy(rInitial),
                 velocity=np.copy(uInitial),
                 pressure=np.copy(pInitial),

--- a/src/stanshock/models/area_change.py
+++ b/src/stanshock/models/area_change.py
@@ -48,7 +48,7 @@ class AreaChange(RightHandSide):
         state0_compact[:, 3] = state.pressure
 
         # Divide domain between explicit and implicit source terms
-        idx_explicit: Index = np.arange(self.geometry.x.shape[0], dtype=np.int64)
+        idx_explicit: Index = np.arange(self.geometry.xc.shape[0], dtype=np.int64)
         assert isinstance(idx_explicit, np.ndarray)
         idx_implicit: Index = np.array([], dtype=np.int64)
         assert isinstance(idx_implicit, np.ndarray)
@@ -57,7 +57,7 @@ class AreaChange(RightHandSide):
         )
 
         if self.geometry.dlnA_dt is not None:
-            dlnA_dt: Array | float = self.geometry.dlnA_dt(time, self.geometry.x)
+            dlnA_dt: Array | float = self.geometry.dlnA_dt(time, self.geometry.xc)
             assert isinstance(dlnA_dt, np.ndarray)
             idx_implicit = np.where(dlnA_dt != 0.0)[0]
             idx_explicit = np.where(dlnA_dt == 0.0)[0]
@@ -67,7 +67,7 @@ class AreaChange(RightHandSide):
                 # Initialize
                 y0: Array = state0_compact[idx_implicit, :].copy()
                 args: tuple[Array, Array] = (
-                    self.geometry.x[idx_implicit],
+                    self.geometry.xc[idx_implicit],
                     gamma_star[idx_implicit],
                 )
                 self.integrator.set_initial_value(y=y0, t=time)
@@ -103,7 +103,7 @@ class AreaChange(RightHandSide):
     ) -> Array:
         """Area change contributions to RHS."""
         rhs_compact: Array = np.zeros_like(state0_compact[idx])
-        x: Array = self.geometry.x[idx]
+        x: Array = self.geometry.xc[idx]
 
         if self.geometry.dlnA_dt is not None:
             dlnA_dt: Array | float = self.geometry.dlnA_dt(time, x)

--- a/src/stanshock/models/area_change.py
+++ b/src/stanshock/models/area_change.py
@@ -18,7 +18,7 @@ class AreaChange(RightHandSide):
         ).set_integrator("lsoda", lband=0, uband=0)
 
         # Define global indices
-        self.idx_locations = np.s_[:]
+        self.idx_locations = self.geometry.idx_cells
         self.idx_source_terms = np.s_[:]
 
         # For geometries with no area change, replace the source term with a no-op
@@ -38,26 +38,28 @@ class AreaChange(RightHandSide):
         if self.no_area_change:
             return np.zeros((1,))
 
-        state = physics.conservative_to_primitive(state_array, gamma_star, e0_star)
+        idx = self.idx_locations
+        xc = self.geometry.xc[idx]
+        state = physics.conservative_to_primitive(
+            state_array[idx], gamma_star[idx], e0_star[idx]
+        )
         Y0 = state.composition
 
-        state0_compact = np.zeros((state_array.shape[0], 4))
+        state0_compact = np.zeros((state_array[idx].shape[0], 4))
         state0_compact[:, 0] = state.density
-        state0_compact[:, 1] = state_array[:, 0]
-        state0_compact[:, 2] = state_array[:, 1]
+        state0_compact[:, 1] = state_array[idx, 0]
+        state0_compact[:, 2] = state_array[idx, 1]
         state0_compact[:, 3] = state.pressure
 
         # Divide domain between explicit and implicit source terms
-        idx_explicit: Index = np.arange(self.geometry.xc.shape[0], dtype=np.int64)
+        idx_explicit: Index = np.arange(self.geometry.n_cells_interior, dtype=np.int64)
         assert isinstance(idx_explicit, np.ndarray)
         idx_implicit: Index = np.array([], dtype=np.int64)
         assert isinstance(idx_implicit, np.ndarray)
-        rhs: Array = np.zeros_like(
-            state_array[self.idx_locations, self.idx_source_terms]
-        )
+        rhs: Array = np.zeros_like(state_array[idx, self.idx_source_terms])
 
         if self.geometry.dlnA_dt is not None:
-            dlnA_dt: Array | float = self.geometry.dlnA_dt(time, self.geometry.xc)
+            dlnA_dt: Array | float = self.geometry.dlnA_dt(time, xc)
             assert isinstance(dlnA_dt, np.ndarray)
             idx_implicit = np.where(dlnA_dt != 0.0)[0]
             idx_explicit = np.where(dlnA_dt == 0.0)[0]
@@ -67,8 +69,8 @@ class AreaChange(RightHandSide):
                 # Initialize
                 y0: Array = state0_compact[idx_implicit, :].copy()
                 args: tuple[Array, Array] = (
-                    self.geometry.xc[idx_implicit],
-                    gamma_star[idx_implicit],
+                    xc[idx_implicit],
+                    gamma_star[idx][idx_implicit],
                 )
                 self.integrator.set_initial_value(y=y0, t=time)
                 self.integrator.set_f_params(args)
@@ -85,9 +87,6 @@ class AreaChange(RightHandSide):
                 )  # rY sources
 
         # Add slow source terms
-        state: FluidState = physics.conservative_to_primitive(
-            state_array, gamma_star=gamma_star, e0_star=e0_star
-        )
         rhs_compact = self.source_slow(
             time=time, state0_compact=state0_compact, state=state, idx=idx_explicit
         )
@@ -103,7 +102,7 @@ class AreaChange(RightHandSide):
     ) -> Array:
         """Area change contributions to RHS."""
         rhs_compact: Array = np.zeros_like(state0_compact[idx])
-        x: Array = self.geometry.xc[idx]
+        x: Array = self.geometry.xc[self.geometry.idx_cells][idx]
 
         if self.geometry.dlnA_dt is not None:
             dlnA_dt: Array | float = self.geometry.dlnA_dt(time, x)

--- a/src/stanshock/numerics/boundary_conditions.py
+++ b/src/stanshock/numerics/boundary_conditions.py
@@ -31,6 +31,14 @@ class SpecifiedFlux(BoundaryCondition[Array]):
     """Directly set the flux through the boundary face."""
 
 
+class FreezeCells(GhostCell):
+    """Hold ghost cells constant (do nothing)."""
+
+    def update(self, time: float, target: Array) -> Array:
+        _: float = time
+        return target
+
+
 class PadCells(GhostCell):
     """Extrapolates constant values from the last interior cell into the ghost layers."""
 
@@ -90,7 +98,7 @@ class Symmetry(GhostCell):
     def update(self, time: float, target: Array) -> Array:
         _: float = time
         target[self.idx_exterior] = target[self.idx_interior]
-        target[self.idx_exterior][1] = -target[self.idx_interior][1]
+        target[self.idx_exterior][:, 0] = -target[self.idx_interior][:, 0]
 
         return target
 
@@ -249,6 +257,12 @@ def set_boundary_conditions(
 ) -> BoundaryConditions:
     """Convenience function to initialize different boundary conditions."""
 
+    # If ghost layer method not specified, default to freezing (hold constant)
+    default_ghost_layers: dict[str, GhostCell] = {
+        "left": FreezeCells(location="left"),
+        "right": FreezeCells(location="right"),
+    }
+
     # Convert lists into BoundaryConditions:
     if not isinstance(boundary_conditions, BoundaryConditions):
         bc_locs: list[Literal["left", "right"]] = ["left", "right"]
@@ -259,10 +273,12 @@ def set_boundary_conditions(
                 if bc_specification == "periodic":
                     bcs += [Periodic(mt, location=bc_loc)]
                 elif bc_specification == "outflow":
+                    default_ghost_layers[bc_loc] = PadCells(mt, location=bc_loc)
                     bcs += [Extrapolate(location=bc_loc)]
                 elif bc_specification in ["symmetry"]:
                     bcs += [Symmetry(mt, location=bc_loc)]
                 elif bc_specification in ["reflecting", "wall"]:
+                    default_ghost_layers[bc_loc] = Symmetry(mt, location=bc_loc)
                     bcs += [AdiabaticWall(location=bc_loc)]
             elif isinstance(bc_specification, BoundaryCondition):
                 bcs += [bc_specification]
@@ -271,11 +287,7 @@ def set_boundary_conditions(
 
         boundary_conditions = BoundaryConditions(boundary_conditions=bcs)
 
-    # If ghost layer method not specified, default to simple padding
-    default_ghost_layers: dict[str, GhostCell] = {
-        "left": PadCells(mt, location="left"),
-        "right": PadCells(mt, location="right"),
-    }
+    # Don't use default GhostCell treatments if already specified
     for bc in boundary_conditions._boundary_conditions:
         if isinstance(bc, Periodic):
             default_ghost_layers = {}

--- a/src/stanshock/processing/initialize.py
+++ b/src/stanshock/processing/initialize.py
@@ -115,7 +115,7 @@ def initialize_riemann_problem(
     # Override with right state
     state_right = initialize_constant(geometry, physics, right_gas, u_right)
 
-    index = np.where(geometry.x >= shock_location)[0]
+    index = np.where(geometry.xc >= shock_location)[0]
     state.density[index] = state_right.density[index]
     state.velocity[index] = state_right.velocity[index]
     state.pressure[index] = state_right.pressure[index]
@@ -162,22 +162,26 @@ def initialize_diffuse_interface(
 
     # Smooth transition between left and right states
     r = smoothing_function(
-        geometry.x, shock_location, delta_smoothing, left_gas.density, right_gas.density
+        geometry.xc,
+        shock_location,
+        delta_smoothing,
+        left_gas.density,
+        right_gas.density,
     )
     geometry.u = smoothing_function(
-        geometry.x, shock_location, delta_smoothing, u_left, u_right
+        geometry.xc, shock_location, delta_smoothing, u_left, u_right
     )
     p = smoothing_function(
-        geometry.x, shock_location, delta_smoothing, left_gas.P, right_gas.P
+        geometry.xc, shock_location, delta_smoothing, left_gas.P, right_gas.P
     )
     gamma = smoothing_function(
-        geometry.x, shock_location, delta_smoothing, gamma_left, gamma_right
+        geometry.xc, shock_location, delta_smoothing, gamma_left, gamma_right
     )
 
     composition = np.zeros((geometry.n, geometry.n_scalars))
     for kSp in range(geometry.n_scalars):
         composition[:, kSp] = smoothing_function(
-            geometry.x,
+            geometry.xc,
             shock_location,
             delta_smoothing,
             composition_left[:, kSp],

--- a/src/stanshock/processing/initialize.py
+++ b/src/stanshock/processing/initialize.py
@@ -65,7 +65,7 @@ def initialize_constant(
             gas = Cantera solution object at the desired thermodynamic state
             u = velocity
     """
-    n = geometry.n
+    n = geometry.n_cells
     ones = np.ones(n)
 
     # Initialize state
@@ -178,7 +178,7 @@ def initialize_diffuse_interface(
         geometry.xc, shock_location, delta_smoothing, gamma_left, gamma_right
     )
 
-    composition = np.zeros((geometry.n, geometry.n_scalars))
+    composition = np.zeros((geometry.n_cells, geometry.n_scalars))
     for kSp in range(geometry.n_scalars):
         composition[:, kSp] = smoothing_function(
             geometry.xc,
@@ -189,7 +189,7 @@ def initialize_diffuse_interface(
         )
 
     return FluidState(
-        shape=(geometry.n,),
+        shape=(geometry.n_cells,),
         density=r,
         pressure=p,
         gamma=gamma,

--- a/src/stanshock/processing/plot.py
+++ b/src/stanshock/processing/plot.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
+
+    from stanshock.components.combustor import Combustor
+    from stanshock.system.backend import Array
 
 
 class XTDiagram:
@@ -17,8 +25,14 @@ class XTDiagram:
             limits = tuple of maximum and minimum for the pcolor (vMin,vMax)
     """
 
-    def __init__(self, domain, variable, skipSteps=0, x=None, limits=None):
-        self.name = None
+    def __init__(
+        self,
+        domain: Combustor,
+        variable: str,
+        skipSteps: int = 0,
+        x: Array | None = None,
+        limits: tuple[float, float] | None = None,
+    ) -> None:
         self.skipSteps = 0
         self.limits = limits
 
@@ -27,20 +41,20 @@ class XTDiagram:
         # check interpolation grid
         geometry = domain.geometry
         if x is None:
-            self.x = geometry.x
-        elif (x[-1] > geometry.x[-1]) or (x[0] < geometry.x[0]):
+            self.xc = geometry.xc
+        elif (x[-1] > geometry.xc[-1]) or (x[0] < geometry.xc[0]):
             msg = "Invalid Interpolation Grid"
             raise Exception(msg)
         else:
-            self.x = x
+            self.xc = x
 
-        self.variable = []  # list of numpy arrays of the variable w.r.t x
-        self.t = []  # list of times
-        self.mdot = []  # list of mass flow rates
+        self.variable: list[Array] = []  # list of numpy arrays of the variable w.r.t x
+        self.t: list[float] = []  # list of times
+        self.mdot: list[float] = []  # list of mass flow rates
 
         self.update(domain)
 
-    def update(self, domain):
+    def update(self, domain: Combustor) -> None:
         """
         This method updates the XT diagram.
             inputs:
@@ -53,29 +67,33 @@ class XTDiagram:
 
         if variable in ["density", "r", "rho"]:
             self.variable.append(
-                np.interp(self.x, geometry.x, state.density[idx_cells])
+                np.interp(self.xc, geometry.xc, state.density[idx_cells])
             )
         elif variable in ["velocity", "u"]:
             self.variable.append(
-                np.interp(self.x, geometry.x, state.velocity[idx_cells])
+                np.interp(self.xc, geometry.xc, state.velocity[idx_cells])
             )
         elif variable in ["pressure", "p"]:
             self.variable.append(
-                np.interp(self.x, geometry.x, state.pressure[idx_cells])
+                np.interp(self.xc, geometry.xc, state.pressure[idx_cells])
             )
         elif variable in ["temperature", "t"]:
             T = domain.physics.get_temperature(state)
-            self.variable.append(np.interp(self.x, geometry.x, T[idx_cells]))
+            self.variable.append(np.interp(self.xc, geometry.xc, T[idx_cells]))
         elif variable in ["gamma", "g", "specific heat ratio", "heat capacity ratio"]:
-            self.variable.append(np.interp(self.x, geometry.x, state.gamma[idx_cells]))
+            self.variable.append(
+                np.interp(self.xc, geometry.xc, state.gamma[idx_cells])
+            )
         elif variable in domain.physics.scalar_names:
             scalarIndex = domain.physics.scalar_names.index(variable)
             self.variable.append(
-                np.interp(self.x, geometry.x, state.composition[idx_cells, scalarIndex])
+                np.interp(
+                    self.xc, geometry.xc, state.composition[idx_cells, scalarIndex]
+                )
             )
         elif variable in ["mach", "m"]:
             M = np.abs(state.velocity) / domain.physics.get_sound_speed(state)
-            self.variable.append(np.interp(self.x, self.x, M[idx_cells]))
+            self.variable.append(np.interp(self.xc, geometry.xc, M[idx_cells]))
         else:
             msg = f"Invalid Variable Name: {variable}"
             raise Exception(msg)
@@ -83,7 +101,7 @@ class XTDiagram:
         if domain.injector is not None:
             self.mdot.append(domain.injector.mdot_f_interp(domain.t))
 
-    def plot(self, figdir="."):
+    def plot(self, figdir: Path | str = ".") -> None:
         """
         This method creates a contour plot of the XTDiagram data
             inputs:
@@ -91,7 +109,7 @@ class XTDiagram:
         """
         t = [t * 1000.0 for t in self.t]
         mdot = [mdot * 1.0e3 for mdot in self.mdot]
-        X, T = np.meshgrid(self.x, t)
+        X, T = np.meshgrid(self.xc, t)
         variableMatrix = np.zeros(X.shape)
         for k, variablek in enumerate(self.variable):
             variableMatrix[k, :] = variablek
@@ -119,7 +137,7 @@ class XTDiagram:
         has_mdot = mdot and any(mdot)
         figsize = (6, 4) if has_mdot else (6, 3)
 
-        fig = plt.figure(figsize=figsize)
+        fig: Figure = plt.figure(figsize=figsize)
         if has_mdot:
             gs = fig.add_gridspec(1, 3, width_ratios=[6, 1, 0.5], wspace=0.125)
             main_ax = fig.add_subplot(gs[0, 0])
@@ -144,7 +162,7 @@ class XTDiagram:
 
         main_ax.set_xlabel(r"$x~[\mathrm{m}]$")
         main_ax.set_ylabel(r"$t~[\mathrm{ms}]$")
-        main_ax.set_xlim(min(self.x), max(self.x))
+        main_ax.set_xlim(min(self.xc), max(self.xc))
         main_ax.set_ylim(min(t), max(t))
 
         if has_mdot:
@@ -158,18 +176,18 @@ class XTDiagram:
             mdot_ax.set_yticklabels([])
             mdot_ax.grid(True, axis="x", linestyle="--", alpha=0.7)
 
-        plt.tight_layout()
-        plt.savefig(Path(figdir) / f"{variable}.png", bbox_inches="tight", dpi=300)
+        fig.tight_layout()
+        fig.savefig(Path(figdir) / f"{variable}.png", bbox_inches="tight", dpi=300)
 
 
-def add_h_plot(domain, ax, scale=1.0):
+def add_h_plot(domain: Combustor, ax: Axes, scale: float = 1.0) -> Axes:
     ax1 = ax.twinx()
     ax1.set_zorder(-np.inf)
     ax.patch.set_visible(False)
 
     geometry = domain.geometry
     t = domain.t
-    x = geometry.x
+    x = geometry.xf
     h = geometry.h(t, x) if geometry.h is not None else geometry.d_outer(t, x)
     ax1.plot(x * scale, h * scale, color="0.8", linestyle="--")
     ax1.axhline(0, color="0.8", linestyle="--")
@@ -178,7 +196,7 @@ def add_h_plot(domain, ax, scale=1.0):
     return ax1
 
 
-def plot_state(domain, filename):
+def plot_state(domain: Combustor, filename: Path | str) -> None:
     xscale = 1.0e3
     physics = domain.physics
     state = domain.state
@@ -186,33 +204,35 @@ def plot_state(domain, filename):
     idx_cells = domain.idx_cells
     T = physics.get_temperature(state)
 
+    fig: Figure
+    ax: list[Axes]
     fig, ax = plt.subplots(7, 1, sharex=True, figsize=(6, 9))
-    ax[0].plot(geometry.x * xscale, state.density[idx_cells])
+    ax[0].plot(geometry.xc * xscale, state.density[idx_cells])
     ax[0].set_ymargin(0.1)
     ax[0].set_ylabel(r"$\rho$ [kg/m$^3$]")
     if geometry.h is not None:
         add_h_plot(domain, ax[0], scale=xscale)
 
-    ax[1].plot(geometry.x * xscale, state.velocity[idx_cells])
+    ax[1].plot(geometry.xc * xscale, state.velocity[idx_cells])
     ax[1].set_ymargin(0.1)
     ax[1].set_ylabel(r"$u$ [m/s]")
     if geometry.h is not None:
         add_h_plot(domain, ax[1], scale=xscale)
 
-    ax[2].plot(geometry.x * xscale, state.pressure[idx_cells])
+    ax[2].plot(geometry.xc * xscale, state.pressure[idx_cells])
     ax[2].set_ymargin(0.1)
     ax[2].set_ylabel(r"$p$ [Pa]")
     if geometry.h is not None:
         add_h_plot(domain, ax[2], scale=xscale)
 
-    ax[3].plot(geometry.x * xscale, T[idx_cells])
+    ax[3].plot(geometry.xc * xscale, T[idx_cells])
     ax[3].set_ymargin(0.1)
     ax[3].set_ylabel(r"$T$ [K]")
     if geometry.h is not None:
         add_h_plot(domain, ax[3], scale=xscale)
 
     M = np.abs(state.velocity) / physics.get_sound_speed(state)
-    ax[4].plot(geometry.x * xscale, M[idx_cells])
+    ax[4].plot(geometry.xc * xscale, M[idx_cells])
     ax[4].axhline(1.0, color="r", linestyle="--")
     ax[4].set_ymargin(0.1)
     ax[4].set_ylabel(r"$M$ [-]")
@@ -229,9 +249,9 @@ def plot_state(domain, filename):
         Y_H2 = Y[:, physics.gas.species_index("H2")]
         Y_OH = Y[:, physics.gas.species_index("OH")]
         Y_H2O = Y[:, physics.gas.species_index("H2O")]
-    ax[5].plot(geometry.x * xscale, Y_H2, label=r"$\mathrm{H}_2$")
-    ax[5].plot(geometry.x * xscale, Y_OH, label=r"$\mathrm{OH}$")
-    ax[5].plot(geometry.x * xscale, Y_H2O, label=r"$\mathrm{H}_2\mathrm{O}$")
+    ax[5].plot(geometry.xc * xscale, Y_H2, label=r"$\mathrm{H}_2$")
+    ax[5].plot(geometry.xc * xscale, Y_OH, label=r"$\mathrm{OH}$")
+    ax[5].plot(geometry.xc * xscale, Y_H2O, label=r"$\mathrm{H}_2\mathrm{O}$")
     if Y_H2.max() < 1e-6:
         ax[5].set_ylim(-1e-3, 1e-3)
     else:
@@ -255,6 +275,6 @@ def plot_state(domain, filename):
 
     fig.suptitle(rf"$t = {domain.t * 1.0e3:.4f}$ ms")
 
-    plt.tight_layout()
-    plt.savefig(filename, bbox_inches="tight", dpi=300)
+    fig.tight_layout()
+    fig.savefig(filename, bbox_inches="tight", dpi=300)
     plt.close()

--- a/src/stanshock/processing/plot.py
+++ b/src/stanshock/processing/plot.py
@@ -41,12 +41,12 @@ class XTDiagram:
         # check interpolation grid
         geometry = domain.geometry
         if x is None:
-            self.xc = geometry.xc
+            self.x = geometry.xf
         elif (x[-1] > geometry.xc[-1]) or (x[0] < geometry.xc[0]):
             msg = "Invalid Interpolation Grid"
             raise Exception(msg)
         else:
-            self.xc = x
+            self.x = x
 
         self.variable: list[Array] = []  # list of numpy arrays of the variable w.r.t x
         self.t: list[float] = []  # list of times
@@ -63,37 +63,26 @@ class XTDiagram:
         variable = self.name
         state = domain.state
         geometry = domain.geometry
-        idx_cells = domain.idx_cells
 
         if variable in ["density", "r", "rho"]:
-            self.variable.append(
-                np.interp(self.xc, geometry.xc, state.density[idx_cells])
-            )
+            self.variable.append(np.interp(self.x, geometry.xc, state.density))
         elif variable in ["velocity", "u"]:
-            self.variable.append(
-                np.interp(self.xc, geometry.xc, state.velocity[idx_cells])
-            )
+            self.variable.append(np.interp(self.x, geometry.xc, state.velocity))
         elif variable in ["pressure", "p"]:
-            self.variable.append(
-                np.interp(self.xc, geometry.xc, state.pressure[idx_cells])
-            )
+            self.variable.append(np.interp(self.x, geometry.xc, state.pressure))
         elif variable in ["temperature", "t"]:
             T = domain.physics.get_temperature(state)
-            self.variable.append(np.interp(self.xc, geometry.xc, T[idx_cells]))
+            self.variable.append(np.interp(self.x, geometry.xc, T))
         elif variable in ["gamma", "g", "specific heat ratio", "heat capacity ratio"]:
-            self.variable.append(
-                np.interp(self.xc, geometry.xc, state.gamma[idx_cells])
-            )
+            self.variable.append(np.interp(self.x, geometry.xc, state.gamma))
         elif variable in domain.physics.scalar_names:
             scalarIndex = domain.physics.scalar_names.index(variable)
             self.variable.append(
-                np.interp(
-                    self.xc, geometry.xc, state.composition[idx_cells, scalarIndex]
-                )
+                np.interp(self.x, geometry.xc, state.composition[:, scalarIndex])
             )
         elif variable in ["mach", "m"]:
             M = np.abs(state.velocity) / domain.physics.get_sound_speed(state)
-            self.variable.append(np.interp(self.xc, geometry.xc, M[idx_cells]))
+            self.variable.append(np.interp(self.x, geometry.xc, M))
         else:
             msg = f"Invalid Variable Name: {variable}"
             raise Exception(msg)
@@ -109,7 +98,7 @@ class XTDiagram:
         """
         t = [t * 1000.0 for t in self.t]
         mdot = [mdot * 1.0e3 for mdot in self.mdot]
-        X, T = np.meshgrid(self.xc, t)
+        X, T = np.meshgrid(self.x, t)
         variableMatrix = np.zeros(X.shape)
         for k, variablek in enumerate(self.variable):
             variableMatrix[k, :] = variablek
@@ -162,7 +151,7 @@ class XTDiagram:
 
         main_ax.set_xlabel(r"$x~[\mathrm{m}]$")
         main_ax.set_ylabel(r"$t~[\mathrm{ms}]$")
-        main_ax.set_xlim(min(self.xc), max(self.xc))
+        main_ax.set_xlim(min(self.x), max(self.x))
         main_ax.set_ylim(min(t), max(t))
 
         if has_mdot:
@@ -180,7 +169,7 @@ class XTDiagram:
         fig.savefig(Path(figdir) / f"{variable}.png", bbox_inches="tight", dpi=300)
 
 
-def add_h_plot(domain: Combustor, ax: Axes, scale: float = 1.0) -> Axes:
+def add_h_plot(domain: Combustor, ax: Axes, scale: float = 1.0e3) -> Axes:
     ax1 = ax.twinx()
     ax1.set_zorder(-np.inf)
     ax.patch.set_visible(False)
@@ -201,38 +190,39 @@ def plot_state(domain: Combustor, filename: Path | str) -> None:
     physics = domain.physics
     state = domain.state
     geometry = domain.geometry
-    idx_cells = domain.idx_cells
+    idx_cells = geometry.idx_cells
+    x = xscale * geometry.xc[idx_cells]
     T = physics.get_temperature(state)
 
     fig: Figure
     ax: list[Axes]
     fig, ax = plt.subplots(7, 1, sharex=True, figsize=(6, 9))
-    ax[0].plot(geometry.xc * xscale, state.density[idx_cells])
+    ax[0].plot(x, state.density[idx_cells])
     ax[0].set_ymargin(0.1)
     ax[0].set_ylabel(r"$\rho$ [kg/m$^3$]")
     if geometry.h is not None:
         add_h_plot(domain, ax[0], scale=xscale)
 
-    ax[1].plot(geometry.xc * xscale, state.velocity[idx_cells])
+    ax[1].plot(x, state.velocity[idx_cells])
     ax[1].set_ymargin(0.1)
     ax[1].set_ylabel(r"$u$ [m/s]")
     if geometry.h is not None:
         add_h_plot(domain, ax[1], scale=xscale)
 
-    ax[2].plot(geometry.xc * xscale, state.pressure[idx_cells])
+    ax[2].plot(x, state.pressure[idx_cells])
     ax[2].set_ymargin(0.1)
     ax[2].set_ylabel(r"$p$ [Pa]")
     if geometry.h is not None:
         add_h_plot(domain, ax[2], scale=xscale)
 
-    ax[3].plot(geometry.xc * xscale, T[idx_cells])
+    ax[3].plot(x, T[idx_cells])
     ax[3].set_ymargin(0.1)
     ax[3].set_ylabel(r"$T$ [K]")
     if geometry.h is not None:
         add_h_plot(domain, ax[3], scale=xscale)
 
     M = np.abs(state.velocity) / physics.get_sound_speed(state)
-    ax[4].plot(geometry.xc * xscale, M[idx_cells])
+    ax[4].plot(x, M[idx_cells])
     ax[4].axhline(1.0, color="r", linestyle="--")
     ax[4].set_ymargin(0.1)
     ax[4].set_ylabel(r"$M$ [-]")
@@ -249,9 +239,9 @@ def plot_state(domain: Combustor, filename: Path | str) -> None:
         Y_H2 = Y[:, physics.gas.species_index("H2")]
         Y_OH = Y[:, physics.gas.species_index("OH")]
         Y_H2O = Y[:, physics.gas.species_index("H2O")]
-    ax[5].plot(geometry.xc * xscale, Y_H2, label=r"$\mathrm{H}_2$")
-    ax[5].plot(geometry.xc * xscale, Y_OH, label=r"$\mathrm{OH}$")
-    ax[5].plot(geometry.xc * xscale, Y_H2O, label=r"$\mathrm{H}_2\mathrm{O}$")
+    ax[5].plot(x, Y_H2, label=r"$\mathrm{H}_2$")
+    ax[5].plot(x, Y_OH, label=r"$\mathrm{OH}$")
+    ax[5].plot(x, Y_H2O, label=r"$\mathrm{H}_2\mathrm{O}$")
     if Y_H2.max() < 1e-6:
         ax[5].set_ylim(-1e-3, 1e-3)
     else:

--- a/src/stanshock/processing/probe.py
+++ b/src/stanshock/processing/probe.py
@@ -41,26 +41,17 @@ class Probe:
     def update(self, domain):
         state = domain.state
         geometry = domain.geometry
-        idx_cells = domain.idx_cells
         self.t.append(domain.t)
-        self.r.append(
-            interpolate(geometry.xc, state.density[idx_cells], self.probeLocation)
-        )
-        self.u.append(
-            interpolate(geometry.xc, state.velocity[idx_cells], self.probeLocation)
-        )
-        self.p.append(
-            interpolate(geometry.xc, state.pressure[idx_cells], self.probeLocation)
-        )
-        self.gamma.append(
-            interpolate(geometry.xc, state.gamma[idx_cells], self.probeLocation)
-        )
+        self.r.append(interpolate(geometry.xc, state.density, self.probeLocation))
+        self.u.append(interpolate(geometry.xc, state.velocity, self.probeLocation))
+        self.p.append(interpolate(geometry.xc, state.pressure, self.probeLocation))
+        self.gamma.append(interpolate(geometry.xc, state.gamma, self.probeLocation))
         YProbe = np.array(
             [
                 (
                     interpolate(
                         geometry.xc,
-                        state.composition[idx_cells, kSp],
+                        state.composition[:, kSp],
                         self.probeLocation,
                     )
                 )

--- a/src/stanshock/processing/probe.py
+++ b/src/stanshock/processing/probe.py
@@ -22,7 +22,7 @@ class Probe:
     def __init__(self, domain, probeLocation, skipSteps=0, probeName=None):
         self.probeLocation = probeLocation
         geometry = domain.geometry
-        if probeLocation > np.max(geometry.x) or probeLocation < np.min(geometry.x):
+        if probeLocation > np.max(geometry.xf) or probeLocation < np.min(geometry.xf):
             msg = "Invalid Probe Location"
             raise Exception(msg)
 
@@ -44,22 +44,22 @@ class Probe:
         idx_cells = domain.idx_cells
         self.t.append(domain.t)
         self.r.append(
-            interpolate(geometry.x, state.density[idx_cells], self.probeLocation)
+            interpolate(geometry.xc, state.density[idx_cells], self.probeLocation)
         )
         self.u.append(
-            interpolate(geometry.x, state.velocity[idx_cells], self.probeLocation)
+            interpolate(geometry.xc, state.velocity[idx_cells], self.probeLocation)
         )
         self.p.append(
-            interpolate(geometry.x, state.pressure[idx_cells], self.probeLocation)
+            interpolate(geometry.xc, state.pressure[idx_cells], self.probeLocation)
         )
         self.gamma.append(
-            interpolate(geometry.x, state.gamma[idx_cells], self.probeLocation)
+            interpolate(geometry.xc, state.gamma[idx_cells], self.probeLocation)
         )
         YProbe = np.array(
             [
                 (
                     interpolate(
-                        geometry.x,
+                        geometry.xc,
                         state.composition[idx_cells, kSp],
                         self.probeLocation,
                     )

--- a/src/stanshock/system/geometry.py
+++ b/src/stanshock/system/geometry.py
@@ -33,20 +33,24 @@ class LinearInterpolator:
 class Geometry:
     def __init__(
         self,
-        x: Array,
+        xf: Array,
         area: SpatioTemporalLike = 1.0,
         perimeter: SpatioTemporalLike = 1.0,
         dlnA_dt: SpatioTemporalFunction | None = None,
         dlnA_dx: SpatioTemporalFunction | None = None,
         regions: dict[str, tuple[float, float]] | None = None,
     ) -> None:
-        self.x: Array = x
-        self.n: int = len(self.x)
-        self.dx: float = self.x[1] - self.x[0]
+        self.xf: Array = xf  # Face-center locations
+        self.xc: Array = 0.5 * (xf[1:] + xf[:-1])  # Cell-center locations
+        self.n: int = len(self.xc)
+        self.dx: Array | float = np.diff(self.xf)
+        # If mesh spacing is constant, simplify this to a float
+        if np.max(np.abs(np.diff(self.dx))) < 1e-8:
+            self.dx = self.dx[0]
 
         # Denote distinct regions by their x-range, mapping them to the mesh index
         if regions is None:
-            regions = {"domain": (x[0], x[-1])}
+            regions = {"domain": (self.xf[0], self.xf[-1])}
         self.regions: dict[str, tuple[float, float]] = regions
         self._region_indices: dict[str, Index] = {}
 
@@ -63,12 +67,12 @@ class Geometry:
                 self.dlnA_dx = None
             else:
                 if isinstance(area, np.ndarray):
-                    x_tmp, y_tmp = self.x, area
+                    x_tmp, y_tmp = self.xf, area
                 elif isinstance(area, tuple):
                     x_tmp, y_tmp = area
                 else:
-                    msg = "Cannot (yet) automatically determine dlnA_dx from callable area."
-                    raise NotImplementedError(msg)
+                    x_tmp = self.xf
+                    y_tmp = area(0.0, self.xf)
                 x_midpoint: Array = 0.5 * (x_tmp[1:] + x_tmp[:-1])
                 area_midpoint: Array = 0.5 * (y_tmp[1:] + y_tmp[:-1])
                 dlnA_dx_fd: Array = np.diff(y_tmp) / (np.diff(x_tmp) * area_midpoint)
@@ -88,7 +92,7 @@ class Geometry:
         elif isinstance(value, tuple):
             func = LinearInterpolator(xp=value[0], fp=value[1])
         elif isinstance(value, np.ndarray):
-            func = LinearInterpolator(xp=self.x, fp=value)
+            func = LinearInterpolator(xp=self.xf, fp=value)
         else:
             func = value
 
@@ -98,7 +102,7 @@ class Geometry:
         self, time: float = 0.0, x: Array | None = None
     ) -> Array | float:
         if x is None:
-            x = self.x
+            x = self.xc
 
         return 4.0 * self.area(time, x) / self.perimeter(time, x)
 
@@ -106,7 +110,7 @@ class Geometry:
         self, time: float = 0.0, x: Array | None = None
     ) -> Array | float:
         if x is None:
-            x = self.x
+            x = self.xc
 
         return self.hydraulic_diameter(time, x)
 
@@ -116,8 +120,8 @@ class Geometry:
 
         if region_name not in self._region_indices:
             x_region_start, x_region_end = self.regions[region_name]
-            start_index: np.intp = np.argmin(np.abs(self.x - x_region_start))
-            end_index: np.intp = np.argmin(np.abs(self.x - x_region_end))
+            start_index: np.intp = np.argmin(np.abs(self.xc - x_region_start))
+            end_index: np.intp = np.argmin(np.abs(self.xc - x_region_end))
 
             self._region_indices[region_name] = np.s_[start_index:end_index]
 
@@ -127,14 +131,14 @@ class Geometry:
 class Cylinder(Geometry):
     def __init__(
         self,
-        x: Array,
+        xf: Array,
         d_outer: SpatioTemporalLike,
         d_inner: SpatioTemporalLike | None = None,
         dlnA_dt: SpatioTemporalFunction | None = None,
         dlnA_dx: SpatioTemporalFunction | None = None,
         regions: dict[str, tuple[float, float]] | None = None,
     ) -> None:
-        self.x: Array = x
+        self.xf: Array = xf
         # Set up functional form of inner and outer diameters
         self.d_outer: SpatioTemporalFunction = self.to_spatiotemporal(value=d_outer)
         self.d_inner: SpatioTemporalFunction = self.to_spatiotemporal(value=d_inner)
@@ -149,7 +153,7 @@ class Cylinder(Geometry):
             area = 0.25 * np.pi * (d_outer**2 - d_inner**2)
             perimeter = 0.5 * np.pi * (d_outer + d_inner)
 
-        super().__init__(x, area, perimeter, dlnA_dt, dlnA_dx, regions)
+        super().__init__(xf, area, perimeter, dlnA_dt, dlnA_dx, regions)
 
     def _area(self, t: float, x: Array) -> Array | float:
         return 0.25 * np.pi * (self.d_outer(t, x) ** 2 - self.d_inner(t, x) ** 2)
@@ -161,7 +165,7 @@ class Cylinder(Geometry):
         self, time: float = 0.0, x: Array | None = None
     ) -> Array | float:
         if x is None:
-            x = self.x
+            x = self.xc
 
         return self.d_outer(time, x) - self.d_inner(time, x)
 
@@ -169,7 +173,7 @@ class Cylinder(Geometry):
         self, time: float = 0.0, x: Array | None = None
     ) -> Array | float:
         if x is None:
-            x = self.x
+            x = self.xc
 
         d_outer: Array | float = self.d_outer(time, x)
         d_inner: Array | float = self.d_inner(time, x)
@@ -187,14 +191,14 @@ class Cylinder(Geometry):
 class Box(Geometry):
     def __init__(
         self,
-        x: Array,
+        xf: Array,
         h: SpatioTemporalLike = 1.0,
         w: SpatioTemporalLike = 1.0,
         dlnA_dt: SpatioTemporalFunction | None = None,
         dlnA_dx: SpatioTemporalFunction | None = None,
         regions: dict[str, tuple[float, float]] | None = None,
     ) -> None:
-        self.x: Array = x
+        self.xf: Array = xf
         # Set up functional forms of height and width
         self.h: SpatioTemporalFunction = self.to_spatiotemporal(value=h)
         self.w: SpatioTemporalFunction = self.to_spatiotemporal(value=w)
@@ -209,7 +213,7 @@ class Box(Geometry):
             area = h * w
             perimeter = 2 * (h + w)
 
-        super().__init__(x, area, perimeter, dlnA_dt, dlnA_dx, regions)
+        super().__init__(xf, area, perimeter, dlnA_dt, dlnA_dx, regions)
 
     def _area(self, time: float, x: Array) -> Array | float:
         return self.h(time, x) * self.w(time, x)
@@ -221,7 +225,7 @@ class Box(Geometry):
         self, time: float = 0.0, x: Array | None = None
     ) -> Array | float:
         if x is None:
-            x = self.x
+            x = self.xc
 
         h: Array | float = self.h(time, x)
         w: Array | float = self.w(time, x)
@@ -231,7 +235,7 @@ class Box(Geometry):
 class AsymmetricBox(Box):
     def __init__(
         self,
-        x: Array,
+        xf: Array,
         upper_wall: SpatioTemporalLike,
         lower_wall: SpatioTemporalLike | None = None,
         w: SpatioTemporalLike = 1.0,
@@ -239,7 +243,7 @@ class AsymmetricBox(Box):
         dlnA_dx: SpatioTemporalFunction | None = None,
         regions: dict[str, tuple[float, float]] | None = None,
     ) -> None:
-        self.x: Array = x
+        self.xf: Array = xf
         # Set up functional forms of height and width
         self.upper_wall: SpatioTemporalFunction = self.to_spatiotemporal(
             value=upper_wall
@@ -248,14 +252,14 @@ class AsymmetricBox(Box):
             value=lower_wall
         )
 
-        super().__init__(x, self._h, w, dlnA_dt, dlnA_dx, regions)
+        super().__init__(xf, self._h, w, dlnA_dt, dlnA_dx, regions)
 
     def _h(self, time: float, x: Array) -> Array | float:
         return self.upper_wall(time, x) - self.lower_wall(time, x)
 
 
 def initialize_geometry(
-    x: Array,
+    xf: Array,
     area: SpatioTemporalLike = 1.0,  # Cross-sectional area of flow
     perimeter: SpatioTemporalLike = 1.0,  # Perimeter of the flow cross section
     d_outer: SpatioTemporalLike | None = None,  # Outer diameter of the cylinder/annulus
@@ -280,7 +284,7 @@ def initialize_geometry(
 
     if upper_wall is not None:
         geometry = AsymmetricBox(
-            x=x,
+            xf=xf,
             upper_wall=upper_wall,
             lower_wall=lower_wall,
             w=w,
@@ -290,7 +294,7 @@ def initialize_geometry(
         )
     elif h is not None:
         geometry = Box(
-            x=x,
+            xf=xf,
             h=h,
             w=w,
             dlnA_dt=dlnA_dt,
@@ -299,7 +303,7 @@ def initialize_geometry(
         )
     elif d_outer is not None:
         geometry = Cylinder(
-            x=x,
+            xf=xf,
             d_outer=d_outer,
             d_inner=d_inner,
             dlnA_dt=dlnA_dt,
@@ -308,7 +312,7 @@ def initialize_geometry(
         )
     else:
         geometry = Geometry(
-            x=x,
+            xf=xf,
             area=area,
             perimeter=perimeter,
             dlnA_dx=dlnA_dx,

--- a/src/stanshock/system/geometry.py
+++ b/src/stanshock/system/geometry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Literal
 
 import numpy as np
 
@@ -39,10 +40,13 @@ class Geometry:
         dlnA_dt: SpatioTemporalFunction | None = None,
         dlnA_dx: SpatioTemporalFunction | None = None,
         regions: dict[str, tuple[float, float]] | None = None,
+        n_ghost_layers: int = 0,
     ) -> None:
         self.xf: Array = xf  # Face-center locations
+        self.n_faces: int = len(self.xf)
         self.xc: Array = 0.5 * (xf[1:] + xf[:-1])  # Cell-center locations
-        self.n: int = len(self.xc)
+        self.n_cells: int = self.n_faces - 1
+        self.n_cells_interior = self.n_cells + 0
         self.dx: Array | float = np.diff(self.xf)
         # If mesh spacing is constant, simplify this to a float
         if np.max(np.abs(np.diff(self.dx))) < 1e-8:
@@ -73,12 +77,23 @@ class Geometry:
                 else:
                     x_tmp = self.xf
                     y_tmp = area(0.0, self.xf)
-                x_midpoint: Array = 0.5 * (x_tmp[1:] + x_tmp[:-1])
-                area_midpoint: Array = 0.5 * (y_tmp[1:] + y_tmp[:-1])
-                dlnA_dx_fd: Array = np.diff(y_tmp) / (np.diff(x_tmp) * area_midpoint)
-                self.dlnA_dx = LinearInterpolator(xp=x_midpoint, fp=dlnA_dx_fd)
+
+                if isinstance(y_tmp, float | int):
+                    self.dlnA_dx = None
+                else:
+                    x_midpoint: Array = 0.5 * (x_tmp[1:] + x_tmp[:-1])
+                    area_midpoint: Array = 0.5 * (y_tmp[1:] + y_tmp[:-1])
+                    dlnA_dx_fd: Array = np.diff(y_tmp) / (
+                        np.diff(x_tmp) * area_midpoint
+                    )
+                    self.dlnA_dx = LinearInterpolator(xp=x_midpoint, fp=dlnA_dx_fd)
         else:
             self.dlnA_dx = dlnA_dx
+
+        # Add ghost layers
+        self.n_ghost_layers = 0
+        self.idx_cells: Index = np.s_[:]
+        self.setup_ghost_layers(n_ghost_layers)
 
     def to_spatiotemporal(
         self, value: SpatioTemporalLike | None
@@ -98,11 +113,29 @@ class Geometry:
 
         return func
 
+    def setup_ghost_layers(self, n_ghost_layers: int) -> None:
+        n_added = n_ghost_layers - self.n_ghost_layers
+        if n_added <= 0:
+            return
+
+        if isinstance(self.dx, float):
+            xc_left = self.xc[0] - np.arange(n_added, 0, -1) * self.dx
+            xc_right = self.xc[-1] + np.arange(1, n_added + 1) * self.dx
+        else:
+            self.dx = np.pad(self.dx, pad_width=n_added, mode="edge")
+            xc_left = self.xc[0] - np.cumulative_sum(self.dx[n_added - 1 :: -1])[::-1]
+            xc_right = self.xc[-1] + np.cumulative_sum(self.dx[-n_added:])
+
+        self.xc = np.concatenate([xc_left, self.xc, xc_right])
+        self.n_ghost_layers = n_ghost_layers
+        self.n_cells = len(self.xc)
+        self.idx_cells = np.s_[self.n_ghost_layers : -self.n_ghost_layers]
+
     def hydraulic_diameter(
         self, time: float = 0.0, x: Array | None = None
     ) -> Array | float:
         if x is None:
-            x = self.xc
+            x = self.xc[self.idx_cells]
 
         return 4.0 * self.area(time, x) / self.perimeter(time, x)
 
@@ -110,7 +143,7 @@ class Geometry:
         self, time: float = 0.0, x: Array | None = None
     ) -> Array | float:
         if x is None:
-            x = self.xc
+            x = self.xc[self.idx_cells]
 
         return self.hydraulic_diameter(time, x)
 
@@ -127,6 +160,31 @@ class Geometry:
 
         return self._region_indices[region_name]
 
+    def surface_area(self, time: float = 0.0, x: Array | None = None) -> Array:
+        """Use Simpson's rule to return surface area between given points."""
+        msg = "Surface area is not fully determined by perimeter alone."
+        raise NotImplementedError(msg)
+
+    def volume(self, time: float = 0.0, x: Array | None = None) -> Array:
+        """Use Simpson's rule to return volume between given points."""
+        if x is None:
+            x = self.xf
+            dx = self.dx
+            if not isinstance(dx, float | int):
+                dx = dx[self.idx_cells]
+        else:
+            dx = np.diff(x)
+
+        x_half = 0.5 * (x[1:] + x[:-1])
+
+        area = self.area(time, x)
+        area_half = self.area(time, x_half)
+        if isinstance(area, float | int):
+            area = np.full_like(x, area)
+            area_half = np.full_like(x_half, area_half)
+
+        return (area[1:] + 4.0 * area_half + area[:-1]) * dx / 6.0
+
 
 class Cylinder(Geometry):
     def __init__(
@@ -137,6 +195,7 @@ class Cylinder(Geometry):
         dlnA_dt: SpatioTemporalFunction | None = None,
         dlnA_dx: SpatioTemporalFunction | None = None,
         regions: dict[str, tuple[float, float]] | None = None,
+        n_ghost_layers: int = 0,
     ) -> None:
         self.xf: Array = xf
         # Set up functional form of inner and outer diameters
@@ -151,21 +210,21 @@ class Cylinder(Geometry):
             d_inner, np.ndarray | float | int
         ):
             area = 0.25 * np.pi * (d_outer**2 - d_inner**2)
-            perimeter = 0.5 * np.pi * (d_outer + d_inner)
+            perimeter = np.pi * (d_outer + d_inner)
 
-        super().__init__(xf, area, perimeter, dlnA_dt, dlnA_dx, regions)
+        super().__init__(xf, area, perimeter, dlnA_dt, dlnA_dx, regions, n_ghost_layers)
 
     def _area(self, t: float, x: Array) -> Array | float:
         return 0.25 * np.pi * (self.d_outer(t, x) ** 2 - self.d_inner(t, x) ** 2)
 
     def _perimeter(self, t: float, x: Array) -> Array | float:
-        return 0.5 * np.pi * (self.d_outer(t, x) + self.d_inner(t, x))
+        return np.pi * (self.d_outer(t, x) + self.d_inner(t, x))
 
     def hydraulic_diameter(
         self, time: float = 0.0, x: Array | None = None
     ) -> Array | float:
         if x is None:
-            x = self.xc
+            x = self.xc[self.idx_cells]
 
         return self.d_outer(time, x) - self.d_inner(time, x)
 
@@ -173,7 +232,7 @@ class Cylinder(Geometry):
         self, time: float = 0.0, x: Array | None = None
     ) -> Array | float:
         if x is None:
-            x = self.xc
+            x = self.xc[self.idx_cells]
 
         d_outer: Array | float = self.d_outer(time, x)
         d_inner: Array | float = self.d_inner(time, x)
@@ -187,6 +246,29 @@ class Cylinder(Geometry):
 
         return characteristic_length
 
+    def surface_area(self, time: float = 0.0, x: Array | None = None) -> Array:
+        """Use Simpson's rule to return surface area between given points."""
+        if x is None:
+            x = self.xf
+            dx = self.dx
+            if not isinstance(dx, float | int):
+                dx = dx[self.idx_cells]
+        else:
+            dx = np.diff(x)
+
+        x_half = 0.5 * (x[1:] + x[:-1])
+
+        ro = 0.5 * self.d_outer(time, x)
+        ro_half = 0.5 * self.d_outer(time, x_half)
+        if isinstance(ro, float | int):
+            ro = np.full_like(x, ro)
+            ro_half = np.full_like(x_half, ro_half)
+
+        drdx = np.diff(ro) / dx
+        arc = (ro[1:] + 4.0 * ro_half + ro[:-1]) * np.sqrt(1.0 + drdx**2)
+
+        return np.pi * arc * dx / 3.0
+
 
 class Box(Geometry):
     def __init__(
@@ -197,6 +279,7 @@ class Box(Geometry):
         dlnA_dt: SpatioTemporalFunction | None = None,
         dlnA_dx: SpatioTemporalFunction | None = None,
         regions: dict[str, tuple[float, float]] | None = None,
+        n_ghost_layers: int = 0,
     ) -> None:
         self.xf: Array = xf
         # Set up functional forms of height and width
@@ -213,7 +296,7 @@ class Box(Geometry):
             area = h * w
             perimeter = 2 * (h + w)
 
-        super().__init__(xf, area, perimeter, dlnA_dt, dlnA_dx, regions)
+        super().__init__(xf, area, perimeter, dlnA_dt, dlnA_dx, regions, n_ghost_layers)
 
     def _area(self, time: float, x: Array) -> Array | float:
         return self.h(time, x) * self.w(time, x)
@@ -225,11 +308,50 @@ class Box(Geometry):
         self, time: float = 0.0, x: Array | None = None
     ) -> Array | float:
         if x is None:
-            x = self.xc
+            x = self.xc[self.idx_cells]
 
         h: Array | float = self.h(time, x)
         w: Array | float = self.w(time, x)
         return 2 * h * w / (h + w)
+
+    def surface_area(self, time: float = 0.0, x: Array | None = None) -> Array:
+        """Use Simpson's rule to return surface area between given points."""
+        if x is None:
+            x = self.xf
+            dx = self.dx
+            if not isinstance(dx, float | int):
+                dx = dx[self.idx_cells]
+        else:
+            dx = np.diff(x)
+
+        x_half = 0.5 * (x[1:] + x[:-1])
+
+        # Treat as symmetric across y = 0
+        y = 0.5 * self.h(time, x)
+        y_half = 0.5 * self.h(time, x_half)
+        if isinstance(y, float | int):
+            y = np.full_like(x, y)
+            y_half = np.full_like(x_half, y_half)
+        dydx = np.diff(y) / dx
+
+        w = 0.5 * self.w(time, x)
+        w_half = 0.5 * self.w(time, x_half)
+        if isinstance(w, float | int):
+            w = np.full_like(x, w)
+            w_half = np.full_like(x_half, w_half)
+        dwdx = np.diff(w) / dx
+
+        # Side wall area
+        area_sides = (
+            2.0 * (y[1:] + 4.0 * y_half + y[:-1]) * np.sqrt(1.0 + dwdx**2) * dx / 3.0
+        )
+
+        # Upper and lower wall area
+        area_horizontal = (
+            2.0 * (w[1:] + 4.0 * w_half + w[:-1]) * np.sqrt(1.0 + dydx**2) * dx / 3.0
+        )
+
+        return area_sides + area_horizontal
 
 
 class AsymmetricBox(Box):
@@ -242,6 +364,7 @@ class AsymmetricBox(Box):
         dlnA_dt: SpatioTemporalFunction | None = None,
         dlnA_dx: SpatioTemporalFunction | None = None,
         regions: dict[str, tuple[float, float]] | None = None,
+        n_ghost_layers: int = 0,
     ) -> None:
         self.xf: Array = xf
         # Set up functional forms of height and width
@@ -252,10 +375,70 @@ class AsymmetricBox(Box):
             value=lower_wall
         )
 
-        super().__init__(xf, self._h, w, dlnA_dt, dlnA_dx, regions)
+        super().__init__(xf, self._h, w, dlnA_dt, dlnA_dx, regions, n_ghost_layers)
 
     def _h(self, time: float, x: Array) -> Array | float:
         return self.upper_wall(time, x) - self.lower_wall(time, x)
+
+    def surface_area(
+        self,
+        time: float = 0.0,
+        x: Array | None = None,
+        surface: Literal["top", "bottom", "sides", "all"] = "all",
+    ) -> Array:
+        """Use Simpson's rule to return surface area between given points."""
+        if x is None:
+            x = self.xf
+            dx = self.dx
+            if not isinstance(dx, float | int):
+                dx = dx[self.idx_cells]
+        else:
+            dx = np.diff(x)
+
+        x_half = 0.5 * (x[1:] + x[:-1])
+
+        yu = self.upper_wall(time, x)
+        yu_half = self.upper_wall(time, x_half)
+        if isinstance(yu, float | int):
+            yu = np.full_like(x, yu)
+            yu_half = np.full_like(x_half, yu_half)
+        dyudx = np.diff(yu) / dx
+
+        yl = self.lower_wall(time, x)
+        yl_half = self.lower_wall(time, x_half)
+        if isinstance(yl, float | int):
+            yl = np.full_like(x, yl)
+            yl_half = np.full_like(x_half, yl_half)
+        dyldx = np.diff(yl) / dx
+
+        w = 0.5 * self.w(time, x)
+        w_half = 0.5 * self.w(time, x_half)
+        if isinstance(w, float | int):
+            w = np.full_like(x, w)
+            w_half = np.full_like(x_half, w_half)
+        dwdx = np.diff(w) / dx
+
+        area = np.zeros_like(x_half)
+
+        if surface in ["sides", "all"]:
+            # Side wall area
+            h = yu - yl
+            area += (
+                (h[1:] + 4.0 * (yu_half - yl_half) + h[:-1])
+                * np.sqrt(1.0 + dwdx**2)
+                * dx
+                / 3.0
+            )
+
+        if surface in ["top", "all"]:
+            # Upper wall area
+            area += (w[1:] + 4.0 * w_half + w[:-1]) * np.sqrt(1.0 + dyudx**2) * dx / 3.0
+
+        if surface in ["bottom", "all"]:
+            # Lower wall area
+            area += (w[1:] + 4.0 * w_half + w[:-1]) * np.sqrt(1.0 + dyldx**2) * dx / 3.0
+
+        return area
 
 
 def initialize_geometry(
@@ -275,6 +458,7 @@ def initialize_geometry(
     dlnA_dx: SpatioTemporalFunction
     | None = None,  # derivative of the natural log of the area of the shock tube with respect to x (needed for quasi-1D)
     regions: dict[str, tuple[float, float]] | None = None,
+    n_ghost_layers: int = 0,
     **_kwargs: float,
 ) -> Geometry:
     geometry: Geometry
@@ -291,6 +475,7 @@ def initialize_geometry(
             dlnA_dt=dlnA_dt,
             dlnA_dx=dlnA_dx,
             regions=regions,
+            n_ghost_layers=n_ghost_layers,
         )
     elif h is not None:
         geometry = Box(
@@ -300,6 +485,7 @@ def initialize_geometry(
             dlnA_dt=dlnA_dt,
             dlnA_dx=dlnA_dx,
             regions=regions,
+            n_ghost_layers=n_ghost_layers,
         )
     elif d_outer is not None:
         geometry = Cylinder(
@@ -309,6 +495,7 @@ def initialize_geometry(
             dlnA_dt=dlnA_dt,
             dlnA_dx=dlnA_dx,
             regions=regions,
+            n_ghost_layers=n_ghost_layers,
         )
     else:
         geometry = Geometry(
@@ -318,6 +505,7 @@ def initialize_geometry(
             dlnA_dx=dlnA_dx,
             dlnA_dt=dlnA_dt,
             regions=regions,
+            n_ghost_layers=n_ghost_layers,
         )
 
     return geometry

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from abc import ABC
+from collections.abc import Callable
+from typing import Generic, TypeAlias, TypeVar
+
+import numpy as np
+import pytest
+from scipy.integrate import quad
+
+from stanshock.system.geometry import (
+    AsymmetricBox,
+    Box,
+    Cylinder,
+    Geometry,
+    SpatioTemporalLike,
+    initialize_geometry,
+)
+
+T = TypeVar("T")
+
+
+class FixtureRequest(pytest.FixtureRequest, Generic[T], ABC):
+    param: T
+
+
+_FuncDerivIntegral: TypeAlias = tuple[
+    str, SpatioTemporalLike, Callable[[float], float], Callable[[float], float]
+]
+
+
+# Function, f(x), and its derivative + integral w.r.t. x
+@pytest.fixture(
+    params=[
+        ("constant", 1.0, lambda _x: 0.0, lambda x: x),
+        (
+            "expand",
+            (np.array([-1.0, 1.0]), np.array([1.0, 2.0])),  # y(x) = 0.5*x + 1.5
+            lambda _x: 0.5,
+            lambda x: 0.25 * x**2 + 1.5 * x,
+        ),
+        (
+            "contract",
+            (np.array([-1.0, 1.0]), np.array([2.0, 1.0])),  # y(x) = -0.5*x + 1.5
+            lambda _x: -0.5,
+            lambda x: -0.25 * x**2 + 1.5 * x,
+        ),
+        (
+            "quadratic",
+            lambda _t, x: x**2 + 1.0,
+            lambda x: 2.0 * x,
+            lambda x: x**3 / 3.0 + x,
+        ),
+    ],
+    ids=["constant", "expand", "contract", "quadratic"],
+    scope="module",
+)
+def key_function(request: FixtureRequest[_FuncDerivIntegral]) -> _FuncDerivIntegral:
+    return request.param
+
+
+# Geometry object, function used to define it, surface integral, and volume integral
+@pytest.fixture(
+    params=[
+        (Geometry, "area"),
+        (Cylinder, "d_outer"),
+        (Box, "h"),
+        (AsymmetricBox, "upper_wall"),
+    ],
+    ids=["generic", "cylinder", "box", "asymmbox"],
+    scope="module",
+)
+def geometry_def(
+    request: FixtureRequest[tuple[type[Geometry], str]],
+) -> tuple[type[Geometry], str]:
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def geometry(
+    geometry_def: tuple[type[Geometry], str], key_function: _FuncDerivIntegral
+) -> Geometry:
+    geometry_type, func_name = geometry_def
+    xf = np.linspace(-1.0, 1.0, 201)
+    kwargs = {"xf": xf, func_name: key_function[1]}
+    return geometry_type(**kwargs)
+
+
+def test_geometry_initializer(
+    geometry_def: tuple[type[Geometry], str],
+    key_function: _FuncDerivIntegral,
+    geometry: Geometry,
+) -> None:
+    geometry_type, func_name = geometry_def
+    xf = np.linspace(-1.0, 1.0, 201)
+    kwargs = {"xf": xf, func_name: key_function[1]}
+    geometry_test = initialize_geometry(**kwargs)
+
+    assert type(geometry_test) is geometry_type
+    assert geometry_test.area(0.0, xf) == pytest.approx(geometry.area(0.0, xf))
+
+
+def test_surface_area_against_quad(
+    geometry: Geometry, key_function: _FuncDerivIntegral
+) -> None:
+    _, _, dfdx, int_f = key_function
+
+    if isinstance(geometry, Cylinder):
+        # Surface of revolution
+        f = geometry.d_outer
+        surf_area_quad: float = (
+            np.pi
+            * quad(
+                lambda x: f(0.0, x) * np.sqrt(1.0 + (0.5 * dfdx(x)) ** 2),
+                a=geometry.xf[0],
+                b=geometry.xf[-1],
+            )[0]
+        )
+    elif isinstance(geometry, AsymmetricBox):
+        w = geometry.w(0.0, geometry.xf)
+        if isinstance(w, float):
+            arc_length = quad(
+                lambda x: np.sqrt(1.0 + dfdx(x) ** 2),
+                a=geometry.xf[0],
+                b=geometry.xf[-1],
+            )[0]
+            surf_area_quad = 2.0 * (
+                int_f(geometry.xf[-1]) - int_f(geometry.xf[0])
+            ) + w * (geometry.xf[-1] - geometry.xf[0] + arc_length)
+        else:
+            pytest.xfail("Not set up to handle variable width AsymmetricBox.")
+    elif isinstance(geometry, Box):
+        w = geometry.w(0.0, geometry.xf)
+        if isinstance(w, float):
+            arc_length = quad(
+                lambda x: np.sqrt(1.0 + (0.5 * dfdx(x)) ** 2),
+                a=geometry.xf[0],
+                b=geometry.xf[-1],
+            )[0]
+            surf_area_quad = 2.0 * (
+                int_f(geometry.xf[-1]) - int_f(geometry.xf[0]) + w * arc_length
+            )
+        else:
+            pytest.xfail("Not set up to handle variable width Box.")
+    else:
+        pytest.xfail(
+            "Geometry objects don't have enough information to compute surface area."
+        )
+
+    surf_area_total: float = geometry.surface_area().sum()
+
+    assert surf_area_total == pytest.approx(surf_area_quad, rel=1e-5)
+
+
+def test_volume_against_quad(geometry: Geometry) -> None:
+    volume_total: float = geometry.volume().sum()
+    volume_quad: float = quad(
+        lambda x: geometry.area(0.0, x), a=geometry.xf[0], b=geometry.xf[-1]
+    )[0]
+
+    assert volume_total == pytest.approx(volume_quad)
+
+
+def test_surface_area_against_analytical(
+    geometry: Geometry, key_function: _FuncDerivIntegral
+) -> None:
+    function_name, _, _, _ = key_function
+
+    if isinstance(geometry, Cylinder):
+        if function_name == "constant":
+            surf_area_analytical = 2.0 * np.pi
+        elif function_name == "quadratic":
+            surf_area_analytical = (
+                0.25
+                * np.pi
+                * (3.0 * np.arctanh(1.0 / np.sqrt(2.0)) + 7.0 * np.sqrt(2.0))
+            )
+        else:
+            surf_area_analytical = np.pi * (np.sqrt(17.0) - 0.5 * np.sqrt(4.25))
+    elif isinstance(geometry, AsymmetricBox):
+        if function_name == "constant":
+            surf_area_analytical = 8.0
+        elif function_name == "quadratic":
+            surf_area_analytical = 22.0 / 3.0 + np.sqrt(5.0) + 0.5 * np.asinh(2.0)
+        else:
+            surf_area_analytical = np.sqrt(5.0) + 8.0
+    elif isinstance(geometry, Box):
+        if function_name == "constant":
+            surf_area_analytical = 8.0
+        elif function_name == "quadratic":
+            surf_area_analytical = (
+                16.0 / 3.0 + np.sqrt(8.0) + 2.0 * np.arctanh(1.0 / np.sqrt(2.0))
+            )
+        else:
+            surf_area_analytical = 2.0 * (np.sqrt(4.25) + 3.0)
+    else:
+        pytest.xfail(
+            "Geometry objects don't have enough information to compute surface area."
+        )
+
+    surf_area_total: float = geometry.surface_area().sum()
+
+    assert surf_area_total == pytest.approx(surf_area_analytical, rel=1e-5)
+
+
+def test_volume_against_analytical(
+    geometry: Geometry, key_function: _FuncDerivIntegral
+) -> None:
+    function_name, _, _, int_f = key_function
+
+    if isinstance(geometry, Cylinder):
+        if function_name == "constant":
+            volume_analytical = 0.5 * np.pi
+        elif function_name == "quadratic":
+            volume_analytical = 14.0 / 15.0 * np.pi
+        else:
+            volume_analytical = np.pi * (4.0 - 0.5) / 3.0
+    elif isinstance(geometry, Box | AsymmetricBox):
+        if function_name == "constant":
+            volume_analytical = 2.0
+        elif function_name == "quadratic":
+            volume_analytical = 8.0 / 3.0
+        else:
+            volume_analytical = 3.0
+    else:
+        # For Geometry f(x) is the area, so int_f(x) is the volume
+        volume_analytical = int_f(geometry.xf[-1]) - int_f(geometry.xf[0])
+
+    volume_total: float = geometry.volume().sum()
+
+    assert volume_total == pytest.approx(volume_analytical)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Callable
-from typing import Generic, TypeAlias, TypeVar
+from typing import Generic, TypeAlias, TypedDict, TypeVar
 
 import numpy as np
 import pytest
 from scipy.integrate import quad
 
+from stanshock.system.backend import Array
 from stanshock.system.geometry import (
     AsymmetricBox,
     Box,
@@ -29,127 +30,139 @@ _FuncDerivIntegral: TypeAlias = tuple[
 ]
 
 
-# Function, f(x), and its derivative + integral w.r.t. x
-@pytest.fixture(
-    params=[
-        ("constant", 1.0, lambda _x: 0.0, lambda x: x),
-        (
-            "expand",
-            (np.array([-1.0, 1.0]), np.array([1.0, 2.0])),  # y(x) = 0.5*x + 1.5
-            lambda _x: 0.5,
-            lambda x: 0.25 * x**2 + 1.5 * x,
-        ),
-        (
-            "contract",
-            (np.array([-1.0, 1.0]), np.array([2.0, 1.0])),  # y(x) = -0.5*x + 1.5
-            lambda _x: -0.5,
-            lambda x: -0.25 * x**2 + 1.5 * x,
-        ),
-        (
-            "quadratic",
-            lambda _t, x: x**2 + 1.0,
-            lambda x: 2.0 * x,
-            lambda x: x**3 / 3.0 + x,
-        ),
-    ],
-    ids=["constant", "expand", "contract", "quadratic"],
-    scope="module",
-)
-def key_function(request: FixtureRequest[_FuncDerivIntegral]) -> _FuncDerivIntegral:
-    return request.param
+class PointData(TypedDict):
+    x: Array
+    area: float
+    perimeter: float
+    hydraulic_diameter: float
+    characteristic_length: float
 
 
-# Geometry object, function used to define it, surface integral, and volume integral
-@pytest.fixture(
-    params=[
-        (Geometry, "area"),
-        (Cylinder, "d_outer"),
-        (Box, "h"),
-        (AsymmetricBox, "upper_wall"),
-    ],
-    ids=["generic", "cylinder", "box", "asymmbox"],
-    scope="module",
-)
-def geometry_def(
-    request: FixtureRequest[tuple[type[Geometry], str]],
-) -> tuple[type[Geometry], str]:
+class GeometryTestCase(TypedDict):
+    geometry: type[Geometry]
+    definition: dict[str, SpatioTemporalLike | None]
+    surface_area: float
+    volume: float
+    point_data: PointData
+
+
+nfaces = 201
+xf: Array = np.linspace(-1.0, 1.0, nfaces, dtype=np.float64)
+x0: Array = np.array([0.0])
+
+cases: dict[str, GeometryTestCase] = {
+    "generic-quadratic": {
+        "geometry": Geometry,
+        "definition": {
+            "xf": xf,
+            "area": lambda _t, x: x**2 + 1.0,
+            "perimeter": lambda _t, x: x**2 + 1.0,
+            "dlnA_dx": lambda _t, x: 2.0 * x / (x**2 + 1.0),
+        },
+        "surface_area": np.nan,
+        "volume": 8.0 / 3.0,
+        "point_data": {
+            "x": x0,
+            "area": 1.0,
+            "perimeter": 1.0,
+            "hydraulic_diameter": 4.0,
+            "characteristic_length": 4.0,
+        },
+    },
+    "cylinder-const": {
+        "geometry": Cylinder,
+        "definition": {
+            "xf": xf,
+            "d_outer": 0.5,
+            "d_inner": 0.1,
+            "n_ghost_layers": 3,
+        },
+        "surface_area": np.pi,
+        "volume": 0.5 * np.pi * (0.5**2 - 0.1**2),
+        "point_data": {
+            "x": x0,
+            "area": 0.25 * np.pi * (0.5**2 - 0.1**2),
+            "perimeter": np.pi * (0.5 + 0.1),
+            "hydraulic_diameter": 0.5 - 0.1,
+            "characteristic_length": 0.5 * (0.5 - 0.1),
+        },
+    },
+    "box-contract": {
+        "geometry": Box,
+        "definition": {
+            "xf": xf,
+            "h": np.linspace(2.0, 1.0, nfaces, dtype=np.float64),
+            "w": 1.0,
+            "n_ghost_layers": 1,
+        },
+        "surface_area": 2.0 * (np.sqrt(4.25) + 3.0),
+        "volume": 3.0,
+        "point_data": {
+            "x": x0,
+            "area": 1.5,
+            "perimeter": 5.0,
+            "hydraulic_diameter": 3.0 / 2.5,
+            "characteristic_length": 3.0 / 2.5,
+        },
+    },
+    "asymm-expand": {
+        "geometry": AsymmetricBox,
+        "definition": {
+            "xf": xf,
+            "upper_wall": (np.array([-1.0, 1.0]), np.array([1.0, 2.0])),
+            "lower_wall": None,
+        },
+        "surface_area": np.sqrt(5.0) + 8.0,
+        "volume": 3.0,
+        "point_data": {
+            "x": x0,
+            "area": 1.5,
+            "perimeter": 5.0,
+            "hydraulic_diameter": 3.0 / 2.5,
+            "characteristic_length": 3.0 / 2.5,
+        },
+    },
+}
+
+case_ids: tuple[str, ...] = tuple(cases.keys())
+case_data: tuple[GeometryTestCase, ...] = tuple(cases[id] for id in case_ids)
+
+
+@pytest.fixture(params=case_data, ids=case_ids, scope="module")
+def test_case(request: FixtureRequest[GeometryTestCase]) -> GeometryTestCase:
     return request.param
 
 
 @pytest.fixture(scope="module")
-def geometry(
-    geometry_def: tuple[type[Geometry], str], key_function: _FuncDerivIntegral
-) -> Geometry:
-    geometry_type, func_name = geometry_def
-    xf = np.linspace(-1.0, 1.0, 201)
-    kwargs = {"xf": xf, func_name: key_function[1]}
+def geometry(test_case: GeometryTestCase) -> Geometry:
+    geometry_type = test_case["geometry"]
+    kwargs = test_case["definition"]
     return geometry_type(**kwargs)
 
 
-def test_geometry_initializer(
-    geometry_def: tuple[type[Geometry], str],
-    key_function: _FuncDerivIntegral,
-    geometry: Geometry,
-) -> None:
-    geometry_type, func_name = geometry_def
-    xf = np.linspace(-1.0, 1.0, 201)
-    kwargs = {"xf": xf, func_name: key_function[1]}
+def test_geometry_initializer(test_case: GeometryTestCase) -> None:
+    geometry_type = test_case["geometry"]
+    kwargs = test_case["definition"]
     geometry_test = initialize_geometry(**kwargs)
 
     assert type(geometry_test) is geometry_type
-    assert geometry_test.area(0.0, xf) == pytest.approx(geometry.area(0.0, xf))
 
 
-def test_surface_area_against_quad(
-    geometry: Geometry, key_function: _FuncDerivIntegral
-) -> None:
-    _, _, dfdx, int_f = key_function
+def test_adding_ghost_layers(geometry: Geometry) -> None:
+    n_ghost_layers = 3
+    n_ghost_layers_added = n_ghost_layers - geometry.n_ghost_layers
 
-    if isinstance(geometry, Cylinder):
-        # Surface of revolution
-        f = geometry.d_outer
-        surf_area_quad: float = (
-            np.pi
-            * quad(
-                lambda x: f(0.0, x) * np.sqrt(1.0 + (0.5 * dfdx(x)) ** 2),
-                a=geometry.xf[0],
-                b=geometry.xf[-1],
-            )[0]
-        )
-    elif isinstance(geometry, AsymmetricBox):
-        w = geometry.w(0.0, geometry.xf)
-        if isinstance(w, float):
-            arc_length = quad(
-                lambda x: np.sqrt(1.0 + dfdx(x) ** 2),
-                a=geometry.xf[0],
-                b=geometry.xf[-1],
-            )[0]
-            surf_area_quad = 2.0 * (
-                int_f(geometry.xf[-1]) - int_f(geometry.xf[0])
-            ) + w * (geometry.xf[-1] - geometry.xf[0] + arc_length)
-        else:
-            pytest.xfail("Not set up to handle variable width AsymmetricBox.")
-    elif isinstance(geometry, Box):
-        w = geometry.w(0.0, geometry.xf)
-        if isinstance(w, float):
-            arc_length = quad(
-                lambda x: np.sqrt(1.0 + (0.5 * dfdx(x)) ** 2),
-                a=geometry.xf[0],
-                b=geometry.xf[-1],
-            )[0]
-            surf_area_quad = 2.0 * (
-                int_f(geometry.xf[-1]) - int_f(geometry.xf[0]) + w * arc_length
-            )
-        else:
-            pytest.xfail("Not set up to handle variable width Box.")
-    else:
-        pytest.xfail(
-            "Geometry objects don't have enough information to compute surface area."
-        )
+    n_cells_before = len(geometry.xc)
+    x_cells_before = geometry.xc[geometry.idx_cells]
 
-    surf_area_total: float = geometry.surface_area().sum()
+    geometry.setup_ghost_layers(n_ghost_layers=3)
 
-    assert surf_area_total == pytest.approx(surf_area_quad, rel=1e-5)
+    n_cells_after = len(geometry.xc)
+    x_cells_after = geometry.xc[geometry.idx_cells]
+
+    assert n_cells_after == n_cells_before + 2 * n_ghost_layers_added
+    assert np.array_equal(x_cells_after, x_cells_before)
+    assert np.all(np.diff(geometry.xc) > 0.0)
 
 
 def test_volume_against_quad(geometry: Geometry) -> None:
@@ -162,38 +175,11 @@ def test_volume_against_quad(geometry: Geometry) -> None:
 
 
 def test_surface_area_against_analytical(
-    geometry: Geometry, key_function: _FuncDerivIntegral
+    test_case: GeometryTestCase, geometry: Geometry
 ) -> None:
-    function_name, _, _, _ = key_function
+    surf_area_analytical = test_case["surface_area"]
 
-    if isinstance(geometry, Cylinder):
-        if function_name == "constant":
-            surf_area_analytical = 2.0 * np.pi
-        elif function_name == "quadratic":
-            surf_area_analytical = (
-                0.25
-                * np.pi
-                * (3.0 * np.arctanh(1.0 / np.sqrt(2.0)) + 7.0 * np.sqrt(2.0))
-            )
-        else:
-            surf_area_analytical = np.pi * (np.sqrt(17.0) - 0.5 * np.sqrt(4.25))
-    elif isinstance(geometry, AsymmetricBox):
-        if function_name == "constant":
-            surf_area_analytical = 8.0
-        elif function_name == "quadratic":
-            surf_area_analytical = 22.0 / 3.0 + np.sqrt(5.0) + 0.5 * np.asinh(2.0)
-        else:
-            surf_area_analytical = np.sqrt(5.0) + 8.0
-    elif isinstance(geometry, Box):
-        if function_name == "constant":
-            surf_area_analytical = 8.0
-        elif function_name == "quadratic":
-            surf_area_analytical = (
-                16.0 / 3.0 + np.sqrt(8.0) + 2.0 * np.arctanh(1.0 / np.sqrt(2.0))
-            )
-        else:
-            surf_area_analytical = 2.0 * (np.sqrt(4.25) + 3.0)
-    else:
+    if test_case["geometry"] is Geometry:
         pytest.xfail(
             "Geometry objects don't have enough information to compute surface area."
         )
@@ -204,28 +190,26 @@ def test_surface_area_against_analytical(
 
 
 def test_volume_against_analytical(
-    geometry: Geometry, key_function: _FuncDerivIntegral
+    test_case: GeometryTestCase, geometry: Geometry
 ) -> None:
-    function_name, _, _, int_f = key_function
-
-    if isinstance(geometry, Cylinder):
-        if function_name == "constant":
-            volume_analytical = 0.5 * np.pi
-        elif function_name == "quadratic":
-            volume_analytical = 14.0 / 15.0 * np.pi
-        else:
-            volume_analytical = np.pi * (4.0 - 0.5) / 3.0
-    elif isinstance(geometry, Box | AsymmetricBox):
-        if function_name == "constant":
-            volume_analytical = 2.0
-        elif function_name == "quadratic":
-            volume_analytical = 8.0 / 3.0
-        else:
-            volume_analytical = 3.0
-    else:
-        # For Geometry f(x) is the area, so int_f(x) is the volume
-        volume_analytical = int_f(geometry.xf[-1]) - int_f(geometry.xf[0])
+    volume_analytical = test_case["volume"]
 
     volume_total: float = geometry.volume().sum()
 
-    assert volume_total == pytest.approx(volume_analytical)
+    assert volume_total == pytest.approx(volume_analytical, rel=1e-5)
+
+
+def test_cross_section_against_analytical(
+    test_case: GeometryTestCase, geometry: Geometry
+) -> None:
+    point_data = test_case["point_data"]
+    x = point_data["x"]
+
+    assert geometry.area(0.0, x) == pytest.approx(point_data["area"])
+    assert geometry.perimeter(0.0, x) == pytest.approx(point_data["perimeter"])
+    assert geometry.hydraulic_diameter(0.0, x) == pytest.approx(
+        point_data["hydraulic_diameter"]
+    )
+    assert geometry.characteristic_length(0.0, x) == pytest.approx(
+        point_data["characteristic_length"]
+    )


### PR DESCRIPTION
This change aims to bring the spatial discretization closer to a conventional finite-volume approach, and provide necessary functionality to support various planned features. Significant changes include:

- Face locations are stored as `xf`, cell locations as `xc`, and functions which accept arbitrary locations use `x`.
- `Geometry` objects are now initialized using face locations, `xf`.
- Mesh spacing, `dx`, is computed from `xf`. Some steps toward supporting non-constant mesh spacings have been added.
- Ghost layer information has been moved into the `Geometry` object:
  - The cell-center array, `xc`, now includes the ghost cells.
  - The `Index` object `idx_cells`, which slices the full `xc` array to return the interior cells, is now created and stored in `Geometry`.
- Cross-sectional area is now well-defined in the ghost layers.
- Added convenience functions to compute cell volumes and surface areas.
  - Optionally separate out surface areas by region, and upper/lower surfaces for `Box` type domains.
  - Added unit tests to verify values against analytical results.
- When not directly provided, `dlnA_dx` is now computed from a callable area functions when possible.
- Fixed bug in Symmetry boundary condition where energy was sign-flipped instead of momentum.
- Change default ghost cell behavior:
  - Default to a new `FreezeCell` option, which prevents updates to the values set at initialization.
  - Certain boundary conditions can also override this default.

Closes #61