### PR TITLE
Ghost Layer Primitive Treatment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,7 +93,8 @@ repos:
     rev: "v0.24.1"
     hooks:
       - id: validate-pyproject
-        additional_dependencies: ["validate-pyproject-schema-store[all]"]
+        additional_dependencies:
+          ["validate-pyproject-schema-store[all]==2025.11.04"]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: "0.34.1"

--- a/examples/hyshot_ii.py
+++ b/examples/hyshot_ii.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from stanshock.components.combustor import Combustor
-from stanshock.numerics.boundary_conditions import PrescribedFace
+from stanshock.numerics.boundary_conditions import SpecifiedFace
 from stanshock.physics.fluid_base import FluidPhysics
 from stanshock.physics.thermotable import ThermoTable
 from stanshock.system.backend import Array
@@ -94,7 +94,7 @@ gas_init.TPX = T_in, P_in, "O2:1,N2:3.76"
 W_in = gas_init.mean_molecular_weight
 
 # Define the boundary conditions
-BC_inlet = PrescribedFace(
+BC_inlet = SpecifiedFace(
     reference_state=(gas_init.density, U_in, gas_init.P, gas_init.Y)
 )
 BC_outlet = "outflow"

--- a/examples/hyshot_ii.py
+++ b/examples/hyshot_ii.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from stanshock.components.combustor import Combustor
-from stanshock.numerics.boundary_conditions import Inflow
+from stanshock.numerics.boundary_conditions import PrescribedFace
 from stanshock.physics.fluid_base import FluidPhysics
 from stanshock.physics.thermotable import ThermoTable
 from stanshock.system.backend import Array
@@ -94,7 +94,9 @@ gas_init.TPX = T_in, P_in, "O2:1,N2:3.76"
 W_in = gas_init.mean_molecular_weight
 
 # Define the boundary conditions
-BC_inlet = Inflow(reference_state=(gas_init.density, U_in, gas_init.P, gas_init.Y))
+BC_inlet = PrescribedFace(
+    reference_state=(gas_init.density, U_in, gas_init.P, gas_init.Y)
+)
 BC_outlet = "outflow"
 BCs = (BC_inlet, BC_outlet)
 

--- a/examples/hyshot_ii_jic/hyshot_ii_jic.py
+++ b/examples/hyshot_ii_jic/hyshot_ii_jic.py
@@ -10,7 +10,7 @@ from scipy import optimize
 
 from stanshock.components.combustor import Combustor
 from stanshock.models.jicf import JICModel
-from stanshock.numerics.boundary_conditions import Inflow
+from stanshock.numerics.boundary_conditions import PrescribedFace
 from stanshock.physics.flamelet import FPVTable
 from stanshock.processing.plot import XTDiagram
 from stanshock.system.geometry import Box
@@ -238,7 +238,9 @@ gas_init = ct.Solution(mech)
 gas_init.TPX = T_in, P_in, "O2:1,N2:3.76"
 
 # Define the boundary conditions
-BC_inlet = Inflow(reference_state=(gas_init.density, U_in, gas_init.P, (1.0, 0.0, 0.0)))
+BC_inlet = PrescribedFace(
+    reference_state=(gas_init.density, U_in, gas_init.P, (1.0, 0.0, 0.0))
+)
 BC_outlet = "outflow"
 BCs = (BC_inlet, BC_outlet)
 

--- a/examples/hyshot_ii_jic/hyshot_ii_jic.py
+++ b/examples/hyshot_ii_jic/hyshot_ii_jic.py
@@ -10,7 +10,7 @@ from scipy import optimize
 
 from stanshock.components.combustor import Combustor
 from stanshock.models.jicf import JICModel
-from stanshock.numerics.boundary_conditions import PrescribedFace
+from stanshock.numerics.boundary_conditions import SpecifiedFace
 from stanshock.physics.flamelet import FPVTable
 from stanshock.processing.plot import XTDiagram
 from stanshock.system.geometry import Box
@@ -238,7 +238,7 @@ gas_init = ct.Solution(mech)
 gas_init.TPX = T_in, P_in, "O2:1,N2:3.76"
 
 # Define the boundary conditions
-BC_inlet = PrescribedFace(
+BC_inlet = SpecifiedFace(
     reference_state=(gas_init.density, U_in, gas_init.P, (1.0, 0.0, 0.0))
 )
 BC_outlet = "outflow"

--- a/examples/laminar_flame.py
+++ b/examples/laminar_flame.py
@@ -9,6 +9,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from stanshock.components.combustor import Combustor
+from stanshock.numerics.boundary_conditions import FreezeCells
 from stanshock.physics.cantera_interface import CanteraInterface
 from stanshock.physics.thermotable import ThermoTable
 
@@ -54,19 +55,19 @@ def main(
     flame_center = flame.grid[np.argmax(np.gradient(flame.T, flame.grid))]
     L = flame.grid[-1] - flame.grid[0]
     xUpper, xLower = flame_center + L * f, flame_center - L * f
-    boundary_conditions = (
-        (gasUnburned.density, uUnburned, None, gasUnburned.Y),
-        (None, None, gasBurned.P, None),
-    )
+    boundary_conditions = {
+        "left": FreezeCells(
+            "left"
+        ),  # (gasUnburned.density, uUnburned, None, gasUnburned.Y),
+        "right": FreezeCells("right"),  # (None, None, gasBurned.P, None),
+    }
     if physics_model == "ThermoTable":
         physics = ThermoTable(gas)
     else:
         physics = CanteraInterface(gas)
 
     ss = Combustor(
-        n_cells=nX,
         xf=np.linspace(xLower, xUpper, nX + 1),
-        dx=(xUpper - xLower) / nX,
         initialization=("Riemann", unburnedState, burnedState, flame_center),
         physics=physics,
         boundary_conditions=boundary_conditions,
@@ -75,6 +76,7 @@ def main(
         include_diffusion=True,
         output_every=10,
     )
+    print(ss.boundary_conditions._boundary_conditions)
 
     # interpolate flame solution
     Y = ss.state.composition
@@ -101,7 +103,8 @@ def main(
 
     # plot setup
     if plot_results:
-        idx = ss.geometry.idx_cells
+        # idx = ss.geometry.idx_cells
+        idx = np.s_[:]
         x = (ss.geometry.xc[idx] - flame_center) / flameThickness
         x_ct = (flame.grid - flame_center) / flameThickness
         T = ss.physics.get_temperature(ss.state)[idx]

--- a/examples/optimization.py
+++ b/examples/optimization.py
@@ -110,7 +110,7 @@ def main(
     gas4.TPX = T4, p4, "HE:1"
 
     # set up solver parameters
-    boundary_conditions = ["reflecting", "reflecting"]
+    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)

--- a/examples/validation/case1.py
+++ b/examples/validation/case1.py
@@ -94,7 +94,7 @@ def main(
 
     # set up solver parameters
     print("Solving with boundary layer terms")
-    boundary_conditions = ["reflecting", "reflecting"]
+    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
@@ -122,7 +122,7 @@ def main(
 
     # without  boundary layer model
     print("Solving without boundary layer model")
-    boundary_conditions = ["reflecting", "reflecting"]
+    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
     gas1.TP = T1, p1
     gas4.TP = T4, p4
     ssnbl = ShockTube(

--- a/examples/validation/case2.py
+++ b/examples/validation/case2.py
@@ -95,7 +95,7 @@ def main(
 
     # set up solver parameters
     print("Solving with boundary layer terms")
-    boundary_conditions = ["reflecting", "reflecting"]
+    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
@@ -123,7 +123,7 @@ def main(
 
     # without  boundary layer model
     print("Solving without boundary layer model")
-    boundary_conditions = ["reflecting", "reflecting"]
+    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
     gas1.TP = T1, p1
     gas4.TP = T4, p4
     ssnbl = ShockTube(

--- a/examples/validation/case3.py
+++ b/examples/validation/case3.py
@@ -144,7 +144,7 @@ def main(
 
     # set up solver parameters
     print("Solving with boundary layer terms")
-    boundary_conditions = ["reflecting", "reflecting"]
+    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
@@ -173,7 +173,7 @@ def main(
 
     # without  boundary layer model
     print("Solving without boundary layer model")
-    boundary_conditions = ["reflecting", "reflecting"]
+    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
     gas1.TP = T1, p1
     gas4.TP = T4, p4
     ssnbl = ShockTube(

--- a/examples/validation/case4.py
+++ b/examples/validation/case4.py
@@ -145,7 +145,7 @@ def main(
         return dA_dx(time, x) / A(time, x)
 
     # solve with boundary layer model
-    boundary_conditions = ["reflecting", "reflecting"]
+    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
@@ -167,8 +167,8 @@ def main(
     ssbl.state.gamma = ssbl.physics.get_gamma(ssbl.state)
     ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xf)))  # end wall probe
     diagram_settings = [
-        ("pressure", [p1 / 101325, p4 / 101325]),
-        ("temperature", [T1, 800.0]),
+        ("pressure", (p1 / 101325, p4 / 101325)),
+        ("temperature", (T1, 800.0)),
     ]
     ssbl.xt_diagrams += [
         XTDiagram(ssbl, variable=variable, limits=limits)
@@ -180,7 +180,7 @@ def main(
     XN2Upper = 1.5 - XN2Lower
     idx = ssbl.geometry.idx_cells
     xc = ssbl.geometry.xc[idx]
-    dV = ssbl.geometry.volume(0.0, xc)
+    dV = ssbl.geometry.volume(0.0, ssbl.geometry.xf)
     VDriver = np.sum(dV[xc < xShock])
     V = np.cumsum(dV)
     V -= V[0] / 2.0  # center
@@ -211,7 +211,7 @@ def main(
             diagram.plot()
 
     # Solve without boundary layer model
-    boundary_conditions = ["reflecting", "reflecting"]
+    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
     gas1.TP = T1, p1
     gas4.TP = T4, p4
     ssnbl = ShockTube(
@@ -240,7 +240,7 @@ def main(
     XN2Upper = 1.5 - XN2Lower
     idx = ssnbl.geometry.idx_cells
     xc = ssnbl.geometry.xc[idx]
-    dV = ssnbl.geometry.volume(0.0, xc)
+    dV = ssnbl.geometry.volume(0.0, ssnbl.geometry.xf)
     VDriver = np.sum(dV[xc < xShock])
     V = np.cumsum(dV)
     V -= V[0] / 2.0  # center

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -6,8 +6,7 @@ import numpy as np
 from stanshock.models.area_change import AreaChange
 from stanshock.models.boundary_layer import BoundaryLayer
 from stanshock.numerics.boundary_conditions import (
-    BCNamesType,
-    BCType,
+    BCInput,
     BoundaryConditions,
     set_boundary_conditions,
 )
@@ -53,10 +52,10 @@ class Combustor:
         self.cfl = 1.0  # stability condition
         self.dx = 1.0  # grid spacing
         self.n_cells = n_cells  # grid size
-        self.boundary_conditions: BoundaryConditions | list[BCNamesType | BCType] = [
-            "outflow",
-            "outflow",
-        ]
+        self.boundary_conditions: BoundaryConditions | BCInput = {
+            "left": "outflow",
+            "right": "outflow",
+        }
         self.xf: Array = np.linspace(
             0.0, self.dx * self.n_cells, self.n_cells + 1, dtype=np.float64
         )
@@ -71,8 +70,8 @@ class Combustor:
         self.source_terms: RightHandSide | None = None  # source term function
         self.injector = None  # injector model
         self.flux_function: RiemannSolver = hllc_flux
-        self.inviscid_face_extrapolator: FaceExtrapolator = FifthOrderWeno
-        self.viscous_face_extrapolator: FaceExtrapolator = FirstOrder
+        self.inviscid_face_extrapolator: type[FaceExtrapolator] = FifthOrderWeno
+        self.viscous_face_extrapolator: type[FaceExtrapolator] = FirstOrder
         self.initialization = None  # initialization options
         self.probes = []  # list of probe objects
         self.xt_diagrams = []  # list of XT diagram objects
@@ -119,7 +118,7 @@ class Combustor:
             raise Exception(msg)
 
         # Set up boundary conditions
-        self.boundary_conditions: BoundaryConditions = set_boundary_conditions(
+        self.boundary_conditions = set_boundary_conditions(
             self.boundary_conditions, self.geometry.n_ghost_layers
         )
 
@@ -148,7 +147,7 @@ class Combustor:
             ),
             boundary_conditions=self.boundary_conditions,
             riemann_solver=self.flux_function,
-            dx=self.geometry.dx,
+            geometry=self.geometry,
         )
 
         if self.include_diffusion:

--- a/src/stanshock/numerics/boundary_conditions.py
+++ b/src/stanshock/numerics/boundary_conditions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Generic, Literal, TypeVar
+from typing import Generic, Literal, TypeVar, TypedDict
 
 from stanshock.physics.fluid_base import FluidState
 from stanshock.system.backend import Array, Index, TypeAlias, np
@@ -21,6 +21,10 @@ class BoundaryCondition(ABC, Generic[_T]):
 
 class GhostCell(BoundaryCondition[Array]):
     """Update the conservative variables in the ghost layers."""
+
+
+class GhostCellPrimitive(BoundaryCondition[FluidState]):
+    """Update the primitive variables in the ghost layers."""
 
 
 class RiemannFlux(BoundaryCondition[FluidState]):
@@ -124,6 +128,39 @@ class SymmetryCells(GhostCell):
         _: float = time
         target[self.idx_exterior] = target[self.idx_interior]
         target[self.idx_exterior][:, 0] = -target[self.idx_interior][:, 0]
+
+        return target
+
+
+class DeactivateWeno(GhostCellPrimitive):
+    """Applies large values and variance to primitives in ghost layers.
+
+    This is one approach to forcing the WENO stencil to only consider interior cells.
+    """
+
+    def __init__(
+        self, mt: int = 3, location: Literal["left", "right"] = "left"
+    ) -> None:
+        super().__init__(location)
+        if self.location == "left":
+            self.values = (10.0 * np.arange(mt, 0, -1)) ** 10.0
+            self.idx_exterior: Index = np.s_[:mt]
+        else:
+            self.values = (10.0 * np.arange(1, mt + 1)) ** 10.0
+            self.idx_exterior = np.s_[-mt:]
+
+    def update(self, time: float, target: FluidState) -> FluidState:
+        _: float = time
+        assert target.density is not None
+        assert target.velocity is not None
+        assert target.pressure is not None
+        assert target.composition is not None
+
+        values = self.values.copy()
+        target.density[self.idx_exterior] = values
+        target.velocity[self.idx_exterior] = values
+        target.pressure[self.idx_exterior] = values
+        target.composition[self.idx_exterior] = values
 
         return target
 
@@ -240,6 +277,14 @@ class BoundaryConditions:
         ]
 
     @property
+    def ghost_cells_primitive(self) -> list[GhostCellPrimitive]:
+        return [
+            boundary_condition
+            for boundary_condition in self._boundary_conditions
+            if isinstance(boundary_condition, GhostCellPrimitive)
+        ]
+
+    @property
     def riemann_fluxes(self) -> list[RiemannFlux]:
         return [
             boundary_condition
@@ -261,6 +306,12 @@ class BoundaryConditions:
 
         return state_array
 
+    def update_ghost_states(self, time: float, state: FluidState) -> FluidState:
+        for ghost_cell_primitive in self.ghost_cells_primitive:
+            state = ghost_cell_primitive.update(time, target=state)
+
+        return state
+
     def update_face_states(self, time: float, face_states: FluidState) -> FluidState:
         for riemann_flux in self.riemann_fluxes:
             face_states = riemann_flux.update(time, target=face_states)
@@ -279,41 +330,45 @@ BCNamesType: TypeAlias = Literal[
 ]
 
 
+class BCInput(TypedDict):
+    left: Sequence[BCNamesType | BCType]
+    right: Sequence[BCNamesType | BCType]
+
+
 def set_boundary_conditions(
-    boundary_conditions: BoundaryConditions | Sequence[BCNamesType | BCType],
-    mt: int = 3,
+    boundary_conditions: BoundaryConditions | BCInput, mt: int = 3
 ) -> BoundaryConditions:
     """Convenience function to initialize different boundary conditions."""
 
     # If ghost layer method not specified, default to freezing (hold constant)
-    default_ghost_layers: dict[str, GhostCell] = {
-        "left": FreezeCells(location="left"),
-        "right": FreezeCells(location="right"),
+    default_ghost_layers: dict[str, GhostCell | GhostCellPrimitive] = {
+        "left": DeactivateWeno(mt=mt, location="left"),
+        "right": DeactivateWeno(mt=mt, location="right"),
     }
 
     # Convert lists into BoundaryConditions:
     if not isinstance(boundary_conditions, BoundaryConditions):
         bc_locs: list[Literal["left", "right"]] = ["left", "right"]
         bcs: list[BCType] = []
-
-        for bc_loc, bc_specification in zip(bc_locs, boundary_conditions, strict=False):
-            if isinstance(bc_specification, str):
-                if bc_specification == "periodic":
-                    bcs += [PeriodicCells(mt, location=bc_loc)]
-                elif bc_specification == "outflow":
-                    default_ghost_layers[bc_loc] = ExtrapolateCells(mt, location=bc_loc)
-                    bcs += [ExtrapolateFace(location=bc_loc)]
-                elif bc_specification in ["symmetry"]:
-                    bcs += [SymmetryCells(mt, location=bc_loc)]
-                elif bc_specification in ["reflecting", "wall"]:
-                    default_ghost_layers[bc_loc] = SymmetryCells(mt, location=bc_loc)
-                    bcs += [AdiabaticWallFace(location=bc_loc)]
-            elif isinstance(bc_specification, BoundaryCondition):
-                bcs += [bc_specification]
-            elif isinstance(bc_specification, tuple | list):
-                bcs += [
-                    PrescribedFace(reference_state=bc_specification, location=bc_loc)
-                ]
+        for bc_loc in bc_locs:
+            for bc_specification in boundary_conditions[bc_loc]:
+                if isinstance(bc_specification, str):
+                    if bc_specification == "periodic":
+                        bcs += [PeriodicCells(mt, location=bc_loc)]
+                    elif bc_specification == "extrapolate":
+                        bcs += [ExtrapolateCells(mt, location=bc_loc)]
+                    elif bc_specification == "outflow":
+                        bcs += [ExtrapolateFace(location=bc_loc)]
+                    elif bc_specification in ["symmetry", "reflecting"]:
+                        bcs += [SymmetryCells(mt, location=bc_loc)]
+                    elif bc_specification == "wall":
+                        bcs += [AdiabaticWallFace(location=bc_loc)]
+                elif isinstance(bc_specification, BoundaryCondition):
+                    bcs += [bc_specification]
+                elif isinstance(bc_specification, tuple | list):
+                    bcs += [
+                        PrescribedFace(reference_state=bc_specification, location=bc_loc)
+                    ]
 
         boundary_conditions = BoundaryConditions(boundary_conditions=bcs)
 
@@ -321,7 +376,7 @@ def set_boundary_conditions(
     for bc in boundary_conditions._boundary_conditions:
         if isinstance(bc, PeriodicCells):
             default_ghost_layers = {}
-        elif isinstance(bc, GhostCell):
+        elif isinstance(bc, GhostCell | GhostCellPrimitive):
             del default_ghost_layers[bc.location]
 
     for _, bc in default_ghost_layers.items():

--- a/src/stanshock/numerics/boundary_conditions.py
+++ b/src/stanshock/numerics/boundary_conditions.py
@@ -203,6 +203,11 @@ class AdiabaticWallFace(ExtrapolateFace):
         return target
 
 
+ReferenceStateType: TypeAlias = tuple[
+    float | None, float | None, float | None, Sequence[float] | None
+]
+
+
 class SpecifiedFace(ExtrapolateFace):
     """Fully or partially specify the fluid state at the boundary face.
 
@@ -211,7 +216,7 @@ class SpecifiedFace(ExtrapolateFace):
 
     def __init__(
         self,
-        reference_state: Sequence[float | Sequence[float] | None],
+        reference_state: ReferenceStateType,
         location: Literal["left", "right"] = "left",
     ) -> None:
         super().__init__(location)
@@ -329,10 +334,12 @@ BCNamesType: TypeAlias = Literal[
     "extrapolate", "outflow", "symmetry", "reflecting", "wall", "periodic"
 ]
 
+BCLike: TypeAlias = BCType | BCNamesType | ReferenceStateType
+
 
 class BCInput(TypedDict):
-    left: BCNamesType | BCType | Sequence[BCNamesType | BCType]
-    right: BCNamesType | BCType | Sequence[BCNamesType | BCType]
+    left: BCLike | Sequence[BCLike]
+    right: BCLike | Sequence[BCLike]
 
 
 def set_boundary_conditions(
@@ -351,7 +358,7 @@ def set_boundary_conditions(
         bc_locs: list[Literal["left", "right"]] = ["left", "right"]
         bcs: list[BCType] = []
         for bc_loc in bc_locs:
-            if isinstance(boundary_conditions[bc_loc], str | BoundaryCondition):
+            if isinstance(boundary_conditions[bc_loc], str | BoundaryCondition | tuple):
                 bc_tmp = [boundary_conditions[bc_loc]]
             else:
                 bc_tmp = boundary_conditions[bc_loc]
@@ -370,7 +377,7 @@ def set_boundary_conditions(
                         bcs += [AdiabaticWallFace(location=bc_loc)]
                 elif isinstance(bc_specification, BoundaryCondition):
                     bcs += [bc_specification]
-                elif isinstance(bc_specification, tuple | list):
+                elif isinstance(bc_specification, tuple):
                     bcs += [
                         SpecifiedFace(reference_state=bc_specification, location=bc_loc)
                     ]

--- a/src/stanshock/numerics/boundary_conditions.py
+++ b/src/stanshock/numerics/boundary_conditions.py
@@ -31,7 +31,7 @@ class RiemannFlux(BoundaryCondition[FluidState]):
     """Update the primitive variables at the boundary face (input to Riemann solver)."""
 
 
-class SpecifiedFlux(BoundaryCondition[Array]):
+class DirichletFlux(BoundaryCondition[Array]):
     """Directly set the flux through the boundary face."""
 
 
@@ -132,7 +132,7 @@ class SymmetryCells(GhostCell):
         return target
 
 
-class DeactivateWeno(GhostCellPrimitive):
+class DeactivateWenoCells(GhostCellPrimitive):
     """Applies large values and variance to primitives in ghost layers.
 
     This is one approach to forcing the WENO stencil to only consider interior cells.
@@ -203,7 +203,7 @@ class AdiabaticWallFace(ExtrapolateFace):
         return target
 
 
-class PrescribedFace(ExtrapolateFace):
+class SpecifiedFace(ExtrapolateFace):
     """Fully or partially specify the fluid state at the boundary face.
 
     Unspecified properties will be extrapolated from interior cells.
@@ -237,7 +237,7 @@ class PrescribedFace(ExtrapolateFace):
         return target
 
 
-class DirichletFlux(SpecifiedFlux):
+class SpecifiedFlux(DirichletFlux):
     """Directly set the flux through the boundary face."""
 
     def __init__(
@@ -293,11 +293,11 @@ class BoundaryConditions:
         ]
 
     @property
-    def specified_fluxes(self) -> list[SpecifiedFlux]:
+    def specified_fluxes(self) -> list[DirichletFlux]:
         return [
             boundary_condition
             for boundary_condition in self._boundary_conditions
-            if isinstance(boundary_condition, SpecifiedFlux)
+            if isinstance(boundary_condition, DirichletFlux)
         ]
 
     def update_ghost_layers(self, time: float, state_array: Array) -> Array:
@@ -342,8 +342,8 @@ def set_boundary_conditions(
 
     # If ghost layer method not specified, default to freezing (hold constant)
     default_ghost_layers: dict[str, GhostCell | GhostCellPrimitive] = {
-        "left": DeactivateWeno(mt=mt, location="left"),
-        "right": DeactivateWeno(mt=mt, location="right"),
+        "left": DeactivateWenoCells(mt=mt, location="left"),
+        "right": DeactivateWenoCells(mt=mt, location="right"),
     }
 
     # Convert lists into BoundaryConditions:
@@ -372,9 +372,7 @@ def set_boundary_conditions(
                     bcs += [bc_specification]
                 elif isinstance(bc_specification, tuple | list):
                     bcs += [
-                        PrescribedFace(
-                            reference_state=bc_specification, location=bc_loc
-                        )
+                        SpecifiedFace(reference_state=bc_specification, location=bc_loc)
                     ]
 
         boundary_conditions = BoundaryConditions(boundary_conditions=bcs)

--- a/src/stanshock/numerics/boundary_conditions.py
+++ b/src/stanshock/numerics/boundary_conditions.py
@@ -7,15 +7,15 @@ from typing import Generic, Literal, TypeVar
 from stanshock.physics.fluid_base import FluidState
 from stanshock.system.backend import Array, Index, TypeAlias, np
 
-T = TypeVar("T")
+_T = TypeVar("_T")
 
 
-class BoundaryCondition(ABC, Generic[T]):
+class BoundaryCondition(ABC, Generic[_T]):
     def __init__(self, location: Literal["left", "right"] = "left") -> None:
         self.location = location
 
     @abstractmethod
-    def update(self, time: float, target: T) -> T:
+    def update(self, time: float, target: _T) -> _T:
         """Update the target of the specific boundary condition type."""
 
 
@@ -39,7 +39,7 @@ class FreezeCells(GhostCell):
         return target
 
 
-class PadCells(GhostCell):
+class ExtrapolateCells(GhostCell):
     """Extrapolates constant values from the last interior cell into the ghost layers."""
 
     def __init__(
@@ -60,7 +60,7 @@ class PadCells(GhostCell):
         return target
 
 
-class LinearExtrapolation(GhostCell):
+class ExtrapolateCellsLinear(GhostCell):
     """Linearly extrapolates values from the interior cells into the ghost layers."""
 
     def __init__(
@@ -74,17 +74,18 @@ class LinearExtrapolation(GhostCell):
             self.idx_interior = np.s_[-mt - 2 : -mt]
             self.idx_exterior = np.s_[-mt:]
         self.mt = mt
+        self.delta = np.arange(self.mt, 0, -1)[:, None]
 
     def update(self, time: float, target: Array) -> Array:
         _: float = time
-        target[self.idx_exterior] = target[self.idx_interior][[0]] - np.arange(
-            self.mt, 0, -1
-        )[:, None] * np.diff(target[self.idx_interior], axis=0)
+        target[self.idx_exterior] = target[self.idx_interior][
+            [0]
+        ] - self.delta * np.diff(target[self.idx_interior], axis=0)
 
         return target
 
 
-class Periodic(GhostCell):
+class PeriodicCells(GhostCell):
     """Replicates solution from opposite end of the domain into the ghost layers."""
 
     def __init__(
@@ -105,7 +106,7 @@ class Periodic(GhostCell):
         return target
 
 
-class Symmetry(GhostCell):
+class SymmetryCells(GhostCell):
     """Mirrors interior solution into the ghost layers."""
 
     def __init__(
@@ -127,7 +128,7 @@ class Symmetry(GhostCell):
         return target
 
 
-class Extrapolate(RiemannFlux):
+class ExtrapolateFace(RiemannFlux):
     """Copy extrapolated fluid state from interior of the boundary face to the exterior side."""
 
     def __init__(self, location: Literal["left", "right"] = "left") -> None:
@@ -154,7 +155,7 @@ class Extrapolate(RiemannFlux):
         return target
 
 
-class AdiabaticWall(Extrapolate):
+class AdiabaticWallFace(ExtrapolateFace):
     """Set the velocity at the wall face to zero."""
 
     def update(self, time: float, target: FluidState) -> FluidState:
@@ -165,8 +166,11 @@ class AdiabaticWall(Extrapolate):
         return target
 
 
-class Inflow(Extrapolate):
-    """Specify the fluid state at the wall face."""
+class PrescribedFace(ExtrapolateFace):
+    """Fully or partially specify the fluid state at the boundary face.
+
+    Unspecified properties will be extrapolated from interior cells.
+    """
 
     def __init__(
         self,
@@ -196,8 +200,8 @@ class Inflow(Extrapolate):
         return target
 
 
-class DirichletInflow(SpecifiedFlux):
-    """Directly set the flux through the wall face."""
+class DirichletFlux(SpecifiedFlux):
+    """Directly set the flux through the boundary face."""
 
     def __init__(
         self, reference_flux: Array, location: Literal["left", "right"] = "left"
@@ -295,25 +299,27 @@ def set_boundary_conditions(
         for bc_loc, bc_specification in zip(bc_locs, boundary_conditions, strict=False):
             if isinstance(bc_specification, str):
                 if bc_specification == "periodic":
-                    bcs += [Periodic(mt, location=bc_loc)]
+                    bcs += [PeriodicCells(mt, location=bc_loc)]
                 elif bc_specification == "outflow":
-                    default_ghost_layers[bc_loc] = PadCells(mt, location=bc_loc)
-                    bcs += [Extrapolate(location=bc_loc)]
+                    default_ghost_layers[bc_loc] = ExtrapolateCells(mt, location=bc_loc)
+                    bcs += [ExtrapolateFace(location=bc_loc)]
                 elif bc_specification in ["symmetry"]:
-                    bcs += [Symmetry(mt, location=bc_loc)]
+                    bcs += [SymmetryCells(mt, location=bc_loc)]
                 elif bc_specification in ["reflecting", "wall"]:
-                    default_ghost_layers[bc_loc] = Symmetry(mt, location=bc_loc)
-                    bcs += [AdiabaticWall(location=bc_loc)]
+                    default_ghost_layers[bc_loc] = SymmetryCells(mt, location=bc_loc)
+                    bcs += [AdiabaticWallFace(location=bc_loc)]
             elif isinstance(bc_specification, BoundaryCondition):
                 bcs += [bc_specification]
             elif isinstance(bc_specification, tuple | list):
-                bcs += [Inflow(reference_state=bc_specification, location=bc_loc)]
+                bcs += [
+                    PrescribedFace(reference_state=bc_specification, location=bc_loc)
+                ]
 
         boundary_conditions = BoundaryConditions(boundary_conditions=bcs)
 
     # Don't use default GhostCell treatments if already specified
     for bc in boundary_conditions._boundary_conditions:
-        if isinstance(bc, Periodic):
+        if isinstance(bc, PeriodicCells):
             default_ghost_layers = {}
         elif isinstance(bc, GhostCell):
             del default_ghost_layers[bc.location]

--- a/src/stanshock/numerics/boundary_conditions.py
+++ b/src/stanshock/numerics/boundary_conditions.py
@@ -60,6 +60,30 @@ class PadCells(GhostCell):
         return target
 
 
+class LinearExtrapolation(GhostCell):
+    """Linearly extrapolates values from the interior cells into the ghost layers."""
+
+    def __init__(
+        self, mt: int = 3, location: Literal["left", "right"] = "left"
+    ) -> None:
+        super().__init__(location)
+        if self.location == "left":
+            self.idx_interior: Index = np.s_[mt : mt + 2]
+            self.idx_exterior: Index = np.s_[:mt]
+        else:
+            self.idx_interior = np.s_[-mt - 2 : -mt]
+            self.idx_exterior = np.s_[-mt:]
+        self.mt = mt
+
+    def update(self, time: float, target: Array) -> Array:
+        _: float = time
+        target[self.idx_exterior] = target[self.idx_interior][[0]] - np.arange(
+            self.mt, 0, -1
+        )[:, None] * np.diff(target[self.idx_interior], axis=0)
+
+        return target
+
+
 class Periodic(GhostCell):
     """Replicates solution from opposite end of the domain into the ghost layers."""
 

--- a/src/stanshock/numerics/boundary_conditions.py
+++ b/src/stanshock/numerics/boundary_conditions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Generic, Literal, TypeVar, TypedDict
+from typing import Generic, Literal, TypedDict, TypeVar
 
 from stanshock.physics.fluid_base import FluidState
 from stanshock.system.backend import Array, Index, TypeAlias, np
@@ -160,7 +160,7 @@ class DeactivateWeno(GhostCellPrimitive):
         target.density[self.idx_exterior] = values
         target.velocity[self.idx_exterior] = values
         target.pressure[self.idx_exterior] = values
-        target.composition[self.idx_exterior] = values
+        target.composition[self.idx_exterior] = values[:, None]
 
         return target
 
@@ -326,13 +326,13 @@ class BoundaryConditions:
 
 
 BCNamesType: TypeAlias = Literal[
-    "outflow", "symmetry", "reflecting", "wall", "periodic"
+    "extrapolate", "outflow", "symmetry", "reflecting", "wall", "periodic"
 ]
 
 
 class BCInput(TypedDict):
-    left: Sequence[BCNamesType | BCType]
-    right: Sequence[BCNamesType | BCType]
+    left: BCNamesType | BCType | Sequence[BCNamesType | BCType]
+    right: BCNamesType | BCType | Sequence[BCNamesType | BCType]
 
 
 def set_boundary_conditions(
@@ -351,7 +351,12 @@ def set_boundary_conditions(
         bc_locs: list[Literal["left", "right"]] = ["left", "right"]
         bcs: list[BCType] = []
         for bc_loc in bc_locs:
-            for bc_specification in boundary_conditions[bc_loc]:
+            if isinstance(boundary_conditions[bc_loc], str | BoundaryCondition):
+                bc_tmp = [boundary_conditions[bc_loc]]
+            else:
+                bc_tmp = boundary_conditions[bc_loc]
+
+            for bc_specification in bc_tmp:
                 if isinstance(bc_specification, str):
                     if bc_specification == "periodic":
                         bcs += [PeriodicCells(mt, location=bc_loc)]
@@ -367,7 +372,9 @@ def set_boundary_conditions(
                     bcs += [bc_specification]
                 elif isinstance(bc_specification, tuple | list):
                     bcs += [
-                        PrescribedFace(reference_state=bc_specification, location=bc_loc)
+                        PrescribedFace(
+                            reference_state=bc_specification, location=bc_loc
+                        )
                     ]
 
         boundary_conditions = BoundaryConditions(boundary_conditions=bcs)

--- a/src/stanshock/numerics/face_extrapolation.py
+++ b/src/stanshock/numerics/face_extrapolation.py
@@ -218,7 +218,7 @@ def weno5(
     # ^ all the characteristic values in the stencil
 
     for iFace in range(nFaces):  # iterate through each cell right edge
-        iCell = iFace + 2  # face is on the right side of the cell
+        iCell = iFace + n_ghost_layers - 1  # face is on the right side of the cell
 
         # Face averages
         rAverage = 0.5 * (r[iCell] + r[iCell + 1])
@@ -452,17 +452,17 @@ class FifthOrderWeno(FaceExtrapolator):
         assert state.gamma_star is not None
         assert state.e0_star is not None
 
-        face_states_array = weno5(
-            state.density,
-            state.velocity,
-            state.pressure,
-            state.composition,
-            state.gamma_star,
-            self.n_ghost_layers,
-            self.n_scalars_rho_sum,
+        face_states_array: Array = weno5(
+            r=state.density,
+            u=state.velocity,
+            p=state.pressure,
+            Y=state.composition,
+            gamma=state.gamma_star,
+            n_ghost_layers=self.n_ghost_layers,
+            n_scalars_rho_sum=self.n_scalars_rho_sum,
         )
 
-        n_faces: int = state.shape[0] - 2 * self.n_ghost_layers + 1
+        n_faces: int = state.shape[0]
 
         return FluidState(
             shape=(2, n_faces),

--- a/src/stanshock/numerics/face_extrapolation.py
+++ b/src/stanshock/numerics/face_extrapolation.py
@@ -382,23 +382,6 @@ def weno5(
             for kSc in range(nSc):
                 PLR[N, iFace, 3 + kSc] = U[mn + kSc] / rLR
 
-    # First order at boundaries
-    for N in range(nLR):
-        for iFace in range(n_ghost_layers):
-            iCell = iFace + 2
-            PLR[N, iFace, 0] = r[iCell + N]
-            PLR[N, iFace, 1] = u[iCell + N]
-            PLR[N, iFace, 2] = p[iCell + N]
-            for kSc in range(nSc):
-                PLR[N, iFace, 3 + kSc] = Y[iCell + N, kSc]
-        for iFace in range(nFaces - n_ghost_layers, nFaces):
-            iCell = iFace + 2
-            PLR[N, iFace, 0] = r[iCell + N]
-            PLR[N, iFace, 1] = u[iCell + N]
-            PLR[N, iFace, 2] = p[iCell + N]
-            for kSc in range(nSc):
-                PLR[N, iFace, 3 + kSc] = Y[iCell + N, kSc]
-
     # Create primitive matrix for limiter
     P = np.zeros((nCells + 2 * n_ghost_layers, nVar + 1))
     P[:, 0] = r[:]

--- a/src/stanshock/numerics/inviscid_flux.py
+++ b/src/stanshock/numerics/inviscid_flux.py
@@ -46,9 +46,7 @@ def lax_friedrichs_flux(
         return:
             F=modeled Euler fluxes [nFaces,mn+nSc]
     """
-    nLR = len(rLR)
-    nFaces = len(rLR[0])
-    nSc = YLR[0].shape[1]
+    nLR, nFaces, nSc = YLR.shape
     nDim = mn + nSc
 
     # find the maximum wave speed
@@ -109,9 +107,7 @@ def hllc_flux(
         return:
             F=modeled Euler fluxes [nFaces,mn+nSc]
     """
-    nLR = len(rLR)
-    nFaces = len(rLR[0])
-    nSc = YLR[0].shape[1]
+    nLR, nFaces, nSc = YLR.shape
     nDim = mn + nSc
 
     # compute the wave speeds
@@ -248,7 +244,7 @@ class InviscidFlux(RightHandSide):
         return self.source_from_primitives(time, face_states, physics)
 
     def source_from_primitives(
-        self, _time: float, face_states: FluidState, _physics: FluidPhysics
+        self, time: float, face_states: FluidState, _physics: FluidPhysics
     ) -> Array:
         assert face_states.density is not None
         assert face_states.velocity is not None
@@ -273,6 +269,9 @@ class InviscidFlux(RightHandSide):
             face_states.gamma_star[0, :],
             face_states.e0_star[0, :],
         )
+
+        self.boundary_conditions.update_face_flux(time, left_face_flux)
+        self.boundary_conditions.update_face_flux(time, right_face_flux)
 
         return cast(
             Array,

--- a/src/stanshock/numerics/inviscid_flux.py
+++ b/src/stanshock/numerics/inviscid_flux.py
@@ -11,6 +11,7 @@ from stanshock.numerics.face_extrapolation import FaceExtrapolator
 from stanshock.physics.fluid_base import FluidPhysics, FluidState
 from stanshock.system.backend import Array, TypeAlias
 from stanshock.system.base import RightHandSide
+from stanshock.system.geometry import Geometry
 
 # Global variables (parameters) used by the solver
 mn = 2  # number of 1D Euler equations
@@ -215,20 +216,22 @@ class InviscidFlux(RightHandSide):
         face_extrapolator: FaceExtrapolator,
         boundary_conditions: BoundaryConditions,
         riemann_solver: RiemannSolver,
-        dx: float,
+        geometry: Geometry,
     ) -> None:
         self.face_extrapolator = face_extrapolator
         self.boundary_conditions = boundary_conditions
         self.riemann_solver = riemann_solver
-        self.dx = dx
+        self.dx: Array | float = geometry.dx
+        if isinstance(self.dx, np.ndarray):
+            self.dx = self.dx[geometry.idx_cells]
 
     def source(
         self,
         time: float,
         state_array: Array,
         physics: FluidPhysics,
-        gamma_star: Array,
-        e0_star: Array,
+        gamma_star: Array | None = None,
+        e0_star: Array | None = None,
     ) -> Array:
         state_array = self.boundary_conditions.update_ghost_layers(time, state_array)
 
@@ -254,6 +257,8 @@ class InviscidFlux(RightHandSide):
         assert face_states.gamma_star is not None
         assert face_states.e0_star is not None
 
+        # Flux from face on cell's left side, using double-flux variables
+        # from cell on the face's right side
         left_face_flux: Array = self.riemann_solver(
             face_states.density,
             face_states.velocity,
@@ -262,6 +267,8 @@ class InviscidFlux(RightHandSide):
             face_states.gamma_star[1, :],
             face_states.e0_star[1, :],
         )
+        # Flux from face on cell's right side, using double-flux variables
+        # from cell on the face's left side
         right_face_flux: Array = self.riemann_solver(
             face_states.density,
             face_states.velocity,

--- a/src/stanshock/numerics/inviscid_flux.py
+++ b/src/stanshock/numerics/inviscid_flux.py
@@ -237,6 +237,7 @@ class InviscidFlux(RightHandSide):
         )
         state.gamma_star = gamma_star
         state.e0_star = e0_star
+        state = self.boundary_conditions.update_ghost_states(time, state)
 
         face_states: FluidState = self.face_extrapolator(state)
         face_states = self.boundary_conditions.update_face_states(time, face_states)


### PR DESCRIPTION
This update addresses the following parts of #64:

**Improved naming scheme:**
- The fundamental BC categories are now: `GhostCell`, `GhostCellPrimitive` (new), `RiemannFlux`, and `DirichletFlux` (renamed from `SpecifiedFlux`).
  - GhostCellPrimitive base class added for updating the primitive variables instead of the conservative variables in the ghost layers.
- All BC names now include what they update: `Cells`, `Face`, or `Flux`.

**New boundary conditions:**
- `ExtrapolateCellsLinear` projects the conservative variables into the ghost layers, maintaining the gradient from the first two interior cells.
  - Experimental, and may make more sense to combine this with `ExtrapolateCells` with a user-specifiable order of extrapolation.
- `DeactivateWenoCells` sets the primitive variables to be large values with large variations in order to force the WENO scheme to disregard them during the stencil-choosing step (see [NASA/CR-97-206253](https://ntrs.nasa.gov/citations/19980007543), section 2.3.3. on page 26).
  - This will now be the default ghost layer treatment, as it works well with the `RiemannFlux` and `DirichletFlux` options.

**Misc. Changes:**
- Improved boundary condition specification using `set_boundary_conditions`, including using a `TypedDict` as the input format for the left and right BCs which can now be a single option or a list of multiple BCs (e.g. if you want to specify both the ghost cell treatment and the face treatment).
- `InviscidFlux` now takes in the `Geometry` object and pulls out the mesh spacing from it.
- Removed section of `weno5` face extrapolation method which forces the extrapolation to first order near the boundaries.

