### PR TITLE
Add isentropic flow tests and utilities

### DIFF
--- a/examples/optimization.py
+++ b/examples/optimization.py
@@ -18,6 +18,7 @@ from stanshock.processing.initialize import (
 from stanshock.processing.plot import XTDiagram
 from stanshock.processing.probe import Probe
 from stanshock.system.backend import Array
+from stanshock.system.geometry import Cylinder
 
 
 def main(
@@ -25,7 +26,7 @@ def main(
     plot_results: bool = True,
     show_results: bool = False,
     results_location: str | None = ".",
-) -> None:
+) -> dict[str, Array]:
     # parameters
     fontsize = 12
     tFinal = 7.5e-3
@@ -128,6 +129,7 @@ def main(
         dlnA_dx=dlnA_dx,
     )
     ss.state.gamma = ss.physics.get_gamma(ss.state)
+    assert isinstance(ss.geometry, Cylinder)
 
     # Solve
     t0 = time.perf_counter()
@@ -158,11 +160,11 @@ def main(
         dlnA_dx=ss.geometry.dlnA_dx,
     )
 
+    diagram_settings = [
+        ("pressure", [0.5, 25]),
+        ("temperature", [200.0, 1800.0]),
+    ]
     if plot_results:
-        diagram_settings = [
-            ("pressure", [0.5, 25]),
-            ("temperature", [200.0, 1800.0]),
-        ]
         ss.xt_diagrams += [
             XTDiagram(ss, variable=variable, limits=limits)
             for variable, limits in diagram_settings
@@ -178,6 +180,7 @@ def main(
     for diagram in ss.xt_diagrams:
         diagram.plot()
 
+    assert isinstance(ss.geometry, Cylinder)
     xInsert = ss.geometry.xc
     d_outer_insert = ss.geometry.d_outer(0.0, ss.geometry.xc)
     d_inner_insert = ss.geometry.d_inner(0.0, ss.geometry.xc)

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -23,6 +23,7 @@ from stanshock.physics.fluid_base import FluidPhysics, FluidState
 from stanshock.processing.initialize import (
     initialize_constant,
     initialize_diffuse_interface,
+    initialize_isentropic,
     initialize_riemann_problem,
 )
 from stanshock.processing.plot import plot_state
@@ -136,6 +137,10 @@ class Combustor:
             )
         elif self.initialization[0].lower() == "diffuse_interface":
             self.state = initialize_diffuse_interface(
+                self.geometry, self.physics, *self.initialization[1:]
+            )
+        elif self.initialization[0].lower() == "isentropic":
+            self.state = initialize_isentropic(
                 self.geometry, self.physics, *self.initialization[1:]
             )
 

--- a/src/stanshock/numerics/inviscid_flux.py
+++ b/src/stanshock/numerics/inviscid_flux.py
@@ -146,6 +146,16 @@ def hllc_flux(
         )
         SLR[0, iFace] = uLR[0, iFace] - aLR[0, iFace] * qLR[0, iFace]
         SLR[1, iFace] = uLR[1, iFace] + aLR[1, iFace] * qLR[1, iFace]
+
+        # srL = np.sqrt(rLR[0, iFace])
+        # srR = np.sqrt(rLR[1, iFace])
+        # denom = 1.0/(srL + srR)
+        # utilde = (srL*uLR[0, iFace] + srR*uLR[1, iFace]) * denom
+        # atilde = (srL*aLR[0, iFace] + srR*aLR[1, iFace]) * denom
+
+        # SLR[0, iFace] = utilde - atilde
+        # SLR[1, iFace] = utilde + atilde
+
         SStar[iFace] = pLR[1, iFace] - pLR[0, iFace]
         SStar[iFace] += rLR[0, iFace] * uLR[0, iFace] * (SLR[0, iFace] - uLR[0, iFace])
         SStar[iFace] -= rLR[1, iFace] * uLR[1, iFace] * (SLR[1, iFace] - uLR[1, iFace])

--- a/src/stanshock/numerics/inviscid_flux.py
+++ b/src/stanshock/numerics/inviscid_flux.py
@@ -27,12 +27,7 @@ RiemannSolver: TypeAlias = Callable[[Array, Array, Array, Array, Array, Array], 
 
 @njit(double2D(double2D, double2D, double2D, double3D, double1D, double1D))
 def lax_friedrichs_flux(
-    rLR: Array,
-    uLR: Array,
-    pLR: Array,
-    YLR: Array,
-    gamma: Array,
-    e0: Array,
+    rLR: Array, uLR: Array, pLR: Array, YLR: Array, gamma: Array, e0: Array
 ) -> Array:
     """
     This method computes the flux at each interface
@@ -147,15 +142,6 @@ def hllc_flux(
         SLR[0, iFace] = uLR[0, iFace] - aLR[0, iFace] * qLR[0, iFace]
         SLR[1, iFace] = uLR[1, iFace] + aLR[1, iFace] * qLR[1, iFace]
 
-        # srL = np.sqrt(rLR[0, iFace])
-        # srR = np.sqrt(rLR[1, iFace])
-        # denom = 1.0/(srL + srR)
-        # utilde = (srL*uLR[0, iFace] + srR*uLR[1, iFace]) * denom
-        # atilde = (srL*aLR[0, iFace] + srR*aLR[1, iFace]) * denom
-
-        # SLR[0, iFace] = utilde - atilde
-        # SLR[1, iFace] = utilde + atilde
-
         SStar[iFace] = pLR[1, iFace] - pLR[0, iFace]
         SStar[iFace] += rLR[0, iFace] * uLR[0, iFace] * (SLR[0, iFace] - uLR[0, iFace])
         SStar[iFace] -= rLR[1, iFace] * uLR[1, iFace] * (SLR[1, iFace] - uLR[1, iFace])
@@ -218,6 +204,77 @@ def hllc_flux(
                 F[iFace, iDim] = FLR[K, iFace, iDim] + SFace * (UStar[iDim] - U[iDim])
 
     return F
+
+
+def hllc_flux_vectorized(
+    rLR: Array, uLR: Array, pLR: Array, YLR: Array, gamma: Array, e0: Array
+) -> Array:
+    """Vectorized version of HLLC flux based on DoubleFlux-1D implementation."""
+    nLR, nFaces = rLR.shape
+
+    aLR = np.sqrt(gamma[None, :] * pLR / rLR)
+    ELR = pLR / (gamma[None, :] - 1.0) + rLR * (e0[None, :] + 0.5 * uLR**2)
+
+    FLR = np.concatenate(
+        (
+            (rLR * uLR**2 + pLR)[..., None],
+            (uLR * (ELR + pLR))[..., None],
+            (rLR * uLR)[..., None] * YLR,
+        ),
+        axis=2,
+    )
+
+    WLR = np.concatenate(
+        (
+            (rLR * uLR)[..., None],
+            ELR[..., None],
+            rLR[..., None] * YLR,
+        ),
+        axis=2,
+    )
+
+    sLR = np.empty((2, nFaces))
+    rBar = 0.5 * (rLR[0] + rLR[1])
+    aBar = 0.5 * (aLR[0] + aLR[1])
+    pStar = 0.5 * (pLR[0] + pLR[1]) - 0.5 * (uLR[1] - uLR[0]) * rBar * aBar
+    qLR = np.ones((2, nFaces))
+    for K in range(nLR):
+        idx = np.where(pStar > pLR[K])[0]
+        qLR[K, idx] = np.sqrt(
+            1.0
+            + (gamma[idx] + 1.0) / (2.0 * gamma[idx]) * (pStar[idx] / pLR[K, idx] - 1.0)
+        )
+    sLR[0] = uLR[0] - aLR[0] * qLR[0]
+    sLR[1] = uLR[1] + aLR[1] * qLR[1]
+
+    sM = (
+        pLR[0]
+        - pLR[1]
+        - rLR[0] * uLR[0] * (sLR[0] - uLR[0])
+        + rLR[1] * uLR[1] * (sLR[1] - uLR[1])
+    ) / (rLR[1] * (sLR[1] - uLR[1]) - rLR[0] * (sLR[0] - uLR[0]))
+    pM = rLR[1] * (uLR[1] - sLR[1]) * (uLR[1] - sM) + pLR[1]
+
+    WMLR = (
+        np.concatenate(
+            (
+                ((sLR - uLR) * rLR * uLR + (pM[None, :] - pLR))[..., None],
+                ((sLR - uLR) * ELR - pLR * uLR + (pM * sM)[None, :])[..., None],
+                ((sLR - uLR) * rLR)[..., None] * YLR,
+            ),
+            axis=2,
+        )
+        / (sLR - sM[None, :])[..., None]
+    )
+
+    sminus = np.minimum(sLR[0], 0.0)
+    splus = np.maximum(sLR[1], 0.0)
+
+    return 0.5 * (1.0 + np.sign(sM)[..., None]) * (
+        FLR[0] + sminus[:, None] * (WMLR[0] - WLR[0])
+    ) + 0.5 * (1.0 - np.sign(sM)[..., None]) * (
+        FLR[1] + splus[:, None] * (WMLR[1] - WLR[1])
+    )
 
 
 class InviscidFlux(RightHandSide):

--- a/src/stanshock/physics/cantera_interface.py
+++ b/src/stanshock/physics/cantera_interface.py
@@ -131,7 +131,7 @@ class CanteraInterface(FluidPhysics):
         gamma = state.gamma
         if gamma is None:
             gamma = self.get_gamma(state)
-        state.sound_speed = np.sqrt(gamma * self.sol.P / self.sol.density)
+        state.sound_speed = np.sqrt(gamma * state.pressure / state.density)
         return state.sound_speed
 
     def get_mass_diffusivity(self, state: FluidState) -> Array:

--- a/src/stanshock/processing/initialize.py
+++ b/src/stanshock/processing/initialize.py
@@ -6,6 +6,7 @@ import numpy as np
 from stanshock.physics.fluid_base import FluidPhysics, FluidState
 from stanshock.system.backend import Array
 from stanshock.system.geometry import Geometry
+from stanshock.utils.isentropic import mach_from_area_ratio, property_ratios
 
 
 def smoothing_function(
@@ -195,3 +196,208 @@ def initialize_diffuse_interface(
         gamma=gamma,
         composition=composition,
     )
+
+
+def initialize_isentropic(
+    geometry: Geometry,
+    physics: FluidPhysics,
+    inflow_state: ct.Solution,
+    throat_area: float | None = None,
+    subsonic_inflow: bool = True,
+    subsonic_outflow: bool = False,
+) -> FluidState:
+    """
+    Applies isentropic flow relations to set initial conditions.
+
+    Note that this formulation is only valid for a flow with constant specific
+    heat ratio. It could be extended for non-ideal gas equations of state
+    """
+    # Get cross-sectional area from the geometry
+    x = geometry.x
+    area = geometry.area(0.0, x)
+    assert isinstance(area, np.ndarray)
+
+    # If throat area is not given, assume choked flow
+    min_area: float = area.min()
+    throat_area = min_area if throat_area is None else min(min_area, throat_area)
+
+    # Get inflow properties for the gas
+    g = inflow_state.cp / inflow_state.cv
+    P_in = inflow_state.P
+    rho_in = inflow_state.density_mass
+    composition = physics.get_composition(inflow_state.Y)
+
+    # Get the permissible subsonic and supersonic Mach numbers throughout
+    # the domain from the area ratio
+    area_ratio = area / throat_area
+    area_ratio_min = area_ratio.min()
+    choked_flow = area_ratio_min <= 1.0
+    if choked_flow:
+        # Adjust throat area based on choked flow - will affect requested boundary conditions
+        area_ratio /= area_ratio_min
+        throat_area /= area_ratio_min
+    else:
+        subsonic_outflow = subsonic_inflow
+
+    # Solve for allowable Mach numbers corresponding to given area ratio
+    subsonic_mach: Array = mach_from_area_ratio(area_ratio, g, subsonic=True)
+    supersonic_mach: Array = mach_from_area_ratio(area_ratio, g, subsonic=False)
+
+    # Combine into one mach profile
+    mach = subsonic_mach
+    if subsonic_inflow != subsonic_outflow:
+        idx = np.argmin(area_ratio)
+
+        if subsonic_inflow:
+            mach[idx:] = supersonic_mach[idx:]
+        else:
+            mach[:idx] = supersonic_mach[:idx]
+    elif not subsonic_inflow and not subsonic_outflow:
+        mach = supersonic_mach
+
+    # Get stagnation properties based on inflow
+    _, inflow_Pratio, inflow_rhoratio = property_ratios(mach[0], g)
+
+    # Get properties throughout
+    _, Pratio_profile, rhoratio_profile = property_ratios(mach, g)
+
+    n = geometry.n
+    state = FluidState(
+        shape=(n,),
+        pressure=P_in / inflow_Pratio * Pratio_profile,
+        density=rho_in / inflow_rhoratio * rhoratio_profile,
+        gamma=g * np.ones((n,)),
+        composition=np.broadcast_to(composition, (n, composition.shape[0])).copy(),
+    )
+    state.velocity = mach * physics.get_sound_speed(state)
+
+    return state
+
+
+def initialize_isentropic_total(
+    geometry: Geometry,
+    physics: FluidPhysics,
+    total_state: ct.Solution,
+    inflow_mach: float | None = None,
+    inflow_pressure: float | None = None,
+    outflow_pressure: float | None = None,
+    throat_area: float | None = None,
+    subsonic_inflow: bool = True,
+    subsonic_outflow: bool = True,
+) -> FluidState:
+    """
+    Applies isentropic flow relations to set initial conditions.
+
+    Note that this formulation is only valid for a flow with constant specific
+    heat ratio. It could be extended for non-ideal gas equations of state
+    """
+    # Get cross-sectional area from the geometry
+    x = geometry.x
+    area = geometry.area(0.0, x)
+    assert isinstance(area, np.ndarray)
+
+    # Get stagnation properties for the gas
+    g = total_state.cp / total_state.cv
+    Pt = total_state.P
+    Tt = total_state.T
+    rhot = total_state.density_mass
+    composition = physics.get_composition(total_state.Y)
+
+    # Determine throat area from given inputs
+    inputs_done = False
+    too_many_inputs_prefix = "Too many inputs specified. "
+    error_msg = "Must specify one of inflow_velocity, inflow_pressure, outflow_pressure, or throat area."
+
+    if throat_area is not None:
+        inputs_done = True
+
+    if inflow_mach is not None:
+        Tratio, _, _ = property_ratios(inflow_mach, g)
+        inflow_area = area[0]
+        throat_area = (
+            inflow_area
+            * inflow_mach
+            * (2.0 * Tratio / (g + 1)) ** (0.5 * (g + 1) / (g - 1))
+        )
+        if inputs_done:
+            raise ValueError(too_many_inputs_prefix + error_msg)
+        inputs_done = True
+
+    if inflow_pressure is not None:
+        Pratio = inflow_pressure / Pt
+        Tratio = Pratio ** ((g - 1.0) / g)
+        inflow_mach = np.sqrt(2.0 * (1.0 / Tratio - 1.0) / (g - 1.0))
+        inflow_area = area[0]
+        throat_area = (
+            inflow_area
+            * inflow_mach
+            * (2.0 * Tratio / (g + 1)) ** (0.5 * (g + 1) / (g - 1))
+        )
+        if inputs_done:
+            raise ValueError(too_many_inputs_prefix + error_msg)
+        inputs_done = True
+
+    if outflow_pressure is not None:
+        Pratio = outflow_pressure / Pt
+        Tratio = Pratio ** ((g - 1.0) / g)
+        outflow_mach = np.sqrt(2.0 * (1.0 / Tratio - 1.0) / (g - 1.0))
+        outflow_area = area[-1]
+        throat_area = (
+            outflow_area
+            * outflow_mach
+            * (2.0 * Tratio / (g + 1)) ** (0.5 * (g + 1) / (g - 1))
+        )
+        if inputs_done:
+            raise ValueError(too_many_inputs_prefix + error_msg)
+        inputs_done = True
+
+    if not inputs_done:
+        raise ValueError(error_msg)
+
+    # Get the permissible subsonic and supersonic Mach numbers throughout
+    # the domain from the area ratio
+    assert isinstance(throat_area, float)
+    area_ratio = area / throat_area
+
+    # Check if flow is choked
+    area_ratio_min = area_ratio.min()
+    choked_flow = area_ratio_min <= 1.0
+    if choked_flow:
+        # Adjust throat area based on choked flow - will affect requested boundary conditions
+        area_ratio /= area_ratio_min
+        throat_area /= area_ratio_min
+
+    # Solve for allowable Mach numbers corresponding to given area ratio
+    subsonic_mach: Array = mach_from_area_ratio(area_ratio, g, subsonic=True)
+    supersonic_mach: Array = mach_from_area_ratio(area_ratio, g, subsonic=False)
+
+    # Combine into one mach profile
+    mach = subsonic_mach
+    if subsonic_inflow != subsonic_outflow:
+        if not choked_flow:
+            msg = f"Subsonic-supersonic transition requested, but flow is not choked. {area_ratio_min = }"
+            raise ValueError(msg)
+        idx = np.argmin(area_ratio)
+
+        if subsonic_inflow:
+            mach[idx:] = supersonic_mach[idx:]
+        else:
+            mach[:idx] = supersonic_mach[:idx]
+    elif not subsonic_inflow and not subsonic_outflow:
+        mach = supersonic_mach
+
+    # Get properties throughout
+    Tratio_profile, Pratio_profile, rhoratio_profile = property_ratios(mach, g)
+
+    n = geometry.n
+    state = FluidState(
+        shape=(n,),
+        temperature=Tt * Tratio_profile,
+        pressure=Pt * Pratio_profile,
+        density=rhot * rhoratio_profile,
+        gamma=g * np.ones((n,)),
+        composition=np.broadcast_to(composition, (n, composition.shape[0])).copy(),
+    )
+    state.velocity = mach * physics.get_sound_speed(state)
+
+    return state

--- a/src/stanshock/processing/initialize.py
+++ b/src/stanshock/processing/initialize.py
@@ -212,28 +212,26 @@ def initialize_isentropic(
     Note that this formulation is only valid for a flow with constant specific
     heat ratio. It could be extended for non-ideal gas equations of state
     """
-    # Get cross-sectional area from the geometry
-    x = geometry.x
-    area = geometry.area(0.0, x)
-    assert isinstance(area, np.ndarray)
-
-    # If throat area is not given, assume choked flow
-    min_area: float = area.min()
-    throat_area = min_area if throat_area is None else min(min_area, throat_area)
-
     # Get inflow properties for the gas
     g = inflow_state.cp / inflow_state.cv
     P_in = inflow_state.P
     rho_in = inflow_state.density_mass
     composition = physics.get_composition(inflow_state.Y)
 
-    # Get the permissible subsonic and supersonic Mach numbers throughout
-    # the domain from the area ratio
+    # Get cross-sectional area from the geometry
+    area = geometry.area(0.0, geometry.xf)
+    assert isinstance(area, np.ndarray)
+
+    # If throat area is not given, assume choked flow
+    min_area: float = area.min()
+    throat_area = min_area if throat_area is None else min(min_area, throat_area)
     area_ratio = area / throat_area
+    inflow_area_ratio = area_ratio[0]
     area_ratio_min = area_ratio.min()
-    choked_flow = area_ratio_min <= 1.0
+    choked_flow = area_ratio_min < 1.0
     if choked_flow:
         # Adjust throat area based on choked flow - will affect requested boundary conditions
+        inflow_area_ratio /= area_ratio_min
         area_ratio /= area_ratio_min
         throat_area /= area_ratio_min
     elif subsonic_inflow != subsonic_outflow:
@@ -241,6 +239,10 @@ def initialize_isentropic(
             "Warning: Subsonic/supersonic transition requested, but flow may not be choked.\n"
             + f"Minimum area ratio = {area_ratio_min}."
         )
+
+    # Get area ratios at cell centers
+    area = geometry.area(0.0, geometry.xc)
+    area_ratio = area / throat_area
 
     # Solve for allowable Mach numbers corresponding to given area ratio
     subsonic_mach: Array = mach_from_area_ratio(area_ratio, g, subsonic=True)
@@ -259,12 +261,15 @@ def initialize_isentropic(
         mach = supersonic_mach
 
     # Get stagnation properties based on inflow
-    _, inflow_Pratio, inflow_rhoratio = property_ratios(mach[0], g)
+    inflow_mach: float = mach_from_area_ratio(
+        inflow_area_ratio, g, subsonic=subsonic_inflow
+    )[0]
+    _, inflow_Pratio, inflow_rhoratio = property_ratios(inflow_mach, g)
 
     # Get properties throughout
     _, Pratio_profile, rhoratio_profile = property_ratios(mach, g)
 
-    n = geometry.n
+    n = geometry.n_cells
     state = FluidState(
         shape=(n,),
         pressure=P_in / inflow_Pratio * Pratio_profile,
@@ -273,6 +278,7 @@ def initialize_isentropic(
         composition=np.broadcast_to(composition, (n, composition.shape[0])).copy(),
     )
     state.velocity = mach * physics.get_sound_speed(state)
+    state.temperature = physics.get_temperature(state)
 
     return state
 

--- a/src/stanshock/processing/initialize.py
+++ b/src/stanshock/processing/initialize.py
@@ -236,8 +236,11 @@ def initialize_isentropic(
         # Adjust throat area based on choked flow - will affect requested boundary conditions
         area_ratio /= area_ratio_min
         throat_area /= area_ratio_min
-    else:
-        subsonic_outflow = subsonic_inflow
+    elif subsonic_inflow != subsonic_outflow:
+        print(
+            "Warning: Subsonic/supersonic transition requested, but flow may not be choked.\n"
+            + f"Minimum area ratio = {area_ratio_min}."
+        )
 
     # Solve for allowable Mach numbers corresponding to given area ratio
     subsonic_mach: Array = mach_from_area_ratio(area_ratio, g, subsonic=True)
@@ -249,7 +252,7 @@ def initialize_isentropic(
         idx = np.argmin(area_ratio)
 
         if subsonic_inflow:
-            mach[idx:] = supersonic_mach[idx:]
+            mach[idx + 1 :] = supersonic_mach[idx + 1 :]
         else:
             mach[:idx] = supersonic_mach[:idx]
     elif not subsonic_inflow and not subsonic_outflow:

--- a/src/stanshock/system/geometry.py
+++ b/src/stanshock/system/geometry.py
@@ -198,6 +198,9 @@ class Cylinder(Geometry):
         n_ghost_layers: int = 0,
     ) -> None:
         self.xf: Array = xf
+        if d_inner is None:
+            d_inner = 0.0
+
         # Set up functional form of inner and outer diameters
         self.d_outer: SpatioTemporalFunction = self.to_spatiotemporal(value=d_outer)
         self.d_inner: SpatioTemporalFunction = self.to_spatiotemporal(value=d_inner)

--- a/src/stanshock/utils/isentropic.py
+++ b/src/stanshock/utils/isentropic.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import overload
+
+import numpy as np
+from scipy.optimize import minimize_scalar
+from scipy.optimize.elementwise import find_root
+
+from stanshock.system.backend import Array
+
+
+@overload
+def area_ratio_from_mach(mach: float, g: float) -> float: ...
+@overload
+def area_ratio_from_mach(mach: Array, g: float) -> Array: ...
+def area_ratio_from_mach(mach: Array | float, g: float) -> Array | float:
+    exponent = (g + 1) / (2 * (g - 1))
+    return ((1 + 0.5 * (g - 1) * mach**2) / (0.5 * (g + 1))) ** exponent / np.maximum(
+        mach, 1.0e-16
+    )
+
+
+def mach_from_area_ratio(area_ratio: Array, g: float, subsonic: bool = True) -> Array:
+    """Find Mach number corresponding to given area ratio, element-wise."""
+
+    def residual(mach: Array, g: float, area_ratio_target: Array | float) -> Array:
+        return area_ratio_from_mach(mach, g) - area_ratio_target
+
+    bracket = ([1e-5], [1.0]) if subsonic else ([1.0], [10.0])
+    mach: Array = find_root(residual, bracket, args=(g, area_ratio)).x
+
+    # Because the element-wise root solve tends to fail near Ma = 1,
+    # perform a minimization to fix any NaN values:
+    def residual2(mach: float, g: float, area_ratio_target: float) -> float:
+        return np.abs(area_ratio_from_mach(mach, g) - area_ratio_target)
+
+    for i in np.where(np.isnan(mach))[0]:
+        mach[i] = minimize_scalar(
+            residual2, args=(g, area_ratio[i]), bracket=(0.8, 1.2)
+        ).x
+
+    return mach
+
+
+@overload
+def property_ratios(mach: float, g: float) -> tuple[float, float, float]: ...
+@overload
+def property_ratios(mach: Array, g: Array | float) -> tuple[Array, Array, Array]: ...
+def property_ratios(
+    mach: Array | float, g: Array | float
+) -> tuple[Array | float, Array | float, Array | float]:
+    """Ratios of static temperature, pressure, and density to their total (stagnation) values."""
+    temperature_ratio = 1.0 / (1.0 + 0.5 * (g - 1) * mach**2)
+    pressure_ratio = temperature_ratio ** (g / (g - 1))
+    density_ratio = temperature_ratio ** (1 / (g - 1))
+
+    return temperature_ratio, pressure_ratio, density_ratio

--- a/src/stanshock/utils/isentropic.py
+++ b/src/stanshock/utils/isentropic.py
@@ -34,10 +34,9 @@ def mach_from_area_ratio(area_ratio: Array, g: float, subsonic: bool = True) -> 
     def residual2(mach: float, g: float, area_ratio_target: float) -> float:
         return np.abs(area_ratio_from_mach(mach, g) - area_ratio_target)
 
+    bracket2 = (0.8, 1.0) if subsonic else (1.0, 1.2)
     for i in np.where(np.isnan(mach))[0]:
-        mach[i] = minimize_scalar(
-            residual2, args=(g, area_ratio[i]), bracket=(0.8, 1.2)
-        ).x
+        mach[i] = minimize_scalar(residual2, args=(g, area_ratio[i]), bracket=bracket2).x
 
     return mach
 

--- a/src/stanshock/utils/isentropic.py
+++ b/src/stanshock/utils/isentropic.py
@@ -36,7 +36,9 @@ def mach_from_area_ratio(area_ratio: Array, g: float, subsonic: bool = True) -> 
 
     bracket2 = (0.8, 1.0) if subsonic else (1.0, 1.2)
     for i in np.where(np.isnan(mach))[0]:
-        mach[i] = minimize_scalar(residual2, args=(g, area_ratio[i]), bracket=bracket2).x
+        mach[i] = minimize_scalar(
+            residual2, args=(g, area_ratio[i]), bracket=bracket2
+        ).x
 
     return mach
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from abc import ABC
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Generic, TypeVar
+
+import numpy as np
+import pytest
+from cantera import Solution
+
+from stanshock.components.combustor import Combustor
+from stanshock.numerics.boundary_conditions import Inflow
+from stanshock.physics.cantera_interface import CanteraInterface
+from stanshock.physics.fluid_base import FluidPhysics
+from stanshock.physics.thermotable import ThermoTable
+from stanshock.system.backend import Array
+from stanshock.system.geometry import Geometry, initialize_geometry
+from stanshock.utils.isentropic import mach_from_area_ratio
+
+T = TypeVar("T")
+
+
+class FixtureRequest(pytest.FixtureRequest, Generic[T], ABC):
+    param: T
+
+
+# Command line option for enabling slow tests
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: Iterable[pytest.Item]
+) -> None:
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow: pytest.MarkDecorator = pytest.mark.skip(
+        reason="need --runslow option to run"
+    )
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
+
+# Reusable fixtures for each piece of a full case setup
+# @pytest.fixture(params=[21, 201], ids=["coarse", "fine"], scope="session")
+# @pytest.fixture(params=[21], ids=["coarse"], scope="session")
+@pytest.fixture(params=[201], ids=["fine"], scope="session")
+def num_points(request: FixtureRequest[int]) -> int:
+    return request.param
+
+
+@pytest.fixture(params=[2.0, 10.0], scope="session")
+def area_range(request: FixtureRequest[float], scope="session") -> float:
+    # Ratio of the largest to smallest flow area
+    return request.param
+
+
+@pytest.fixture(
+    params=["constant", "converging", "diverging", "converging-diverging"],
+    scope="session",
+)
+def area(request: FixtureRequest[str], area_range: float, num_points: int) -> Array:
+    area: Array = np.ones((num_points,), dtype=np.float64)
+    if request.param == "converging":
+        area = np.linspace(area_range, 1.0, num_points, dtype=np.float64)
+    elif request.param == "diverging":
+        area = np.linspace(1.0, area_range, num_points, dtype=np.float64)
+    elif request.param == "converging-diverging":
+        scale = 5.0
+        shift = 2.0
+        x = np.linspace(-scale, scale, num_points, dtype=np.float64)
+        area = np.tanh(x - shift) - np.tanh(x + shift) + 2.0
+        area_min = np.tanh(-shift) - np.tanh(shift) + 2.0
+        area_max = np.tanh(scale - shift) - np.tanh(scale + shift) + 2.0
+        area = (area - area_min) / (area_max - area_min) * (
+            1.0 - 1.0 / area_range
+        ) + 1.0 / area_range
+    return area
+
+
+@pytest.fixture(
+    params=["box", "cylinder"],
+    scope="session",
+)
+def geometry(request: FixtureRequest[str], area: Array) -> Geometry:
+    num_points = area.shape[0]
+    x = np.linspace(0.0, 10.0, num_points, dtype=np.float64)
+
+    if request.param == "box":
+        geometry: Geometry = initialize_geometry(x=x, h=area)
+    elif request.param == "cylinder":
+        geometry = initialize_geometry(x=x, d_outer=2.0 * np.sqrt(area / np.pi))
+    else:
+        geometry = initialize_geometry(x=x, area=area)
+    return geometry
+
+
+@pytest.fixture(
+    params=["HeliumArgon.yaml"],
+    ids=["HeAr"],
+    scope="session",
+)
+def mechanism(request: FixtureRequest[str]) -> Path:
+    return (
+        Path(__file__).resolve().parent / ".." / "data" / "mechanisms" / request.param
+    )
+
+
+@pytest.fixture(scope="session")
+def gas(mechanism: Path) -> Solution:
+    gas = Solution(mechanism)
+    nsp = gas.n_species
+    gas.TPY = 3000.0, 30e6, np.ones((nsp,)) / nsp
+    return gas
+
+
+@pytest.fixture(
+    params=[ThermoTable, CanteraInterface],
+    scope="session",
+)
+def fluid_physics(
+    request: FixtureRequest[type[FluidPhysics]], gas: Solution
+) -> FluidPhysics:
+    return request.param(gas)
+
+
+# Set inflow boundary condition for a choked flow with area ratio 10.0
+@pytest.fixture(scope="session")
+def inflow_bc(gas: Solution) -> Inflow:
+    g: float = gas.cp / gas.cv
+    area_ratio = np.array([10.0])
+
+    # Get subsonic result
+    inflow_mach: float = mach_from_area_ratio(area_ratio, g, subsonic=True)[0]
+
+    # Get corresponding inflow velocity and return inflow definition
+    inflow_velocity = inflow_mach * gas.sound_speed
+
+    return Inflow(reference_state=(gas.density, inflow_velocity, gas.P, gas.Y))
+
+
+@pytest.fixture(scope="session")
+def isentropic_flow(
+    gas: Solution, fluid_physics: FluidPhysics, geometry: Geometry, inflow_bc: Inflow
+) -> Combustor:
+    # Get throat area at which flow will choke
+    throat_area: float = geometry.area(0.0, geometry.x[0]) / 10.0
+
+    # Set up simulation object
+    return Combustor(
+        boundary_conditions=[inflow_bc, "outflow"],
+        geometry=geometry,
+        initialization=("isentropic", gas, throat_area),
+        physics=fluid_physics,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from cantera import Solution
 
 from stanshock.components.combustor import Combustor
-from stanshock.numerics.boundary_conditions import FreezeCells, Inflow
+from stanshock.numerics.boundary_conditions import FreezeCells, SpecifiedFace
 from stanshock.physics.cantera_interface import CanteraInterface
 from stanshock.physics.fluid_base import FluidPhysics
 from stanshock.physics.thermotable import ThermoTable
@@ -154,7 +154,7 @@ def fluid_physics(
 
 # Set inflow boundary condition for a choked flow with area ratio 10.0
 @pytest.fixture(scope="session")
-def inflow_bc(gas: Solution) -> Inflow:
+def inflow_bc(gas: Solution) -> SpecifiedFace:
     nsp = gas.n_species
     gas.TPY = 3000.0, 30e6, np.ones((nsp,)) / nsp
     g: float = gas.cp / gas.cv
@@ -166,16 +166,22 @@ def inflow_bc(gas: Solution) -> Inflow:
     # Get corresponding inflow velocity and return inflow definition
     inflow_velocity = inflow_mach * gas.sound_speed
 
-    return Inflow(reference_state=(gas.density, inflow_velocity, gas.P, gas.Y))
+    return SpecifiedFace(reference_state=(gas.density, inflow_velocity, gas.P, gas.Y))
 
 
 @pytest.fixture(scope="session")
 def isentropic_flow(
-    gas: Solution, fluid_physics: FluidPhysics, geometry: Geometry, inflow_bc: Inflow
+    gas: Solution,
+    fluid_physics: FluidPhysics,
+    geometry: Geometry,
 ) -> Combustor:
     # Reinitialize Solution object to inflow conditions
     nsp = gas.n_species
     gas.TPY = 3000.0, 30e6, np.ones((nsp,)) / nsp
+    bcs = {
+        "left": FreezeCells(location="left"),
+        "right": FreezeCells(location="right"),
+    }
 
     # Get throat area at which flow will choke
     area = geometry.area(0.0, geometry.xf)
@@ -184,7 +190,7 @@ def isentropic_flow(
 
     # Set up simulation object
     return Combustor(
-        boundary_conditions=[inflow_bc, FreezeCells(location="right"), "outflow"],
+        boundary_conditions=bcs,
         geometry=geometry,
         initialization=("isentropic", gas, throat_area, True, subsonic_outflow),
         physics=fluid_physics,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,16 @@ import pytest
 from cantera import Solution
 
 from stanshock.components.combustor import Combustor
-from stanshock.numerics.boundary_conditions import Inflow
+from stanshock.numerics.boundary_conditions import FreezeCells, Inflow
 from stanshock.physics.cantera_interface import CanteraInterface
 from stanshock.physics.fluid_base import FluidPhysics
 from stanshock.physics.thermotable import ThermoTable
 from stanshock.system.backend import Array
-from stanshock.system.geometry import Geometry, initialize_geometry
+from stanshock.system.geometry import (
+    Geometry,
+    SpatioTemporalFunction,
+    initialize_geometry,
+)
 from stanshock.utils.isentropic import mach_from_area_ratio
 
 T = TypeVar("T")
@@ -51,56 +55,74 @@ def pytest_collection_modifyitems(
 
 
 # Reusable fixtures for each piece of a full case setup
-# @pytest.fixture(params=[21, 201], ids=["coarse", "fine"], scope="session")
-# @pytest.fixture(params=[21], ids=["coarse"], scope="session")
-@pytest.fixture(params=[201], ids=["fine"], scope="session")
+@pytest.fixture(params=[401, 1001], ids=["coarse", "fine"], scope="session")
 def num_points(request: FixtureRequest[int]) -> int:
     return request.param
 
 
-@pytest.fixture(params=[2.0, 10.0], scope="session")
-def area_range(request: FixtureRequest[float], scope="session") -> float:
-    # Ratio of the largest to smallest flow area
-    return request.param
+choking_area_ratio = 10.0
 
 
 @pytest.fixture(
     params=["constant", "converging", "diverging", "converging-diverging"],
     scope="session",
 )
-def area(request: FixtureRequest[str], area_range: float, num_points: int) -> Array:
-    area: Array = np.ones((num_points,), dtype=np.float64)
+def area(request: FixtureRequest[str]) -> SpatioTemporalFunction:
     if request.param == "converging":
-        area = np.linspace(area_range, 1.0, num_points, dtype=np.float64)
+        area_range = 4.0
+
+        def area_function(_t: float, x: Array) -> Array:
+            return 1.0 + (1.0 - 0.1 * x) * (area_range - 1.0)
+
     elif request.param == "diverging":
-        area = np.linspace(1.0, area_range, num_points, dtype=np.float64)
+        area_range = 2.0
+
+        def area_function(_t: float, x: Array) -> Array:
+            return 1.0 + 0.1 * x * (area_range - 1.0)
+
     elif request.param == "converging-diverging":
-        scale = 5.0
-        shift = 2.0
-        x = np.linspace(-scale, scale, num_points, dtype=np.float64)
-        area = np.tanh(x - shift) - np.tanh(x + shift) + 2.0
-        area_min = np.tanh(-shift) - np.tanh(shift) + 2.0
-        area_max = np.tanh(scale - shift) - np.tanh(scale + shift) + 2.0
-        area = (area - area_min) / (area_max - area_min) * (
-            1.0 - 1.0 / area_range
-        ) + 1.0 / area_range
-    return area
+        area_range = choking_area_ratio
+
+        def area_function(_t: float, x: Array) -> Array:
+            scale = 5.0
+            shift = 2.0
+
+            x = x - scale
+
+            area = np.tanh(x - shift) - np.tanh(x + shift) + 2.0
+            area_min = np.tanh(-shift) - np.tanh(shift) + 2.0
+            area_max = np.tanh(scale - shift) - np.tanh(scale + shift) + 2.0
+            return (area - area_min) / (area_max - area_min) * (
+                1.0 - 1.0 / area_range
+            ) + 1.0 / area_range
+    else:
+
+        def area_function(_t: float, x: Array) -> Array:
+            return np.ones_like(x)
+
+    return area_function
 
 
 @pytest.fixture(
     params=["box", "cylinder"],
     scope="session",
 )
-def geometry(request: FixtureRequest[str], area: Array) -> Geometry:
-    num_points = area.shape[0]
-    x = np.linspace(0.0, 10.0, num_points, dtype=np.float64)
+def geometry(
+    request: FixtureRequest[str], area: SpatioTemporalFunction, num_points: int
+) -> Geometry:
+    xf = np.linspace(0.0, 10.0, num_points, dtype=np.float64)
 
     if request.param == "box":
-        geometry: Geometry = initialize_geometry(x=x, h=area)
+        geometry: Geometry = initialize_geometry(xf=xf, h=area)
+
     elif request.param == "cylinder":
-        geometry = initialize_geometry(x=x, d_outer=2.0 * np.sqrt(area / np.pi))
+
+        def d_outer(t: float, x: Array) -> Array:
+            return 2.0 * np.sqrt(area(t, x) / np.pi)
+
+        geometry = initialize_geometry(xf=xf, d_outer=d_outer)
     else:
-        geometry = initialize_geometry(x=x, area=area)
+        geometry = initialize_geometry(xf=xf, area=area)
     return geometry
 
 
@@ -117,10 +139,7 @@ def mechanism(request: FixtureRequest[str]) -> Path:
 
 @pytest.fixture(scope="session")
 def gas(mechanism: Path) -> Solution:
-    gas = Solution(mechanism)
-    nsp = gas.n_species
-    gas.TPY = 3000.0, 30e6, np.ones((nsp,)) / nsp
-    return gas
+    return Solution(mechanism)
 
 
 @pytest.fixture(
@@ -136,8 +155,10 @@ def fluid_physics(
 # Set inflow boundary condition for a choked flow with area ratio 10.0
 @pytest.fixture(scope="session")
 def inflow_bc(gas: Solution) -> Inflow:
+    nsp = gas.n_species
+    gas.TPY = 3000.0, 30e6, np.ones((nsp,)) / nsp
     g: float = gas.cp / gas.cv
-    area_ratio = np.array([10.0])
+    area_ratio = np.array([choking_area_ratio])
 
     # Get subsonic result
     inflow_mach: float = mach_from_area_ratio(area_ratio, g, subsonic=True)[0]
@@ -152,13 +173,19 @@ def inflow_bc(gas: Solution) -> Inflow:
 def isentropic_flow(
     gas: Solution, fluid_physics: FluidPhysics, geometry: Geometry, inflow_bc: Inflow
 ) -> Combustor:
+    # Reinitialize Solution object to inflow conditions
+    nsp = gas.n_species
+    gas.TPY = 3000.0, 30e6, np.ones((nsp,)) / nsp
+
     # Get throat area at which flow will choke
-    throat_area: float = geometry.area(0.0, geometry.x[0]) / 10.0
+    area = geometry.area(0.0, geometry.xf)
+    throat_area: float = area[0] / choking_area_ratio
+    subsonic_outflow = area.min() - throat_area > 1e-3
 
     # Set up simulation object
     return Combustor(
-        boundary_conditions=[inflow_bc, "outflow"],
+        boundary_conditions=[inflow_bc, FreezeCells(location="right"), "outflow"],
         geometry=geometry,
-        initialization=("isentropic", gas, throat_area),
+        initialization=("isentropic", gas, throat_area, True, subsonic_outflow),
         physics=fluid_physics,
     )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -14,6 +14,7 @@ _directory_prefix = Path("tests/resources")
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Skip validation tests.")
 def test_validation_case1():
     results = case1.main(plot_results=False, results_location=None)
@@ -21,6 +22,7 @@ def test_validation_case1():
     assert all(np.allclose(results[name], baseline[name]) for name in baseline)
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Skip validation tests.")
 def test_validation_case2():
     results = case2.main(plot_results=False, results_location=None)
@@ -28,6 +30,7 @@ def test_validation_case2():
     assert all(np.allclose(results[name], baseline[name]) for name in baseline)
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Skip validation tests.")
 def test_validation_case3():
     results = case3.main(plot_results=False, results_location=None)
@@ -35,6 +38,7 @@ def test_validation_case3():
     assert all(np.allclose(results[name], baseline[name]) for name in baseline)
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Skip validation tests.")
 def test_validation_case4():
     results = case4.main(plot_results=False, results_location=None)
@@ -42,6 +46,7 @@ def test_validation_case4():
     assert all(np.allclose(results[name], baseline[name]) for name in baseline)
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Skip examples.")
 def test_laminar_flame():
     results = laminar_flame.main(
@@ -51,6 +56,7 @@ def test_laminar_flame():
     assert all(np.allclose(results[name], baseline[name]) for name in baseline)
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Skip examples.")
 def test_optimization():
     results = optimization.main(plot_results=False, results_location=None)

--- a/tests/test_flux.py
+++ b/tests/test_flux.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
+from stanshock.components.combustor import Combustor
 from stanshock.numerics.inviscid_flux import hllc_flux, lax_friedrichs_flux
 
 lax_friedrichs_flux = lax_friedrichs_flux.__wrapped__  # unwrap for coverage testing
@@ -50,3 +52,22 @@ def test_hllc_predicts_constant_flux():
     expected_flux = np.array([r * u**2 + p, H * u, r * Y * u])[np.newaxis, ...]
     expected_flux = np.repeat(expected_flux, num_faces, axis=0)
     assert np.allclose(flux, expected_flux)
+
+
+def test_isentropic_flow_relations(isentropic_flow: Combustor) -> None:
+    # Get initial state from given solution
+    t = isentropic_flow.t
+    state = isentropic_flow.state
+    physics = isentropic_flow.physics
+    idx = isentropic_flow.idx_cells
+    y = isentropic_flow.physics.primitive_to_conservative(state)
+    gamma_star = state.gamma
+
+    # Get source terms from inviscid flux
+    source_flux = isentropic_flow.inviscid_flux.source(t, y, physics, gamma_star)
+
+    # Get source terms from area change
+    source_area = isentropic_flow.area_change.source(
+        t, y[idx], physics, gamma_star[idx], 1.0
+    )
+    assert source_flux[3:-3] == pytest.approx(-source_area[3:-3], abs=1e-3)

--- a/tests/test_flux.py
+++ b/tests/test_flux.py
@@ -59,15 +59,16 @@ def test_isentropic_flow_relations(isentropic_flow: Combustor) -> None:
     t = isentropic_flow.t
     state = isentropic_flow.state
     physics = isentropic_flow.physics
-    idx = isentropic_flow.idx_cells
     y = isentropic_flow.physics.primitive_to_conservative(state)
-    gamma_star = state.gamma
+    gamma_star, e0_star = isentropic_flow.physics.get_double_flux_variables(state)
 
     # Get source terms from inviscid flux
-    source_flux = isentropic_flow.inviscid_flux.source(t, y, physics, gamma_star)
+    source_flux = isentropic_flow.inviscid_flux.source(
+        t, y, physics, gamma_star, e0_star
+    )
 
     # Get source terms from area change
     source_area = isentropic_flow.area_change.source(
-        t, y[idx], physics, gamma_star[idx], 1.0
+        t, y, physics, gamma_star, e0_star, 1.0
     )
-    assert source_flux[3:-3] == pytest.approx(-source_area[3:-3], abs=1e-3)
+    assert source_flux[3:-3] == pytest.approx(-source_area[3:-3], rel=1e-3)

--- a/tests/test_flux.py
+++ b/tests/test_flux.py
@@ -71,4 +71,4 @@ def test_isentropic_flow_relations(isentropic_flow: Combustor) -> None:
     source_area = isentropic_flow.area_change.source(
         t, y, physics, gamma_star, e0_star, 1.0
     )
-    assert source_flux[3:-3] == pytest.approx(-source_area[3:-3], rel=1e-3)
+    assert source_flux == pytest.approx(-source_area, rel=1e-3)


### PR DESCRIPTION
This addresses a large portion of #55 by adding tests which verify the isentropic flow relations. This includes a new initialization routine which sets flow properties based on the isentropic flow relations (valid for constant-gamma flow), and some parameterized unit tests which verify that the predicted inviscid flux values are approximately equal in magnitude and opposite in sign to the area change source terms across various geometries.

Some additional minor changes include adding a vectorized implementation of the HLLC flux and adding `slow` markers to the `test_examples` and a `runslow` option to the `pytest` configuration. Now, the default behavior when running `pytest` is to skip the `examples` tests (which don't currently pass anyways), and running `pytest --runslow` will reactivate them.