### PR TITLE
[#67] Update type annotations for FluidPhysics.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,15 @@ module = "stanshock.*"
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 
+[[tool.mypy.overrides]]
+module = ["numba.*", "h5py.*"]
+ignore_missing_imports = true
+
+
+[tool.basedpyright]
+reportImplicitOverride = false
+reportConstantRedefinition = false
+
 
 [tool.ruff]
 

--- a/src/stanshock/physics/cantera_interface.py
+++ b/src/stanshock/physics/cantera_interface.py
@@ -1,15 +1,23 @@
 from __future__ import annotations
 
-import cantera as ct
 import numpy as np
+from cantera import Solution, SolutionArray
 
 from stanshock.physics.fluid_base import FluidPhysics, FluidState
+from stanshock.system.backend import Array, Composition
 
 
 class CanteraInterface(FluidPhysics):
-    def __init__(self, gas: ct.Solution, ox_def=None, fuel_def=None, prog_def=None):
+    def __init__(
+        self,
+        gas: Solution,
+        ox_def: Composition | None = None,
+        fuel_def: Composition | None = None,
+        prog_def: Composition | None = None,
+    ) -> None:
         super().__init__(gas, ox_def, fuel_def, prog_def)
-        self._cached_solutions: dict[int, ct.SolutionArray] = {}
+        self._cached_solutions: dict[tuple[int, ...], SolutionArray[Solution]] = {}
+        self.sol: SolutionArray[Solution]
 
     def set_state(self, state: FluidState) -> FluidState:
         """Sets up a Cantera SolutionArray with the current fluid state.
@@ -21,7 +29,7 @@ class CanteraInterface(FluidPhysics):
         all initialized.
         """
         if state.shape not in self._cached_solutions:
-            self._cached_solutions[state.shape] = ct.SolutionArray(
+            self._cached_solutions[state.shape] = SolutionArray(
                 self.gas, shape=state.shape
             )
 
@@ -30,6 +38,7 @@ class CanteraInterface(FluidPhysics):
         # Update SolutionArray only if state has changed
         if not state._cache_valid:
             state.mass_fractions = state.composition
+            assert state.mass_fractions is not None
 
             # Prioritize density-based updates
             if state.density is not None:
@@ -59,47 +68,50 @@ class CanteraInterface(FluidPhysics):
 
         return state
 
-    def get_cp(self, state: FluidState):
+    def get_cp(self, state: FluidState) -> Array:
         """Compute specific heat capacity at constant pressure."""
         state = self.set_state(state)
         state.cp = self.sol.cp_mass
         return state.cp
 
-    def get_gamma(self, state: FluidState):
+    def get_gamma(self, state: FluidState) -> Array:
         """Compute specific heat ratio, gamma."""
         state = self.set_state(state)
         state.gamma = self.sol.cp / self.sol.cv
         return state.gamma
 
-    def get_mu(self, state: FluidState):
+    def get_mu(self, state: FluidState) -> Array:
         """Compute dynamic viscosity."""
         state = self.set_state(state)
         state.viscosity = self.sol.viscosity
         return state.viscosity
 
-    def get_thermal_conductivity(self, state: FluidState):
+    def get_thermal_conductivity(self, state: FluidState) -> Array:
         """Compute thermal conductivity."""
         state = self.set_state(state)
         state.thermal_conductivity = self.sol.thermal_conductivity
         return state.thermal_conductivity
 
-    def get_temperature(self, state: FluidState):
+    def get_temperature(self, state: FluidState) -> Array:
         """Compute temperature of the gas."""
         if state.temperature is None:
             state = self.set_state(state)
             state.temperature = self.sol.T
         return state.temperature
 
-    def get_pressure(self, state: FluidState):
+    def get_pressure(self, state: FluidState) -> Array:
         """Compute pressure of the gas."""
         if state.pressure is None:
             state = self.set_state(state)
             state.pressure = self.sol.P
         return state.pressure
 
-    def get_internal_energy(self, state: FluidState):
+    def get_internal_energy(self, state: FluidState) -> Array:
         """Compute internal energy of the gas."""
         if state.e0_star is not None:
+            assert state.pressure is not None
+            assert state.density is not None
+            assert state.gamma_star is not None
             state.internal_energy = (
                 state.pressure / (state.density * (state.gamma_star - 1.0))
                 + state.e0_star
@@ -110,11 +122,11 @@ class CanteraInterface(FluidPhysics):
 
         return state.internal_energy
 
-    def get_species_enthalpies(self, state: FluidState):
+    def get_species_enthalpies(self, state: FluidState) -> Array:
         state = self.set_state(state)
         return self.sol.partial_molar_enthalpies / self.gas.molecular_weights
 
-    def get_sound_speed(self, state: FluidState):
+    def get_sound_speed(self, state: FluidState) -> Array:
         """Compute speed of sound of the gas."""
         gamma = state.gamma
         if gamma is None:
@@ -122,12 +134,12 @@ class CanteraInterface(FluidPhysics):
         state.sound_speed = np.sqrt(gamma * self.sol.P / self.sol.density)
         return state.sound_speed
 
-    def get_mass_diffusivity(self, state: FluidState):
+    def get_mass_diffusivity(self, state: FluidState) -> Array:
         """Compute mixture-averaged diffusion coefficients."""
-        self.set_state(state)
+        state = self.set_state(state)
         return self.sol.mix_diff_coeffs_mass
 
-    def get_source_terms(self, state: FluidState):
+    def get_source_terms(self, state: FluidState) -> Array:
         """Compute reaction source terms corresponding to transported scalars."""
-        self.set_state(state)
+        state = self.set_state(state)
         return self.sol.net_production_rates

--- a/src/stanshock/physics/flamelet.py
+++ b/src/stanshock/physics/flamelet.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import h5py
 import numpy as np
+from cantera import Solution
 from scipy.interpolate import RegularGridInterpolator
 
 from stanshock.physics.fluid_base import FluidPhysics, FluidState
+from stanshock.system.backend import Array, Composition
 
 
 class TableVariable:
@@ -12,17 +14,17 @@ class TableVariable:
     Class to represent a variable in an FPV table.
     """
 
-    def __init__(self, name, data, Z, Q, L):
+    def __init__(self, name: str, data: Array, Z: Array, Q: Array, L: Array) -> None:
         """
         Initialize the TableVariable object with the name of the variable and the data.
         """
-        self.name = name
-        self.data = data
-        self.interp = RegularGridInterpolator(
+        self.name: str = name
+        self.data: Array = data
+        self.interp: RegularGridInterpolator[np.float64] = RegularGridInterpolator(
             (Z, Q, L), data, bounds_error=False, fill_value=None
         )
 
-    def lookup(self, Z, Q, L):
+    def lookup(self, Z: Array | float, Q: Array | float, L: Array | float) -> Array:
         """
         Perform a lookup of the variable at the given Z, Q, and L values.
         """
@@ -36,54 +38,56 @@ class FPVTable(FluidPhysics):
 
     def __init__(
         self,
-        filename,
-        gas,
-        ox_def=None,
-        fuel_def=None,
-        prog_def=None,
-        p_correction=False,
-        T_correction=False,
-    ):
+        filename: str,
+        gas: Solution,
+        ox_def: Composition | None = None,
+        fuel_def: Composition | None = None,
+        prog_def: Composition | None = None,
+        p_correction: bool = False,
+        T_correction: bool = False,
+    ) -> None:
         """
         Initialize the FPVTable object by reading the HDF5 file.
         """
-        self.gas = gas
-        self.n_scalars = 3
-        self.n_scalars_rho_sum = 1
+        self.gas: Solution = gas
+        self.n_scalars: int = 3
+        self.n_scalars_rho_sum: int = 1
         self.scalar_names = ["density", "mixture fraction", "progress variable"]
         self.is_flamelet = True
-        self.filename = filename
-        self.p_correction = p_correction
-        self.T_correction = T_correction
+        self.filename: str = filename
+        self.p_correction: bool = p_correction
+        self.T_correction: bool = T_correction
         with h5py.File(filename, "r") as f:
-            self.P = f["Header"]["Doubles"]["Double_0"].attrs["Value"][0]
-            self.Z = f["Coordinates"]["Coor_0"][()]
-            self.Q = f["Coordinates"]["Coor_1"][()]
-            self.L = f["Coordinates"]["Coor_2"][()]
+            self.P: float = f["Header"]["Doubles"]["Double_0"].attrs["Value"][0]
+            self.Z: Array = f["Coordinates"]["Coor_0"][:]
+            self.Q: Array = f["Coordinates"]["Coor_1"][:]
+            self.L: Array = f["Coordinates"]["Coor_2"][:]
 
-            var_names = [
-                var.decode("utf-8") for var in f["Header"]["Variable Names"][()]
+            var_names: list[str] = [
+                var.decode("utf-8") for var in f["Header"]["Variable Names"][:]
             ]
-            data_raw = f["Data"][()]
+            data_raw: Array = f["Data"][:]
             n_tot = self.Z.size * self.Q.size * self.L.size
-            self.variables = []
+            self.variables: list[TableVariable] = []
             for i, var in enumerate(var_names):
                 data = data_raw[i * n_tot : (i + 1) * n_tot].reshape(
                     self.Z.size, self.Q.size, self.L.size, order="C"
                 )
                 self.variables.append(TableVariable(var, data, self.Z, self.Q, self.L))
 
-        self.ox_def = ox_def
-        self.fuel_def = fuel_def
-        self.prog_def = prog_def
+        self.ox_def: Composition | None = ox_def
+        self.fuel_def: Composition | None = fuel_def
         if self.ox_def is None or self.fuel_def is None:
-            self.get_fuel_and_oxidizer_definitions()
+            self.ox_def, self.fuel_def = self.get_fuel_and_oxidizer_definitions()
         self.initialize_bilger_mixture_fraction()
 
+        self.prog_def: Composition | None = prog_def
         if self.prog_def is not None:
             self.initialize_progress_variable(self.prog_def)
 
-    def get_fuel_and_oxidizer_definitions(self, cutoff=1e-6):
+    def get_fuel_and_oxidizer_definitions(
+        self, cutoff: float = 1e-6
+    ) -> tuple[Composition, Composition]:
         """Get the fuel and oxidizer composition from the table."""
         self.ox_def = {}
         self.fuel_def = {}
@@ -105,37 +109,43 @@ class FPVTable(FluidPhysics):
         self.ox_def = {sp_name: Y / sum_ox for sp_name, Y in self.ox_def.items()}
         self.fuel_def = {sp_name: Y / sum_fuel for sp_name, Y in self.fuel_def.items()}
 
+        return self.ox_def, self.fuel_def
+
     def set_state(self, state: FluidState) -> FluidState:
         """Get the flamelet table coordinates from the composition."""
+        assert state.composition is not None
         Z = state.mixture_fraction = state.composition[:, 1]
         C = state.progress_variable = state.composition[:, 2]
         state.normalized_progress_variable = self.get_normalized_progress_variable(Z, C)
         return state
 
-    def get_composition(self, Y):
+    def get_composition(self, Y: Array) -> Array:
         """Converts mass fractions to mixture fraction and progress variable."""
         Z = self.get_bilger_mixture_fraction(Y)
         C = self.get_progress_variable(Y)
 
         return np.stack([np.ones_like(Z), Z, C], axis=1)
 
-    def get_normalized_progress_variable(self, Z, C):
+    def get_normalized_progress_variable(self, Z: Array, C: Array) -> Array:
         """
         Compute the normalized progress variable value at the given Z and C values.
         """
-        C_min = np.zeros_like(Z)
+        C_min: Array = np.zeros_like(Z)
+        C_max: Array = np.ones_like(Z)
         for v in self.variables:
             if v.name == "PROG":
                 C_max = v.lookup(Z, 0, 1)
         L = (C - C_min) / (C_max - C_min)
         return np.clip(L, 0, 1)
 
-    def lookup(self, var, state: FluidState):
+    def lookup(self, var: str, state: FluidState) -> Array:
         """
         Perform a lookup of the variable with the given name at the given Z, Q, and L values.
         """
         if state.normalized_progress_variable is None:
-            self.set_state(state)
+            state = self.set_state(state)
+        assert state.mixture_fraction is not None
+        assert state.normalized_progress_variable is not None
 
         Z = state.mixture_fraction
         Q = np.zeros_like(Z)
@@ -143,7 +153,9 @@ class FPVTable(FluidPhysics):
 
         return self.lookup_direct(var, Z, Q, L)
 
-    def lookup_direct(self, var, Z, Q, L):
+    def lookup_direct(
+        self, var: str, Z: Array | float, Q: Array | float, L: Array | float
+    ) -> Array:
         """
         Perform a lookup of the variable with the given name at the given Z, Q, and L values.
         """
@@ -154,12 +166,14 @@ class FPVTable(FluidPhysics):
         msg = f"Variable {var} not found in table {self.filename}."
         raise ValueError(msg)
 
-    def lookup_all(self, state: FluidState):
+    def lookup_all(self, state: FluidState) -> dict[str, Array]:
         """
         Perform a lookup of all variables at the given Z, Q, and L values.
         """
         if state.normalized_progress_variable is None:
-            self.set_state(state)
+            state = self.set_state(state)
+        assert state.mixture_fraction is not None
+        assert state.normalized_progress_variable is not None
 
         Z = state.mixture_fraction
         Q = np.zeros_like(Z)
@@ -167,12 +181,12 @@ class FPVTable(FluidPhysics):
 
         return {v.name: v.lookup(Z, Q, L) for v in self.variables}
 
-    def get_gamma(self, state: FluidState):
+    def get_gamma(self, state: FluidState) -> Array:
         """
         Compute the specific heat ratio at the given Z, Q, L and T values.
         """
         if state.temperature is None:
-            self.get_temperature(state)
+            state.temperature = self.get_temperature(state)
 
         gamma0 = self.lookup("GAMMA0", state)
         ag = self.lookup("AGAMMA", state)
@@ -180,13 +194,13 @@ class FPVTable(FluidPhysics):
         state.gamma = gamma0 + ag * (state.temperature - T0)
         return state.gamma
 
-    def get_specific_gas_constant(self, state: FluidState):
+    def get_specific_gas_constant(self, state: FluidState) -> Array:
         """
         Compute the gas constant at the given Z, Q, and L values.
         """
         return self.lookup("ROM", state)
 
-    def get_cp(self, state: FluidState):
+    def get_cp(self, state: FluidState) -> Array:
         """
         Compute the specific heat at the given Z, Q, L and T values.
         """
@@ -195,7 +209,7 @@ class FPVTable(FluidPhysics):
         state.cp = R * gamma / (gamma - 1)
         return state.cp
 
-    def get_cv(self, state: FluidState):
+    def get_cv(self, state: FluidState) -> Array:
         """
         Compute the specific heat at constant volume at the given Z, Q, and L values.
         """
@@ -203,22 +217,24 @@ class FPVTable(FluidPhysics):
         gamma = self.get_gamma(state)
         return R / (gamma - 1)
 
-    def get_mu(self, state: FluidState):
+    def get_mu(self, state: FluidState) -> Array:
         """
         Compute the dynamic viscosity at the given Z, Q, and L values.
         """
+        assert state.temperature is not None
         mu0 = self.lookup("MU0", state)
         T0 = self.lookup("T0", state)
         amu = self.lookup("AMU", state)
         state.viscosity = mu0 * (state.temperature / T0) ** amu
         return state.viscosity
 
-    def get_thermal_conductivity(self, state: FluidState):
+    def get_thermal_conductivity(self, state: FluidState) -> Array:
         """
         Compute the thermal conductivity at the given Z, Q, and L values.
         """
+        assert state.temperature is not None
         if state.cp is None:
-            self.get_cp(state)
+            state.cp = self.get_cp(state)
 
         loc0 = self.lookup("LOC0", state)
         T0 = self.lookup("T0", state)
@@ -226,7 +242,7 @@ class FPVTable(FluidPhysics):
         state.thermal_conductivity = state.cp * loc0 * (state.temperature / T0) ** aloc
         return state.thermal_conductivity
 
-    def get_temperature(self, state: FluidState):
+    def get_temperature(self, state: FluidState) -> Array:
         """
         Compute the temperature at the given Z, Q, L and e values.
         Note: Using sensible energy instead of internal energy because
@@ -234,8 +250,10 @@ class FPVTable(FluidPhysics):
         """
         R = self.get_specific_gas_constant(state)
         if state.pressure is not None:
+            assert state.density is not None
             state.temperature = state.pressure / (state.density * R)
         else:
+            assert state.internal_energy is not None
             T0 = self.lookup("T0", state)
             e0 = self.lookup("E0", state)
             gamma0 = self.lookup("GAMMA0", state)
@@ -245,13 +263,18 @@ class FPVTable(FluidPhysics):
             )
         return state.temperature
 
-    def get_pressure(self, state: FluidState):
+    def get_pressure(self, state: FluidState) -> Array:
+        assert state.density is not None
+        assert state.temperature is not None
         R = self.get_specific_gas_constant(state)
         state.pressure = state.temperature * R * state.density
         return state.pressure
 
-    def get_internal_energy(self, state: FluidState):
+    def get_internal_energy(self, state: FluidState) -> Array:
         if state.e0_star is not None:
+            assert state.gamma_star is not None
+            assert state.density is not None
+            assert state.pressure is not None
             state.internal_energy = (
                 state.pressure / (state.density * (state.gamma_star - 1.0))
                 + state.e0_star
@@ -279,31 +302,35 @@ class FPVTable(FluidPhysics):
 
         return state.internal_energy
 
-    def get_species_enthalpies(self, state: FluidState):
+    def get_species_enthalpies(self, state: FluidState) -> Array:
         state = self.set_state(state)
-        return 0.0
+        return np.zeros(state.shape)
 
-    def get_sound_speed(self, state):
+    def get_sound_speed(self, state: FluidState) -> Array:
+        assert state.density is not None
         if state.gamma is None:
-            self.get_gamma(state)
+            state.gamma = self.get_gamma(state)
         if state.pressure is None:
-            self.get_pressure(state)
+            state.pressure = self.get_pressure(state)
         state.sound_speed = np.sqrt(state.gamma * state.pressure / state.density)
         return state.sound_speed
 
-    def get_source_terms(self, state):
+    def get_source_terms(self, state: FluidState) -> Array:
         return self.lookup("SRC_PROG", state)
 
-    def get_source_progress_variable_compressibility_factor(self, state: FluidState):
+    def get_source_progress_variable_compressibility_factor(
+        self, state: FluidState
+    ) -> Array:
         """
         Compute the scaling factor for the progress variable source term at the given Z, Q, L, p and T values.
         """
-        factor = 1.0
+        factor = np.ones(state.shape)
         if self.p_correction:
+            assert state.pressure is not None
             factor *= state.pressure / self.P
         if self.T_correction:
             if state.temperature is None:
-                self.get_temperature(state)
+                state.temperature = self.get_temperature(state)
             TA = self.lookup("TA", state)
             T0 = self.lookup("T0", state)
             factor *= np.exp(-TA * ((1 / state.temperature) - (1 / T0)))

--- a/src/stanshock/physics/fluid_base.py
+++ b/src/stanshock/physics/fluid_base.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import cantera as ct
 import numpy as np
 
-from stanshock.system.backend import Array
+from stanshock.system.backend import Array, Composition
 
 
 @dataclass
@@ -39,21 +39,28 @@ class FluidState:
 
 
 class FluidPhysics(ABC):
-    def __init__(self, gas: ct.Solution, ox_def=None, fuel_def=None, prog_def=None):
-        self.gas = gas
-        self.n_scalars = self.gas.n_species
-        self.n_scalars_rho_sum = self.n_scalars
-        self.scalar_names = [species.lower() for species in self.gas.species_names]
+    def __init__(
+        self,
+        gas: ct.Solution,
+        ox_def: Composition | None = None,
+        fuel_def: Composition | None = None,
+        prog_def: Composition | None = None,
+    ) -> None:
+        self.gas: ct.Solution = gas
+        self.n_scalars: int = self.gas.n_species
+        self.n_scalars_rho_sum: int = self.n_scalars
+        self.scalar_names: list[str] = [
+            species.lower() for species in self.gas.species_names
+        ]
 
-        self.is_flamelet = False
+        self.is_flamelet: bool = False
 
         # For mixture fraction and progress variable definitions (optional):
-        self.ox_def = ox_def  # Oxidizer molar composition
-        self.fuel_def = fuel_def  # Fuel molar composition
-        self.prog_def = prog_def  # Progress variable molar composition
-        self.Z_weights = None
-        self.Z_offset = None
-        self.prog_weights = None
+        self.ox_def: Composition | None = ox_def  # Oxidizer molar composition
+        self.fuel_def: Composition | None = fuel_def  # Fuel molar composition
+        self.prog_def: Composition | None = (
+            prog_def  # Progress variable molar composition
+        )
 
         if self.ox_def is not None and self.fuel_def is not None:
             self.initialize_bilger_mixture_fraction()
@@ -62,15 +69,18 @@ class FluidPhysics(ABC):
             self.initialize_progress_variable(self.prog_def)
 
     @abstractmethod
-    def get_cp(self, state: FluidState):
+    def get_cp(self, state: FluidState) -> Array:
         """Compute specific heat capacity at constant pressure."""
 
     @abstractmethod
-    def get_gamma(self, state: FluidState):
+    def get_gamma(self, state: FluidState) -> Array:
         """Compute specific heat ratio, gamma."""
 
     def get_double_flux_variables(self, state: FluidState) -> tuple[Array, Array]:
         """Compute effective specific heat ratio, gamma*, and reference energy, e_0^*."""
+        assert state.internal_energy is not None
+        assert state.pressure is not None
+        assert state.density is not None
         # Valid for any ideal gas, g* = rho*c^2/p = g
         state.gamma_star = self.get_gamma(state)
         state.e0_star = state.internal_energy - state.pressure / (
@@ -80,48 +90,51 @@ class FluidPhysics(ABC):
         return state.gamma_star, state.e0_star
 
     @abstractmethod
-    def get_mu(self, state: FluidState):
+    def get_mu(self, state: FluidState) -> Array:
         """Compute dynamic viscosity."""
 
     @abstractmethod
-    def get_thermal_conductivity(self, state: FluidState):
+    def get_thermal_conductivity(self, state: FluidState) -> Array:
         """Compute thermal conductivity."""
 
     @abstractmethod
-    def get_temperature(self, state: FluidState):
+    def get_temperature(self, state: FluidState) -> Array:
         """Compute temperature of the gas."""
 
     @abstractmethod
-    def get_pressure(self, state: FluidState):
+    def get_pressure(self, state: FluidState) -> Array:
         """Compute pressure of the gas."""
 
     @abstractmethod
-    def get_internal_energy(self, state: FluidState):
+    def get_internal_energy(self, state: FluidState) -> Array:
         """Compute internal energy of the gas."""
 
     @abstractmethod
-    def get_species_enthalpies(self, state: FluidState):
+    def get_species_enthalpies(self, state: FluidState) -> Array:
         """Compute total enthalpies of each species."""
 
     @abstractmethod
-    def get_sound_speed(self, state: FluidState):
+    def get_sound_speed(self, state: FluidState) -> Array:
         """Compute speed of sound of the gas."""
 
-    def get_thermal_diffusivity(self, state: FluidState):
+    def get_thermal_diffusivity(self, state: FluidState) -> Array:
         """Compute thermal diffusivity, alpha = kappa / (rho * cp)."""
         kappa = self.get_thermal_conductivity(state)
         density = state.density
+        assert density is not None
         cp = self.get_cp(state)
         return kappa / (density * cp)
 
-    def get_mass_diffusivity(self, state: FluidState):
+    def get_mass_diffusivity(self, state: FluidState) -> Array:
         """Compute mass diffusivity (Unity Lewis Number assumption)."""
         return self.get_thermal_diffusivity(state)[:, None]
 
-    def initialize_bilger_mixture_fraction(self):
+    def initialize_bilger_mixture_fraction(self) -> None:
         """Compute coefficients defining Bilger mixture fraction."""
-        self.Z_weights = np.zeros(self.gas.n_species)
-        self.Z_offset = 0.0
+        assert self.ox_def is not None
+        assert self.fuel_def is not None
+        self.Z_weights: Array = np.zeros(self.gas.n_species)
+        self.Z_offset: float = 0.0
         denom = 0.0
 
         # Set the values for C, H, and O:
@@ -155,13 +168,17 @@ class FluidPhysics(ABC):
         self.Z_weights /= denom * self.gas.molecular_weights
         self.Z_offset /= denom
 
-    def get_bilger_mixture_fraction(self, Y):
+    def get_bilger_mixture_fraction(self, Y: Array) -> Array:
         """Compute the Bilger mixture fraction from given mass fractions."""
-        return np.clip(np.dot(Y, self.Z_weights) + self.Z_offset, 0.0, 1.0)
+        assert self.Z_weights is not None
+        assert self.Z_offset is not None
+        tmp = np.dot(Y, self.Z_weights)
+        assert isinstance(tmp, np.ndarray)
+        return np.clip(tmp + self.Z_offset, 0.0, 1.0)
 
-    def initialize_progress_variable(self, prog_def: dict[str, float]):
+    def initialize_progress_variable(self, prog_def: Composition) -> None:
         """Set coefficients defining progress variable."""
-        self.prog_weights = np.zeros(self.gas.n_species)
+        self.prog_weights: Array = np.zeros(self.gas.n_species)
 
         for sp, val in prog_def.items():
             self.prog_weights[self.gas.species_index(sp)] = val
@@ -172,37 +189,44 @@ class FluidPhysics(ABC):
 
         self.prog_weights /= np.sum(self.prog_weights)
 
-    def get_progress_variable(self, Y):
+    def get_progress_variable(self, Y: Array) -> Array:
         """Compute the progress variable from given mass fractions."""
-        if self.prog_weights is None:
+        if self.prog_def is None:
             msg = "Progress Variable Not Defined"
             raise Exception(msg)
 
-        return np.clip(np.dot(Y, self.prog_weights), 0.0, 1.0)
+        tmp = np.dot(Y, self.prog_weights)
+        assert isinstance(tmp, np.ndarray)
+        return np.clip(tmp, 0.0, 1.0)
 
     def set_state(self, state: FluidState) -> FluidState:
         """Updates internal representation of the fluid state if needed."""
-        self._cache_valid = True
+        state._cache_valid = True
         return state
 
-    def get_composition(self, Y):
+    def get_composition(self, Y: Array) -> Array:
         """Converts mass fractions to set of transported scalars."""
         return Y
 
-    def get_normalized_progress_variable(self, Z, C):
+    def get_normalized_progress_variable(self, Z: Array, C: Array) -> Array:
+        _ = Z, C
         msg = f"Normalized progress variable not implemented for {self.__class__}."
         raise NotImplementedError(msg)
 
-    def lookup(self, var: str, state: FluidState):
+    def lookup(self, var: str, state: FluidState) -> Array:
+        _ = var, state
         msg = (
             f"Looking up a variable by string is not implemented for {self.__class__}."
         )
         raise NotImplementedError(msg)
 
-    def primitive_to_conservative(self, state: FluidState):
+    def primitive_to_conservative(self, state: FluidState) -> Array:
         """Transform primitive variables into vector of conservatives, accounting for chemical contributions."""
         # Compute total energy including chemical contributions
-        self.set_state(state)
+        state = self.set_state(state)
+        assert state.velocity is not None
+        assert state.density is not None
+        assert state.composition is not None
 
         e_int = state.internal_energy
         if e_int is None:
@@ -216,6 +240,7 @@ class FluidPhysics(ABC):
                 state.density[..., None] * state.composition,
             ),
             axis=-1,
+            dtype=np.float64,
         )
 
     def conservative_to_primitive(
@@ -230,9 +255,10 @@ class FluidPhysics(ABC):
         rY = state_array[..., 2:]
 
         # Enforce non-negativity
-        np.clip(rY, 0, None, out=rY)
+        rY = np.clip(rY, 0, None, out=rY)
 
-        r = rY[..., : self.n_scalars_rho_sum].sum(axis=-1)
+        r = np.sum(rY[..., : self.n_scalars_rho_sum], axis=-1, dtype=np.float64)
+        assert isinstance(r, np.ndarray)
         u = ru / r
         e_int = (re_t / r) - 0.5 * u**2.0
         Y = rY / r[..., None]
@@ -247,10 +273,11 @@ class FluidPhysics(ABC):
 
         if gamma_star is not None:
             # Compute pressure using double-flux method
+            assert e0_star is not None
             state.pressure = (gamma_star - 1.0) * r * (e_int - e0_star)
 
         return self.set_state(state)
 
     @abstractmethod
-    def get_source_terms(self, state: FluidState):
+    def get_source_terms(self, state: FluidState) -> Array:
         """Compute reaction source terms corresponding to transported scalars."""

--- a/src/stanshock/physics/thermotable.py
+++ b/src/stanshock/physics/thermotable.py
@@ -6,6 +6,7 @@ from numba import double, njit
 
 from stanshock.physics.cantera_interface import CanteraInterface
 from stanshock.physics.fluid_base import FluidState
+from stanshock.system.backend import Array, Composition
 
 # Type signatures for numba
 double1D = double[:]
@@ -14,7 +15,7 @@ double3D = double[:, :, :]
 
 
 @njit(double1D(double2D, double1D))
-def get_specific_gas_constant_compiled(Y, molecularWeights):
+def get_specific_gas_constant_compiled(Y: Array, molecularWeights: Array) -> Array:
     """
     Function used by the thermoTable class to find the gas constant. This
     function is compiled for speed-up.
@@ -30,7 +31,7 @@ def get_specific_gas_constant_compiled(Y, molecularWeights):
     # determine R
     R = np.zeros(nX)
     for iX in range(nX):
-        molecularWeight = 0.0
+        molecularWeight: float = 0.0
         for iSp in range(nSp):
             molecularWeight += Y[iX, iSp] / molecularWeights[iSp]
         molecularWeight = 1.0 / molecularWeight
@@ -39,7 +40,7 @@ def get_specific_gas_constant_compiled(Y, molecularWeights):
 
 
 @njit(double1D(double1D, double2D, double1D, double2D, double2D))
-def get_cp_compiled(T, Y, TTable, a, b):
+def get_cp_compiled(T: Array, Y: Array, TTable: Array, a: Array, b: Array) -> Array:
     """
     Function used by the thermoTable class to find the constant pressure
     specific heats. This function is compiled for speed-up.
@@ -85,7 +86,13 @@ class ThermoTable(CanteraInterface):
     relevant methods
     """
 
-    def __init__(self, gas: ct.Solution, ox_def=None, fuel_def=None, prog_def=None):
+    def __init__(
+        self,
+        gas: ct.Solution,
+        ox_def: Composition | None = None,
+        fuel_def: Composition | None = None,
+        prog_def: Composition | None = None,
+    ) -> None:
         """
         This method initializes the temperature table. The table uses a
         piecewise linear function for the constant pressure specific heat
@@ -93,19 +100,25 @@ class ThermoTable(CanteraInterface):
         enthalpies at the table points.
         """
         super().__init__(gas, ox_def, fuel_def, prog_def)
-        nSp = gas.n_species
-        self.TMin = 50.0
-        self.dT = 100.0
-        self.TMax = 9950.0
-        self.T = np.arange(
-            self.TMin, self.TMax, self.dT
+        nSp: int = gas.n_species
+        self.TMin: float = 50.0
+        self.dT: float = 100.0
+        self.TMax: float = 9950.0
+        self.T: Array = np.arange(
+            self.TMin, self.TMax, self.dT, dtype=np.float64
         )  # vector of temperatures assuming thermal equilibrium between species
         nT = len(self.T)
-        self.h = np.zeros((nT, nSp))  # matrix of species enthalpies per temperature
+        self.h: Array = np.zeros(
+            (nT, nSp)
+        )  # matrix of species enthalpies per temperature
         # cpk = ak*T+bk for T in [Tk,Tk+1], k in {0,1,2,...,nT-1}
-        self.a = np.zeros((nT, nSp))  # matrix of species first order coefficients
-        self.b = np.zeros((nT, nSp))  # matrix of species zeroth order coefficients
-        self.molecularWeights = gas.molecular_weights
+        self.a: Array = np.zeros(
+            (nT, nSp)
+        )  # matrix of species first order coefficients
+        self.b: Array = np.zeros(
+            (nT, nSp)
+        )  # matrix of species zeroth order coefficients
+        self.molecularWeights: Array = gas.molecular_weights
         # determine the coefficients
         for kSp, species in enumerate(gas.species()):
             # initialize with actual cp
@@ -124,7 +137,7 @@ class ThermoTable(CanteraInterface):
                 cpk = self.a[kT, kSp] * (Tkp1) + self.b[kT, kSp]
                 hk = hkp1
 
-    def get_specific_gas_constant(self, state: FluidState):
+    def get_specific_gas_constant(self, state: FluidState) -> Array:
         """
         This method computes the mixture-specific gas constat
             inputs:
@@ -132,11 +145,12 @@ class ThermoTable(CanteraInterface):
             outputs:
                 R: vector of mixture-specific gas constants [n]
         """
+        assert state.composition is not None
         return get_specific_gas_constant_compiled(
             state.composition.reshape((-1, self.n_scalars)), self.molecularWeights
         ).reshape(state.shape)
 
-    def get_cp(self, state: FluidState):
+    def get_cp(self, state: FluidState) -> Array:
         """
         This method computes the constant pressure specific heat as determined
         by Billet and Abgrall (2003) for the double flux method.
@@ -146,6 +160,7 @@ class ThermoTable(CanteraInterface):
             outputs:
                 cp: vector of constant pressure specific heats
         """
+        assert state.composition is not None
         if state.temperature is None:
             state.temperature = self.get_temperature(state)
         return get_cp_compiled(
@@ -156,7 +171,7 @@ class ThermoTable(CanteraInterface):
             self.b,
         ).reshape(state.shape)
 
-    def get_frozen_enthalpy(self, T, Y):
+    def get_frozen_enthalpy(self, T: Array, Y: Array) -> Array:
         """
         This method computes the enthalpy according to Billet and Abgrall (2003).
         This is the enthalpy that is frozen over the time step
@@ -177,7 +192,7 @@ class ThermoTable(CanteraInterface):
             h0[k] = np.dot(Y[k, :], self.h[index] - bbar * self.T[index])
         return h0
 
-    def get_gamma(self, state: FluidState):
+    def get_gamma(self, state: FluidState) -> Array:
         """
         This method computes the specific heat ratio, gamma.
             inputs:
@@ -189,7 +204,7 @@ class ThermoTable(CanteraInterface):
         R = self.get_specific_gas_constant(state)
         return cp / (cp - R)
 
-    def get_temperature(self, state: FluidState):
+    def get_temperature(self, state: FluidState) -> Array:
         """
         This method applies the ideal gas law to compute the temperature
             inputs:
@@ -199,21 +214,25 @@ class ThermoTable(CanteraInterface):
         """
         R = self.get_specific_gas_constant(state)
         if state.pressure is None:
-            self.set_state(state)
+            state = self.set_state(state)
             state.temperature = self.sol.T
         else:
+            assert state.density is not None
             state.temperature = state.pressure / (state.density * R)
         return state.temperature
 
-    def get_pressure(self, state: FluidState):
+    def get_pressure(self, state: FluidState) -> Array:
+        assert state.temperature is not None
+        assert state.density is not None
         R = self.get_specific_gas_constant(state)
         state.pressure = state.temperature * R * state.density
         return state.pressure
 
-    def get_species_enthalpies(self, state: FluidState):
-        T = state.temperature
+    def get_species_enthalpies(self, state: FluidState) -> Array:
         if state.temperature is None:
             T = self.get_temperature(state)
+        else:
+            T = state.temperature
 
         if any(np.logical_or(self.TMin > T, self.TMax < T)):
             msg = "Temperature not within table"
@@ -226,7 +245,9 @@ class ThermoTable(CanteraInterface):
         )
         return self.h[indices, :] - bbar * self.T[indices, None]
 
-    def get_sound_speed(self, state: FluidState):
+    def get_sound_speed(self, state: FluidState) -> Array:
+        assert state.pressure is not None
+        assert state.density is not None
         gamma = state.gamma
         if gamma is None:
             gamma = self.get_gamma(state)

--- a/src/stanshock/system/backend.py
+++ b/src/stanshock/system/backend.py
@@ -4,8 +4,10 @@ from typing import TypeAlias
 
 import numpy as np
 
-__all__: list[str] = ["Array", "Index", "TypeAlias", "np"]
+__all__: list[str] = ["Array", "Composition", "Index", "TypeAlias", "np"]
 
 # Define the Array type for use in type hints to make future changes easier
 Array: TypeAlias = np.ndarray[tuple[int, ...], np.dtype[np.float64]]
 Index: TypeAlias = np.ndarray[tuple[int, ...], np.dtype[np.int64]] | slice
+
+Composition: TypeAlias = dict[str, float]

--- a/stubs/cantera/py.typed
+++ b/stubs/cantera/py.typed
@@ -1,1 +1,0 @@
-partial

--- a/stubs/h5py/py.typed
+++ b/stubs/h5py/py.typed
@@ -1,1 +1,0 @@
-partial

--- a/stubs/numba/py.typed
+++ b/stubs/numba/py.typed
@@ -1,1 +1,0 @@
-partial


### PR DESCRIPTION
Closes #67

Adds a bunch of missing type annotations for the `FluidPhysics` classes. Still some remaining issues, especially in relation to `h5py` and `numba`, which will be deferred for the time being.