### PR TITLE
Abstract out time integration

### DIFF
--- a/examples/hyshot_ii.py
+++ b/examples/hyshot_ii.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import code
+from typing import Unpack
 
 import cantera as ct
 import matplotlib.pyplot as plt
@@ -8,11 +9,11 @@ import numpy as np
 
 from stanshock.components.combustor import Combustor
 from stanshock.numerics.boundary_conditions import SpecifiedFace
-from stanshock.physics.fluid_base import FluidPhysics
+from stanshock.physics.fluid_base import FluidState
 from stanshock.physics.thermotable import ThermoTable
 from stanshock.system.backend import Array
-from stanshock.system.base import RightHandSide
-from stanshock.system.geometry import Box, Geometry
+from stanshock.system.base import PrecomputeSteps, RightHandSide
+from stanshock.system.geometry import Box
 
 plt.rcParams.update(
     {
@@ -98,12 +99,16 @@ BC_inlet = SpecifiedFace(
     reference_state=(gas_init.density, U_in, gas_init.P, gas_init.Y)
 )
 BC_outlet = "outflow"
-BCs = (BC_inlet, BC_outlet)
+BCs = {"left": BC_inlet, "right": BC_outlet}
 
 
 # Define the fuel inflow
 class HydrogenInjection(RightHandSide):
-    def __init__(self, gas: ct.Solution, geometry: Geometry) -> None:
+    def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
+        super().__init__(**precompute_steps)
+        gas = self.physics.gas
+        n_variables = self.physics.n_scalars + 2
+
         # Injector area
         r_f = 0.2e-3  # m
         N_f = 4  # -
@@ -134,45 +139,53 @@ class HydrogenInjection(RightHandSide):
         scale_factor = 3.960715337483353
 
         # Get geometry information
-        xf = geometry.xf
-        index = np.where(np.logical_and(xf >= x_inj, xf < x_inj + L_src))[0]
+        xf = self.geometry.xf
+        self.idx_domain = (
+            np.where(np.logical_and(xf >= x_inj, xf < x_inj + L_src))[0]
+            + self.geometry.n_ghost_layers
+        )
+        self.xc = self.geometry.xc[self.idx_domain]
+        n_cells = len(self.xc)
+        self.shape_domain = (n_cells, n_variables)
+        self.shape_update = (n_cells, 3)
+        self.idx_source = np.array([0, 1, 2 + gas.species_index("H2")])
 
-        nsp = gas.n_species
-        self.rhs = np.zeros([geometry.n_cells, 2 + nsp])
-        self.rhs[index, 0] = rho_f
-        self.rhs[index, 1] = rhoE_f
-        self.rhs[index, 2 + gas.species_index("H2")] = rhoYH2_f
-        self.rhs[index, :] *= U_f * A_f / L_src * scale_factor
+        self.rhs = np.zeros(self.shape_update)
+        self.rhs[:, 0] = rho_f * U_f
+        self.rhs[:, 1] = rhoE_f
+        self.rhs[:, 2] = rhoYH2_f
+        self.rhs *= U_f * A_f / L_src * scale_factor
 
-        self.xc = geometry.xc[index]
-        self.geometry = geometry
-        self.index = index
-
-    def source(
+    def source_implementation(
         self,
         time: float,
-        _state_array: Array,
-        _physics: FluidPhysics,
-        _gamma_star: Array | None = None,
-        _e0_star: Array | None = None,
+        state_array_local: Array | None,
+        state: FluidState | None,
+        face_states: FluidState | None,
+        avg_face_states: FluidState | None,
+        face_gradients: FluidState | None,
     ) -> Array:
-        rhs = self.rhs.copy()
-        rhs[self.index, :] /= self.geometry.area(time, self.xc)[:, None]
-        return rhs
+        _ = state_array_local, state, face_states, avg_face_states, face_gradients
+        area = self.geometry.area(time, self.xc)
+        if isinstance(area, np.ndarray):
+            area = area[:, None]
+
+        return np.ravel(self.rhs / area)
 
 
 # Initialize and run the simulation
+physics = ThermoTable(gas)
 ss = Combustor(
     xf=xf,
     geometry=geometry,
     initialization=("constant", gas_init, U_in),
     boundary_conditions=BCs,
-    source_terms=HydrogenInjection(gas, geometry),
+    source_terms=HydrogenInjection(geometry=geometry, physics=physics),
     cfl=0.5,
     reacting=True,
     include_diffusion=False,
     output_every=10,
-    physics=ThermoTable(gas),
+    physics=physics,
 )
 ss.advance_simulation(t_end)
 

--- a/examples/hyshot_ii.py
+++ b/examples/hyshot_ii.py
@@ -140,17 +140,17 @@ class HydrogenInjection(RightHandSide):
 
         # Get geometry information
         xf = self.geometry.xf
-        self.idx_domain = (
+        self.idx_input = (
             np.where(np.logical_and(xf >= x_inj, xf < x_inj + L_src))[0]
             + self.geometry.n_ghost_layers
         )
-        self.xc = self.geometry.xc[self.idx_domain]
+        self.xc = self.geometry.xc[self.idx_input]
         n_cells = len(self.xc)
-        self.shape_domain = (n_cells, n_variables)
-        self.shape_update = (n_cells, 3)
+        self.shape_input = (n_cells, n_variables)
+        self.shape_output = (n_cells, 3)
         self.idx_source = np.array([0, 1, 2 + gas.species_index("H2")])
 
-        self.rhs = np.zeros(self.shape_update)
+        self.rhs = np.zeros(self.shape_output)
         self.rhs[:, 0] = rho_f * U_f
         self.rhs[:, 1] = rhoE_f
         self.rhs[:, 2] = rhoYH2_f

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -27,7 +27,8 @@ from stanshock.numerics.time_integration import (
     TimeIntegrator,
 )
 from stanshock.numerics.viscous_flux import ViscousFlux
-from stanshock.physics.fluid_base import ChemistrySource, FluidPhysics
+from stanshock.physics.chemistry_source import ChemistrySource, ConstantVolumeChemistry
+from stanshock.physics.fluid_base import FluidPhysics
 from stanshock.processing.initialize import (
     initialize_constant,
     initialize_diffuse_interface,
@@ -170,14 +171,20 @@ class Combustor:
         advection = SSPRK3(self.inviscid_flux)
         if self.physics.is_flamelet:
             integrators += [
-                HeunsMethod(ChemistrySource),
+                HeunsMethod(
+                    ChemistrySource(geometry=self.geometry, physics=self.physics)
+                ),
                 advection,
             ]
         else:
             integrators += [
                 StrangSplitting(
                     transport_operator=advection,
-                    reaction_operator=ScipyIVP(ChemistrySource),
+                    reaction_operator=ScipyIVP(
+                        ConstantVolumeChemistry(
+                            geometry=self.geometry, physics=self.physics
+                        )
+                    ),
                 )
             ]
 

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -24,6 +24,7 @@ from stanshock.numerics.time_integration import (
     LieSplitting,
     ScipyIVP,
     StrangSplitting,
+    TimeIntegrator,
 )
 from stanshock.numerics.viscous_flux import ViscousFlux
 from stanshock.physics.fluid_base import ChemistrySource, FluidPhysics
@@ -33,7 +34,8 @@ from stanshock.processing.initialize import (
     initialize_isentropic,
     initialize_riemann_problem,
 )
-from stanshock.processing.plot import plot_state
+from stanshock.processing.plot import XTDiagram, plot_state
+from stanshock.processing.probe import Probe
 from stanshock.system.backend import Array
 from stanshock.system.base import RightHandSide
 from stanshock.system.geometry import Geometry, initialize_geometry
@@ -45,13 +47,13 @@ class Combustor:
     1D gasdynamics solver.
     """
 
-    def __init__(
+    def __init__(  # type: ignore[no-untyped-def]
         self,
         physics: FluidPhysics,
         n_cells: int = 10,
         geometry: Geometry | None = None,
         **kwargs,
-    ):
+    ) -> None:
         """
         initialization of the object with default values. The keyword arguments
         allow the user to initialize the state
@@ -81,8 +83,8 @@ class Combustor:
         self.inviscid_face_extrapolator: type[FaceExtrapolator] = FifthOrderWeno
         self.viscous_face_extrapolator: type[FaceExtrapolator] = FirstOrder
         self.initialization = None  # initialization options
-        self.probes = []  # list of probe objects
-        self.xt_diagrams = []  # list of XT diagram objects
+        self.probes: list[Probe] = []  # list of probe objects
+        self.xt_diagrams: list[XTDiagram] = []  # list of XT diagram objects
         self.skin_friction_coefficient = None  # skin friction functor
         self.optimization_iteration = 0  # counter to keep track of optimization
         self.physics = physics  # Model handling all fluid property evaluations
@@ -164,7 +166,7 @@ class Combustor:
         )
 
         # Set up time integrators
-        integrators = []
+        integrators: list[TimeIntegrator] = []
         advection = SSPRK3(self.inviscid_flux)
         if self.physics.is_flamelet:
             integrators += [
@@ -262,9 +264,9 @@ class Combustor:
         This method updates all the XT Diagrams to the current value.
         """
         # update diagrams
-        for XTDiagram in self.xt_diagrams:
-            if iters % (XTDiagram.skipSteps + 1) == 0:
-                XTDiagram.update(self)
+        for diagram in self.xt_diagrams:
+            if iters % (diagram.skipSteps + 1) == 0:
+                diagram.update(self)
 
     def advance_simulation(self, tFinal, res_p_target=-1.0):
         """

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -19,6 +19,7 @@ from stanshock.numerics.gradient import CentralDifference
 from stanshock.numerics.inviscid_flux import InviscidFlux, RiemannSolver, hllc_flux
 from stanshock.numerics.time_integration import (
     SSPRK3,
+    FastSlowIntegrator,
     ForwardEuler,
     HeunsMethod,
     LieSplitting,
@@ -120,7 +121,7 @@ class Combustor:
 
         # Add area-change related source terms
         if self.geometry.dlnA_dt is not None or self.geometry.dlnA_dx is not None:
-            self.area_change = AreaChange(geometry=self.geometry)
+            self.area_change = AreaChange(geometry=self.geometry, physics=self.physics)
 
         # set the number of scalars
         self.n_scalars = self.physics.n_scalars
@@ -176,7 +177,7 @@ class Combustor:
                 ),
                 advection,
             ]
-        else:
+        elif self.physics.gas.n_reactions > 0:
             integrators += [
                 StrangSplitting(
                     transport_operator=advection,
@@ -187,6 +188,8 @@ class Combustor:
                     ),
                 )
             ]
+        else:
+            integrators += [advection]
 
         if self.include_diffusion:
             self.viscous_flux = ViscousFlux(
@@ -203,7 +206,8 @@ class Combustor:
             integrators += [HeunsMethod(self.viscous_flux)]
 
         if self.area_change is not None:
-            integrators += [ForwardEuler(self.area_change)]
+            # integrators += [ForwardEuler(self.area_change)]
+            integrators += [FastSlowIntegrator(self.area_change)]
 
         if self.include_boundary_layer:
             # Initialize the boundary layer source terms
@@ -211,6 +215,7 @@ class Combustor:
                 wall_temperature=self.wall_temperature,
                 skin_friction_coefficient=self.skin_friction_coefficient,
                 geometry=self.geometry,
+                physics=self.physics,
             )
             integrators += [ForwardEuler(self.boundary_layer)]
 
@@ -221,7 +226,7 @@ class Combustor:
             integrators += [HeunsMethod(self.injector)]
 
         # Apply Lie splitting approach
-        self.time_integrator = LieSplitting(integrators, update_double_flux=True)
+        self.time_integrator = LieSplitting(integrators)
 
         self.F = np.ones(self.geometry.n_cells)  # thickening
 
@@ -285,12 +290,15 @@ class Combustor:
         res_p = np.inf
         gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
         state_array = self.physics.primitive_to_conservative(self.state)
+        self.shape_full: tuple[int, int] = state_array.shape
+        state_array = np.ravel(state_array)
+        p_new = self.physics.get_pressure(self.state)
         while self.t < tFinal and res_p > res_p_target:
-            p_old = self.state.pressure
             dt = min(tFinal - self.t, self.get_time_step())
+            p_old = p_new + 0.0
 
             # Update the system state
-            self.t, state_array = self.time_integrator.advance(
+            self.t, state_array, gamma_star, e0_star = self.time_integrator.advance(
                 dt=dt,
                 time=self.t,
                 state_array=state_array,
@@ -298,15 +306,16 @@ class Combustor:
                 e0_star=e0_star,
             )
             self.state = self.physics.conservative_to_primitive(
-                state_array, gamma_star, e0_star
+                np.reshape(state_array, self.shape_full), gamma_star, e0_star
             )
-            gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
+            p_new = self.physics.get_pressure(self.state)
+            self.state.gamma = self.physics.get_gamma(self.state)
 
             # perform other updates
             self.update_probes(iters)
             self.update_XT_diagrams(iters)
             iters += 1
-            res_p = np.linalg.norm(self.state.pressure - p_old)
+            res_p = np.linalg.norm(p_new - p_old)
             if self.verbose and iters % self.output_every == 0:
                 print(
                     f"Iteration: {iters}. Current time: {self.t}. Time step: {dt:e}. "

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import cantera as ct
 import numpy as np
 
 from stanshock.models.area_change import AreaChange
@@ -17,9 +16,16 @@ from stanshock.numerics.face_extrapolation import (
 )
 from stanshock.numerics.gradient import CentralDifference
 from stanshock.numerics.inviscid_flux import InviscidFlux, RiemannSolver, hllc_flux
+from stanshock.numerics.time_integration import (
+    SSPRK3,
+    ForwardEuler,
+    HeunsMethod,
+    LieSplitting,
+    ScipyIVP,
+    StrangSplitting,
+)
 from stanshock.numerics.viscous_flux import ViscousFlux
-from stanshock.physics.flamelet import FPVTable
-from stanshock.physics.fluid_base import FluidPhysics, FluidState
+from stanshock.physics.fluid_base import ChemistrySource, FluidPhysics
 from stanshock.processing.initialize import (
     initialize_constant,
     initialize_diffuse_interface,
@@ -155,6 +161,22 @@ class Combustor:
             geometry=self.geometry,
         )
 
+        # Set up time integrators
+        integrators = []
+        advection = SSPRK3(self.inviscid_flux)
+        if self.physics.is_flamelet:
+            integrators += [
+                HeunsMethod(ChemistrySource),
+                advection,
+            ]
+        else:
+            integrators += [
+                StrangSplitting(
+                    transport_operator=advection,
+                    reaction_operator=ScipyIVP(ChemistrySource),
+                )
+            ]
+
         if self.include_diffusion:
             self.viscous_flux = ViscousFlux(
                 boundary_conditions=self.boundary_conditions,
@@ -165,6 +187,10 @@ class Combustor:
                 geometry=self.geometry,
                 gradient=CentralDifference(n_ghost_layers=self.geometry.n_ghost_layers),
             )
+            integrators += [HeunsMethod(self.viscous_flux)]
+
+        if self.area_change is not None:
+            integrators += [ForwardEuler(self.area_change)]
 
         if self.include_boundary_layer:
             # Initialize the boundary layer source terms
@@ -173,6 +199,16 @@ class Combustor:
                 wall_temperature=self.wall_temperature,
                 skin_friction_coefficient=self.skin_friction_coefficient,
             )
+            integrators += [ForwardEuler(self.boundary_layer)]
+
+        if self.source_terms is not None:
+            integrators += [HeunsMethod(self.source_terms)]
+
+        if self.injector is not None:
+            integrators += [HeunsMethod(self.injector)]
+
+        # Apply Lie splitting approach
+        self.time_integrator = LieSplitting(integrators, update_double_flux=True)
 
         self.F = np.ones(self.geometry.n_cells)  # thickening
 
@@ -207,310 +243,6 @@ class Combustor:
             local_timescale = np.minimum(local_timescale, viscous_timescale)
         return self.cfl * min(local_timescale)
 
-    def advance_advection(self, dt):
-        """
-        This method advances the advection terms by the prescribed timestep.
-        The advection terms are integrated using RK3.
-            inputs
-                dt=time step
-        """
-        idx = self.geometry.idx_cells
-        y = self.physics.primitive_to_conservative(self.state)
-        gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
-
-        # 1st stage of RK3
-        dydt = self.inviscid_flux.source(self.t, y, self.physics, gamma_star, e0_star)
-        y1 = y.copy()
-        y1[idx] += dt * dydt
-
-        # 2nd stage of RK3
-        dydt = self.inviscid_flux.source(self.t, y1, self.physics, gamma_star, e0_star)
-        y2 = 0.75 * y + 0.25 * y1
-        y2[idx] += 0.25 * dt * dydt
-
-        # 3rd stage of RK3
-        dydt = self.inviscid_flux.source(self.t, y2, self.physics, gamma_star, e0_star)
-
-        y[idx] = (1.0 / 3.0) * y[idx] + (2.0 / 3.0) * y2[idx] + (2.0 / 3.0) * dt * dydt
-
-        # Remove ghost layers and update gamma
-        self.state = self.physics.conservative_to_primitive(y, gamma_star, e0_star)
-
-    def advance_diffusion(self, dt):
-        """
-        This method advances the diffusion terms in the axial direction
-            inputs
-                dt=time step
-        """
-        idx = self.geometry.idx_cells
-        y = self.physics.primitive_to_conservative(self.state)
-        gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
-
-        if self.thickening is not None:
-            self.F = self.thickening(self)
-
-            # No gradient in F at boundary
-            self.viscous_flux.F = np.pad(
-                self.F, self.geometry.n_ghost_layers, mode="edge"
-            )
-
-        # 1st stage of RK2
-        dydt = self.viscous_flux.source(self.t, y, self.physics, gamma_star, e0_star)
-        y1 = y.copy()
-        y1[idx] += dt * dydt
-
-        # 2nd stage of RK2
-        dydt = self.viscous_flux.source(self.t, y1, self.physics, gamma_star, e0_star)
-        y[idx] = 0.5 * (y[idx] + y1[idx] + dt * dydt)
-
-        # Remove ghost layers and update gamma
-        self.state = self.physics.conservative_to_primitive(y, gamma_star, e0_star)
-
-    def advance_chemistry(self, dt):
-        """
-        This method advances the combustion chemistry of a reacting system. It
-        is only called if the "reacting" flag is set to True.
-            inputs
-                dt=time step
-        """
-        if not self.reacting:
-            return
-        if self.physics.is_flamelet:
-            self.advance_chemistry_FPV(dt)
-        else:
-            self.advance_chemistry_FRC(dt)
-
-    def advance_chemistry_FPV(self, dt):
-        """
-        This method advances the combustion chemistry of a reacting system using
-        the flamelet progress variable approach. It is only called if the "reacting"
-        flag is set to True.
-            inputs
-                dt=time step
-        """
-        # initialize
-        idx = self.geometry.idx_cells
-        y = self.physics.primitive_to_conservative(self.state)
-        gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
-
-        # 1st stage of RK2
-        omegaC = self.injector.get_chemical_sources(
-            self.t,
-            y[idx],
-            self.physics,
-            gamma_star[idx],
-            e0_star[idx],
-        )
-        y1 = y.copy()
-        y1[idx, 4] += dt * omegaC
-
-        # 2nd stage of RK2
-        omegaC1 = self.injector.get_chemical_sources(
-            self.t + dt,
-            y1[idx],
-            self.physics,
-            gamma_star[idx],
-            e0_star[idx],
-        )
-        y[idx, 4] = 0.5 * (y[idx, 4] + y1[idx, 4] + dt * omegaC1)
-
-        # update properties
-        self.state = self.physics.conservative_to_primitive(y, gamma_star, e0_star)
-        self.state.temperature = self.physics.get_temperature(self.state)
-
-    def advance_chemistry_FRC(self, dt):
-        """
-        This method advances the combustion chemistry of a reacting system using
-        finite rate chemistry. It is only called if the "reacting" flag is set to True.
-            inputs
-                dt=time step
-        """
-
-        #######################################################################
-        def dydt(t, y, args):
-            """
-            function: dydt
-            -------------------------------------------------------------------
-            this function gives the source terms of a constant volume reactor
-                inputs
-                    dt=time step
-            """
-            _ = t  # Hack to silence linter
-            # unpack the input
-            r = args[0]
-            F = args[1]
-            Y = y[:-1]
-            T = y[-1]
-            # set the state for the gas object
-            self.physics.gas.TDY = T, r, Y
-            # gas properties
-            cv = self.physics.gas.cv_mass
-            W = self.physics.gas.molecular_weights
-            wHatDot = self.physics.gas.net_production_rates  # kmol/m^3.s
-            wDot = wHatDot * W  # kg/m^3.s
-            eRT = self.physics.gas.standard_int_energies_RT
-            # compute the derivatives
-            YDot = wDot / r
-            TDot = -np.sum(eRT * wHatDot) * ct.gas_constant * T / (r * cv)
-            f = np.zeros(self.n_scalars + 1)
-            f[:-1] = YDot
-            f[-1] = TDot
-            return f / F
-
-        #######################################################################
-        from scipy import integrate
-
-        # get indices
-        indices = np.where(self.in_reacting_region(self.t, self.geometry.xc))[0]
-        state_temp = FluidState(
-            shape=(len(indices),),
-            density=self.state.density[indices].copy(),
-            pressure=self.state.pressure[indices].copy(),
-            composition=self.state.composition[indices, :].copy(),
-        )
-        state_temp.temperature = Ts = self.physics.get_temperature(state_temp)
-        state_temp.pressure = None
-        state_temp._cache_valid = False
-
-        # initialize integrator
-        y0 = np.zeros(self.physics.n_scalars + 1)
-        integrator = integrate.ode(dydt).set_integrator("lsoda")
-        for TIndex, k in enumerate(indices):
-            # initialize
-            y0[:-1] = self.state.composition[k, :]
-            y0[-1] = Ts[TIndex]
-            args = [self.state.density[k], self.F[k]]
-            integrator.set_initial_value(y0, 0.0)
-            integrator.set_f_params(args)
-            # solve
-            integrator.integrate(dt)
-            # clip and normalize
-            Y = integrator.y[:-1]
-            Y = np.clip(Y, 0.0, 1.0)
-            Y /= np.sum(Y)
-            # update
-            state_temp.composition[TIndex, :] = Y
-            state_temp.temperature[TIndex] = integrator.y[-1]
-
-        # update state
-        self.state.pressure[indices] = self.physics.get_pressure(state_temp)
-        self.state.composition[indices, :] = state_temp.composition
-        self.state.temperature = None
-        self.state._cache_valid = False
-
-    def advance_quasi_1d(self, dt):
-        """
-        This method advances the quasi-1D terms used to model area changes in
-        the shock tube. The client must supply the functions dlnA_dt and dlnA_dx
-        to the Combustor object.
-        """
-        idx = self.geometry.idx_cells
-        y = self.physics.primitive_to_conservative(self.state)
-        gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
-
-        dydt = self.area_change.source(self.t, y, self.physics, gamma_star, e0_star, dt)
-
-        # Update
-        y[idx] += dt * dydt
-        self.state = self.physics.conservative_to_primitive(y, gamma_star, e0_star)
-
-    def advance_boundary_layer(self, dt):
-        """
-        This method advances the boundary layer terms
-            inputs
-                dt=time step
-        """
-        idx = self.geometry.idx_cells
-        y = self.physics.primitive_to_conservative(self.state)
-        gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
-
-        dydt = self.boundary_layer.source(
-            self.t,
-            y[idx],
-            self.physics,
-            gamma_star[idx],
-            e0_star[idx],
-        )
-
-        # Update
-        y[idx] += dydt * dt
-        self.state = self.physics.conservative_to_primitive(y, gamma_star, e0_star)
-
-    def advance_source_terms(self, dt):
-        """
-        This method advances the source terms in the axial direction
-            inputs
-                dt=time step
-        """
-        # initialize
-        idx = self.geometry.idx_cells
-        y = self.physics.primitive_to_conservative(self.state)
-        gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
-
-        # 1st stage of RK2
-        dydt = self.source_terms.source(
-            self.t,
-            y[idx],
-            self.physics,
-            gamma_star[idx],
-            e0_star[idx],
-        )
-        y1 = y[idx] + dt * dydt
-        # state1 = self.physics.conservative_to_primitive(y1, gamma_star, e0_Star)
-
-        # 2nd stage of RK2
-        dydt = self.source_terms.source(
-            self.t + dt,
-            y1,
-            self.physics,
-            gamma_star[idx],
-            e0_star[idx],
-        )
-
-        y[idx] = 0.5 * (y[idx] + y1 + dt * dydt)
-        self.state = self.physics.conservative_to_primitive(y, gamma_star, e0_star)
-
-    def advance_injector(self, dt):
-        """
-        This method advances the source terms from the injector using the
-        jet-in-crossflow model.
-            inputs
-                dt=time step
-        """
-        if not isinstance(self.physics, FPVTable):
-            msg = "JIC injector model requires FPVTable physics."
-            raise Exception(msg)
-
-        # initialize
-        idx = self.geometry.idx_cells
-        y = self.physics.primitive_to_conservative(self.state)
-        gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
-
-        self.injector.update_fluid_tip_positions(dt, self.t, self.state.velocity[idx])
-
-        # 1st stage of RK2
-        dydt = self.injector.source(
-            self.t,
-            y[idx],
-            self.physics,
-            gamma_star[idx],
-            e0_star[idx],
-        )
-        y1 = y[idx] + dt * dydt
-
-        # 2nd stage of RK2
-        dydt = self.injector.source(
-            self.t + dt,
-            y1,
-            self.physics,
-            gamma_star[idx],
-            e0_star[idx],
-        )
-        y[idx] = 0.5 * (y[idx] + y1 + dt * dydt)
-
-        # update
-        self.state = self.physics.conservative_to_primitive(y, gamma_star, e0_star)
-
     def update_probes(self, iters):
         """
         This method updates all the probes to the current value
@@ -538,34 +270,27 @@ class Combustor:
         """
         iters = 0
         res_p = np.inf
+        gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
+        state_array = self.physics.primitive_to_conservative(self.state)
         while self.t < tFinal and res_p > res_p_target:
             p_old = self.state.pressure
             dt = min(tFinal - self.t, self.get_time_step())
-            # advance advection and chemistry
-            if self.physics.is_flamelet:
-                self.advance_advection(dt)
-                self.advance_chemistry(dt)
-            else:
-                # use Strang splitting
-                self.advance_chemistry(dt / 2.0)
-                self.advance_advection(dt)
-                self.advance_chemistry(dt / 2.0)
-            # advance other terms
-            if self.include_diffusion:
-                self.advance_diffusion(dt)
-            if self.area_change is not None:
-                self.advance_quasi_1d(dt)
-            if self.include_boundary_layer:
-                self.advance_boundary_layer(dt)
-            if self.source_terms is not None:
-                self.advance_source_terms(dt)
-            if self.injector is not None:
-                self.advance_injector(dt)
-            # update properties
-            self.state.temperature = self.physics.get_temperature(self.state)
-            self.state.gamma = self.physics.get_gamma(self.state)
+
+            # Update the system state
+            self.t, state_array = self.time_integrator.advance(
+                dt=dt,
+                time=self.t,
+                state_array=state_array,
+                physics=self.physics,
+                gamma_star=gamma_star,
+                e0_star=e0_star,
+            )
+            self.state = self.physics.conservative_to_primitive(
+                state_array, gamma_star, e0_star
+            )
+            gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
+
             # perform other updates
-            self.t += dt
             self.update_probes(iters)
             self.update_XT_diagrams(iters)
             iters += 1

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -178,16 +178,10 @@ class Combustor:
                 advection,
             ]
         elif self.physics.gas.n_reactions > 0:
-            integrators += [
-                StrangSplitting(
-                    transport_operator=advection,
-                    reaction_operator=ScipyIVP(
-                        ConstantVolumeChemistry(
-                            geometry=self.geometry, physics=self.physics
-                        )
-                    ),
-                )
-            ]
+            chemistry = ScipyIVP(
+                ConstantVolumeChemistry(geometry=self.geometry, physics=self.physics)
+            )
+            integrators += [StrangSplitting((chemistry, advection))]
         else:
             integrators += [advection]
 
@@ -226,7 +220,7 @@ class Combustor:
             integrators += [HeunsMethod(self.injector)]
 
         # Apply Lie splitting approach
-        self.time_integrator = LieSplitting(integrators)
+        self.time_integrator = LieSplitting(tuple(integrators))
 
         self.F = np.ones(self.geometry.n_cells)  # thickening
 

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -287,7 +287,6 @@ class Combustor:
                 dt=dt,
                 time=self.t,
                 state_array=state_array,
-                physics=self.physics,
                 gamma_star=gamma_star,
                 e0_star=e0_star,
             )

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -9,6 +9,7 @@ from stanshock.numerics.boundary_conditions import (
     BoundaryConditions,
     set_boundary_conditions,
 )
+from stanshock.numerics.face_average import SimpleAverage
 from stanshock.numerics.face_extrapolation import (
     FaceExtrapolator,
     FifthOrderWeno,
@@ -159,6 +160,7 @@ class Combustor:
             boundary_conditions=self.boundary_conditions,
             riemann_solver=self.flux_function,
             geometry=self.geometry,
+            physics=self.physics,
         )
 
         # Set up time integrators
@@ -179,12 +181,14 @@ class Combustor:
 
         if self.include_diffusion:
             self.viscous_flux = ViscousFlux(
+                geometry=self.geometry,
+                physics=self.physics,
                 boundary_conditions=self.boundary_conditions,
                 face_extrapolator=self.viscous_face_extrapolator(
                     n_scalars_rho_sum=self.physics.n_scalars_rho_sum,
                     n_ghost_layers=self.geometry.n_ghost_layers,
                 ),
-                geometry=self.geometry,
+                face_average=SimpleAverage(),
                 gradient=CentralDifference(n_ghost_layers=self.geometry.n_ghost_layers),
             )
             integrators += [HeunsMethod(self.viscous_flux)]
@@ -195,9 +199,9 @@ class Combustor:
         if self.include_boundary_layer:
             # Initialize the boundary layer source terms
             self.boundary_layer = BoundaryLayer(
-                geometry=self.geometry,
                 wall_temperature=self.wall_temperature,
                 skin_friction_coefficient=self.skin_friction_coefficient,
+                geometry=self.geometry,
             )
             integrators += [ForwardEuler(self.boundary_layer)]
 

--- a/src/stanshock/models/area_change.py
+++ b/src/stanshock/models/area_change.py
@@ -1,139 +1,191 @@
 from __future__ import annotations
 
+from typing import Unpack
+
 import numpy as np
 from scipy import integrate
 
-from stanshock.physics.fluid_base import FluidPhysics, FluidState
+from stanshock.physics.fluid_base import FluidState
 from stanshock.system.backend import Array, Index
-from stanshock.system.base import RightHandSide
-from stanshock.system.geometry import Geometry
+from stanshock.system.base import FastSlowSource, PrecomputeSteps
 
 
-class AreaChange(RightHandSide):
-    def __init__(self, geometry: Geometry) -> None:
-        self.geometry: Geometry = geometry
+class AreaChange(FastSlowSource):
+    PRECOMPUTE_STEPS = ("geometry", "physics")
+
+    def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
+        super().__init__(**precompute_steps)
         # self.integrator = integrate.ode(f=self.source_fast).set_integrator(name="lsoda")
         self.integrator = integrate.ode(
             f=self.source_fast, jac=self.source_fast_jacobian_banded
         ).set_integrator("lsoda", lband=0, uband=0)
-
-        # Define global indices
-        self.idx_locations = self.geometry.idx_cells
-        self.idx_source_terms = np.s_[:]
 
         # For geometries with no area change, replace the source term with a no-op
         self.no_area_change: bool = (
             self.geometry.dlnA_dt is None and self.geometry.dlnA_dx is None
         )
 
-    def source(
-        self,
-        time: float,
-        state_array: Array,
-        physics: FluidPhysics,
-        gamma_star: Array,
-        e0_star: Array,
-        dt: float,
-    ) -> Array:
-        if self.no_area_change:
-            return np.zeros((1,))
-
-        idx = self.idx_locations
-        xc = self.geometry.xc[idx]
-        state = physics.conservative_to_primitive(
-            state_array[idx], gamma_star[idx], e0_star[idx]
-        )
-        Y0 = state.composition
-
-        state0_compact = np.zeros((state_array[idx].shape[0], 4))
-        state0_compact[:, 0] = state.density
-        state0_compact[:, 1] = state_array[idx, 0]
-        state0_compact[:, 2] = state_array[idx, 1]
-        state0_compact[:, 3] = state.pressure
-
-        # Divide domain between explicit and implicit source terms
-        idx_explicit: Index = np.arange(self.geometry.n_cells_interior, dtype=np.int64)
-        assert isinstance(idx_explicit, np.ndarray)
+    def update_indices(self, time: float) -> None:
+        """Divide domain between explicit and implicit source terms."""
+        idx_explicit: Index = self.geometry.idx_cells
         idx_implicit: Index = np.array([], dtype=np.int64)
-        assert isinstance(idx_implicit, np.ndarray)
-        rhs: Array = np.zeros_like(state_array[idx, self.idx_source_terms])
 
         if self.geometry.dlnA_dt is not None:
-            dlnA_dt: Array | float = self.geometry.dlnA_dt(time, xc)
+            x = self.geometry.xc[self.idx_domain]
+            dlnA_dt: Array | float = self.geometry.dlnA_dt(time, x)
             assert isinstance(dlnA_dt, np.ndarray)
             idx_implicit = np.where(dlnA_dt != 0.0)[0]
             idx_explicit = np.where(dlnA_dt == 0.0)[0]
 
-            # Integrate fast terms implicitly
-            if idx_implicit.size != 0:
-                # Initialize
-                y0: Array = state0_compact[idx_implicit, :].copy()
-                args: tuple[Array, Array] = (
-                    xc[idx_implicit],
-                    gamma_star[idx][idx_implicit],
-                )
-                self.integrator.set_initial_value(y=y0, t=time)
-                self.integrator.set_f_params(args)
-                self.integrator.set_jac_params(args)
+        self.idx_implicit = idx_implicit
+        self.idx_explicit = idx_explicit
 
-                # Solve
-                self.integrator.integrate(t=time + dt)
-
-                # Store RHS source term
-                rhs_compact: Array = (self.integrator.y - y0) / dt
-                rhs[idx_implicit, 0:2] += rhs_compact[:, 1:]  # ru and re_t
-                rhs[idx_implicit, 2:] += (
-                    rhs_compact[:, 0:1] * Y0[idx_implicit, :]
-                )  # rY sources
-
-        # Add slow source terms
-        rhs_compact = self.source_slow(
-            time=time, state0_compact=state0_compact, state=state, idx=idx_explicit
+    def precompute(
+        self,
+        time: float,
+        state_array: Array,
+        gamma_star: Array | None = None,
+        e0_star: Array | None = None,
+    ) -> tuple[
+        Array,
+        FluidState | None,
+        FluidState | None,
+        FluidState | None,
+        FluidState | None,
+    ]:
+        state_array, state, _, _, _ = super().precompute(
+            time, state_array, gamma_star, e0_star
         )
-        rhs[idx_explicit, 0:2] += rhs_compact[idx_explicit, 1:3]  # ru and re_t
-        rhs[idx_explicit, 2:] += (
-            rhs_compact[idx_explicit, 0:1] * Y0[idx_explicit, :]
-        )  # rY sources
+        assert state is not None
+        assert state.density is not None
+        assert state.pressure is not None
 
-        return rhs
+        idx = self.idx_domain
+        state_array = state_array[idx]
+
+        state0_compact = np.zeros((state_array.shape[0], 4))
+        state0_compact[:, 0] = state.density[idx]
+        state0_compact[:, 1] = state_array[:, 0]
+        state0_compact[:, 2] = state_array[:, 1]
+        state0_compact[:, 3] = state.pressure[idx]
+
+        return state0_compact, state, None, None, None
+
+    def source(
+        self,
+        time: float,
+        state_array: Array,
+        gamma_star: Array | None = None,
+        e0_star: Array | None = None,
+    ) -> Array:
+        rhs_full = np.zeros_like(state_array)
+        if self.no_area_change:
+            return rhs_full
+
+        state_array, state, _, _, _ = self.precompute(
+            time, state_array, gamma_star, e0_star
+        )
+
+        return self.source_implementation(time, state_array, state, None, None, None)
+
+        # # Integrate fast terms implicitly
+        # if idx_implicit.size != 0:
+        #     # Initialize
+        #     y0: Array = state0_compact[idx_implicit, :].copy()
+        #     args: tuple[Array, Array] = (
+        #         xc[idx_implicit],
+        #         gamma_star[idx][idx_implicit],
+        #     )
+        #     self.integrator.set_initial_value(y=y0, t=time)
+        #     self.integrator.set_f_params(args)
+        #     self.integrator.set_jac_params(args)
+
+        #     # Solve
+        #     self.integrator.integrate(t=time + dt)
+
+        #     # Store RHS source term
+        #     rhs_compact: Array = (self.integrator.y - y0) / dt
+        #     rhs[idx_implicit, 0:2] += rhs_compact[:, 1:]  # ru and re_t
+        #     rhs[idx_implicit, 2:] += (
+        #         rhs_compact[:, 0:1] * Y0[idx_implicit, :]
+        #     )  # rY sources
+
+        # # Add slow source terms
+        # rhs_compact = self.source_slow(
+        #     time=time, state0_compact=state0_compact, state=state, idx=idx_explicit
+        # )
+        # rhs[idx_explicit, 0:2] += rhs_compact[idx_explicit, 1:3]  # ru and re_t
+        # rhs[idx_explicit, 2:] += (
+        #     rhs_compact[idx_explicit, 0:1] * Y0[idx_explicit, :]
+        # )  # rY sources
+
+        # return rhs
+
+    def postcompute(self, state_array: Array, state: FluidState) -> Array:
+        """Undo any transforms to the state array during precompute steps."""
+        state_array_full = np.zeros(self.shape)
+
+        assert state.composition is not None
+        Y = state.composition
+        state_array_full[:, 0:2] = state_array[:, 1:3]  # ru and re_t
+        state_array_full[:, 2:] = state_array[:, 0:1] * Y
+
+        return np.ravel(state_array_full)
 
     def source_slow(
-        self, time: float, state0_compact: Array, state: FluidState, idx: Index
+        self,
+        time: float,
+        state_array: Array | None,
+        state: FluidState | None,
+        face_states: FluidState | None,
+        avg_face_states: FluidState | None,
+        face_gradients: FluidState | None,
     ) -> Array:
         """Area change contributions to RHS."""
-        rhs_compact: Array = np.zeros_like(state0_compact[idx])
-        x: Array = self.geometry.xc[self.geometry.idx_cells][idx]
-
-        if self.geometry.dlnA_dt is not None:
-            dlnA_dt: Array | float = self.geometry.dlnA_dt(time, x)
-            rhs_compact -= state0_compact[idx, :] * dlnA_dt
+        assert state_array is not None
+        _ = face_states, avg_face_states, face_gradients
+        idx = self.idx_explicit
+        state_array = state_array[idx, :]
+        rhs_compact: Array = np.zeros_like(state_array)
 
         if self.geometry.dlnA_dx is not None:
+            assert state is not None
             assert state.pressure is not None
             assert state.velocity is not None
 
+            x: Array = self.geometry.xc[idx]
             dlnA_dx: Array | float = self.geometry.dlnA_dx(time, x)
-            rhs_compact[:, 0] -= state0_compact[idx, 1] * dlnA_dx
+            rhs_compact[:, 0] -= state_array[:, 1] * dlnA_dx
             rhs_compact[:, 1] -= (
-                state0_compact[idx, 1] ** 2.0 / state0_compact[idx, 0]
+                state_array[:, 1] ** 2.0 / state_array[:, 0]
             ) * dlnA_dx
             rhs_compact[:, 2] -= (
-                state.velocity[idx] * (state0_compact[idx, 2] + state.pressure[idx])
+                state.velocity[idx] * (state_array[:, 2] + state.pressure[idx])
             ) * dlnA_dx
 
         return rhs_compact
 
-    def source_fast(self, time: float, y: Array, args: tuple[Array, Array]) -> Array:
+    def source_fast(
+        self,
+        time: float,
+        state_array: Array | None,
+        state: FluidState | None,
+        face_states: FluidState | None,
+        avg_face_states: FluidState | None,
+        face_gradients: FluidState | None,
+    ) -> Array:
         """Fast source terms for quasi-1D geometry."""
-        # Unpack the input and initialize
-        x: Array = args[0]
-        # gamma_star: Array = args[1]
+        assert state_array is not None
+        _ = face_states, avg_face_states, face_gradients
+        x: Array = self.geometry.xc[self.idx_implicit]
         n: int = len(x)
-        r: Array = y[0:n]
-        ru: Array = y[n : 2 * n]
-        rE: Array = y[2 * n : 3 * n]
-        p: Array = y[3 * n : 4 * n]
-        rhs: Array = np.zeros_like(y)
+        r: Array = state_array[0:n]
+        ru: Array = state_array[n : 2 * n]
+        rE: Array = state_array[2 * n : 3 * n]
+        assert state is not None
+        assert state.pressure is not None
+        p: Array = state.pressure
+        rhs: Array = np.zeros_like(state_array)
 
         # create quasi-1D right hand side
         if self.geometry.dlnA_dt is not None:

--- a/src/stanshock/models/area_change.py
+++ b/src/stanshock/models/area_change.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from typing import Unpack
-
 import numpy as np
-from scipy import integrate
 
 from stanshock.physics.fluid_base import FluidState
-from stanshock.system.backend import Array, Index
+from stanshock.system.backend import Array, Index, Unpack
 from stanshock.system.base import FastSlowSource, PrecomputeSteps
 
 
@@ -15,24 +12,23 @@ class AreaChange(FastSlowSource):
 
     def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
         super().__init__(**precompute_steps)
-        # self.integrator = integrate.ode(f=self.source_fast).set_integrator(name="lsoda")
-        self.integrator = integrate.ode(
-            f=self.source_fast, jac=self.source_fast_jacobian_banded
-        ).set_integrator("lsoda", lband=0, uband=0)
+        self.shape_update = (-1, 3)
+        self.jac = self.source_fast_jacobian_banded
+        self.x: Array = self.geometry.xc[self.idx_domain]
 
         # For geometries with no area change, replace the source term with a no-op
         self.no_area_change: bool = (
             self.geometry.dlnA_dt is None and self.geometry.dlnA_dx is None
         )
 
-    def update_indices(self, time: float) -> None:
+    def update_indices(self, time: float, state: FluidState) -> None:
         """Divide domain between explicit and implicit source terms."""
-        idx_explicit: Index = self.geometry.idx_cells
+        _ = state
+        idx_explicit: Index = np.s_[:]
         idx_implicit: Index = np.array([], dtype=np.int64)
 
         if self.geometry.dlnA_dt is not None:
-            x = self.geometry.xc[self.idx_update]
-            dlnA_dt: Array | float = self.geometry.dlnA_dt(time, x)
+            dlnA_dt: Array | float = self.geometry.dlnA_dt(time, self.x)
             assert isinstance(dlnA_dt, np.ndarray)
             idx_implicit = np.where(dlnA_dt != 0.0)[0]
             idx_explicit = np.where(dlnA_dt == 0.0)[0]
@@ -44,14 +40,15 @@ class AreaChange(FastSlowSource):
         self,
         time: float,
         state_array: Array,
-        update_double_flux: bool = True,
+        gamma_star: Array | None,
+        e0_star: Array | None,
     ) -> tuple[Array, Array | None, Array | None]:
         """Replace species transport equations with mass continuity."""
         state_array_local, gamma_star, e0_star = super().before_time_integration(
-            time, state_array, update_double_flux
+            time, state_array, gamma_star, e0_star
         )
 
-        assert self.physics is not None
+        state_array_local = np.reshape(state_array_local, self.shape_domain)
         state_compact = state_array_local[:, :3].copy()
         n = self.physics.n_scalars_rho_sum
         if n > 1:
@@ -60,20 +57,41 @@ class AreaChange(FastSlowSource):
         # Store the frozen composition
         self.composition_frozen = state_array_local[:, 2:] / state_compact[:, 2:3]
 
-        return state_compact, gamma_star, e0_star
+        return np.ravel(state_compact), gamma_star, e0_star
 
     def after_time_integration(
-        self, state_array: Array, state_array_local: Array
-    ) -> Array:
+        self,
+        time: float,
+        state_array_local: Array,
+        gamma_star_local: Array | None,
+        e0_star_local: Array | None,
+        state_array: Array,
+        gamma_star: Array | None,
+        e0_star: Array | None,
+    ) -> tuple[Array, Array | None, Array | None]:
         """Apply density update to all scalars."""
-        assert self.physics is not None
+        state_array_local = np.reshape(state_array_local, shape=self.shape_update)
         state_array_local = np.pad(
-            state_array_local, (0, (0, self.physics.n_scalars - 1)), mode="edge"
+            state_array_local, ((0, 0), (0, self.physics.n_scalars - 1)), mode="edge"
         )
         state_array_local[:, 2:] *= self.composition_frozen
-        state_array[self.idx_domain] = np.ravel(state_array_local)
 
-        return state_array
+        return super().after_time_integration(
+            time=time,
+            state_array_local=state_array_local,
+            gamma_star_local=gamma_star_local,
+            e0_star_local=e0_star_local,
+            state_array=state_array,
+            gamma_star=gamma_star,
+            e0_star=e0_star,
+        )
+
+    def add_source(self, y: Array, dy: Array) -> Array:
+        """Add (2D) source term to the (1D) state array."""
+        dy = np.reshape(dy, self.shape_update)
+        state_array_local = np.reshape(y, self.shape_update)
+        state_array_local[self.idx_update, self.idx_source] += dy
+        return np.ravel(state_array_local)
 
     def precompute_for_source(
         self,
@@ -89,6 +107,7 @@ class AreaChange(FastSlowSource):
         FluidState | None,
     ]:
         _ = time
+        state_array_local = np.reshape(state_array_local, shape=self.shape_update)
         ru = state_array_local[:, 0]
         re_t = state_array_local[:, 1]
         r = state_array_local[:, 2]
@@ -105,8 +124,10 @@ class AreaChange(FastSlowSource):
             gamma_star=gamma_star,
             e0_star=e0_star,
         )
+        state.pressure = self.physics.get_pressure(state)
+        state.temperature = self.physics.get_temperature(state)
 
-        return state_array_local, state, None, None, None
+        return np.ravel(state_array_local), state, None, None, None
 
     def source(
         self,
@@ -119,20 +140,23 @@ class AreaChange(FastSlowSource):
             return np.zeros_like(state_array_local)
         return super().source(time, state_array_local, gamma_star, e0_star)
 
-        # # Integrate fast terms implicitly
-        # if idx_implicit.size != 0:
-        #     # Initialize
-        #     y0: Array = state0_compact[idx_implicit, :].copy()
-        #     args: tuple[Array, Array] = (
-        #         xc[idx_implicit],
-        #         gamma_star[idx][idx_implicit],
-        #     )
-        #     self.integrator.set_initial_value(y=y0, t=time)
-        #     self.integrator.set_f_params(args)
-        #     self.integrator.set_jac_params(args)
+    def source_full(
+        self,
+        time: float,
+        state_array_local: Array,
+        gamma_star: Array | None = None,
+        e0_star: Array | None = None,
+    ) -> Array:
+        """Transform the RHS into standard format."""
+        rhs = self.source(time, state_array_local, gamma_star, e0_star)
+        rhs = np.reshape(rhs, self.shape_update)
+        rhs = np.pad(rhs, ((0, 0), (0, self.physics.n_scalars - 1)), mode="edge")
+        rhs[:, 2:] *= self.composition_frozen
 
-        #     # Solve
-        #     self.integrator.integrate(t=time + dt)
+        rhs_full = np.zeros(self.shape_domain)
+        rhs_full[self.idx_update, :] = rhs
+
+        return np.ravel(rhs_full)
 
     def source_slow(
         self,
@@ -146,26 +170,26 @@ class AreaChange(FastSlowSource):
         """Area change contributions to RHS."""
         assert state_array_local is not None
         _ = face_states, avg_face_states, face_gradients
-        idx = self.idx_explicit
-        state_array_local = state_array_local[idx, :]
+        state_array_local = np.reshape(state_array_local, shape=self.shape_update)
         rhs_compact: Array = np.zeros_like(state_array_local)
 
         if self.geometry.dlnA_dx is not None:
             assert state is not None
-            assert state.pressure is not None
             assert state.velocity is not None
+            assert state.pressure is not None
+            ru: Array = state_array_local[:, 0]
+            rE: Array = state_array_local[:, 1]
+            u: Array = state.velocity
+            p: Array = state.pressure
 
-            x: Array = self.geometry.xc[idx]
+            x: Array = self.x[self.idx_explicit]
             dlnA_dx: Array | float = self.geometry.dlnA_dx(time, x)
-            rhs_compact[:, 0] -= state_array_local[:, 1] * dlnA_dx
-            rhs_compact[:, 1] -= (
-                state_array_local[:, 1] ** 2.0 / state_array_local[:, 0]
-            ) * dlnA_dx
-            rhs_compact[:, 2] -= (
-                state.velocity[idx] * (state_array_local[:, 2] + state.pressure[idx])
-            ) * dlnA_dx
 
-        return rhs_compact
+            rhs_compact[:, 0] -= u * ru * dlnA_dx
+            rhs_compact[:, 1] -= u * (rE + p) * dlnA_dx
+            rhs_compact[:, 2] -= ru * dlnA_dx
+
+        return np.ravel(rhs_compact)
 
     def source_fast(
         self,
@@ -179,39 +203,47 @@ class AreaChange(FastSlowSource):
         """Fast source terms for quasi-1D geometry."""
         assert state_array_local is not None
         _ = face_states, avg_face_states, face_gradients
-        x: Array = self.geometry.xc[self.idx_implicit]
-        n: int = len(x)
-        r: Array = state_array_local[0:n]
-        ru: Array = state_array_local[n : 2 * n]
-        rE: Array = state_array_local[2 * n : 3 * n]
-        assert state is not None
-        assert state.pressure is not None
-        p: Array = state.pressure
-        rhs: Array = np.zeros_like(state_array_local)
+        x: Array = self.x[self.idx_implicit]
+        state_array_local = np.reshape(state_array_local, shape=self.shape_update)
+        rhs_compact: Array = np.zeros_like(state_array_local)
 
         # create quasi-1D right hand side
         if self.geometry.dlnA_dt is not None:
             dlnA_dt: Array | float = self.geometry.dlnA_dt(time, x)
-            rhs[0:n] -= r * dlnA_dt
-            rhs[n : 2 * n] -= ru * dlnA_dt
-            rhs[2 * n : 3 * n] -= rE * dlnA_dt
+            if isinstance(dlnA_dt, np.ndarray):
+                dlnA_dt = dlnA_dt[:, None]
+            rhs_compact -= state_array_local * dlnA_dt
 
         if self.geometry.dlnA_dx is not None:
+            assert state is not None
+            assert state.velocity is not None
+            assert state.pressure is not None
+            ru: Array = state_array_local[:, 0]
+            rE: Array = state_array_local[:, 1]
+            u: Array = state.velocity
+            p: Array = state.pressure
             dlnA_dx: Array | float = self.geometry.dlnA_dx(time, x)
-            rhs[0:n] -= ru * dlnA_dx
-            rhs[n : 2 * n] -= (ru**2 / r) * dlnA_dx
-            rhs[2 * n : 3 * n] -= (ru / r * (rE + p)) * dlnA_dx
 
-        return rhs
+            rhs_compact[:, 0] -= u * ru * dlnA_dx
+            rhs_compact[:, 1] -= u * (rE + p) * dlnA_dx
+            rhs_compact[:, 2] -= ru * dlnA_dx
+
+        return np.ravel(rhs_compact)
 
     def source_fast_jacobian_banded(
-        self, time: float, y: Array, args: tuple[Array, Array]
+        self,
+        time: float,
+        state_array_local: Array,
+        gamma_star: Array | None,
+        e0_star: Array | None,
     ) -> Array:
-        x: Array = args[0]
-        gamma_star: Array = args[1]
+        assert gamma_star is not None
+        _ = e0_star
+        x: Array = self.geometry.xc[self.idx_implicit]
         n: int = len(x)
-        r: Array = y[0:n]
-        ru: Array = y[n : 2 * n]
+        state_array_local = np.reshape(state_array_local, shape=self.shape_update)
+        ru: Array = state_array_local[:, 0]
+        r: Array = state_array_local[:, 2]
         # rE: Array = y[2 * n : 3 * n]
         # p = (gamma_star - 1) * (rE - r*e0_star - 0.5 * ru**2 / r)
 
@@ -222,12 +254,12 @@ class AreaChange(FastSlowSource):
             self.geometry.dlnA_dx(time, x) if self.geometry.dlnA_dx is not None else 0.0
         )
 
-        J_diag: Array = np.zeros(3 * n)
+        J_diag: Array = np.zeros((n, 3))
 
         # Diagonal entries per variable
-        J_diag[0:n] = -dlnAdt  # ∂R/∂ρ  # noqa: RUF003
-        J_diag[n : 2 * n] = -dlnAdt  # ∂R/∂(ρu)  # noqa: RUF003
-        J_diag[2 * n : 3 * n] = -dlnAdt - (ru / r) * gamma_star * dlnAdx  # ∂R/∂E
+        J_diag[:, 0] = -dlnAdt  # ∂R/∂(ρu)  # noqa: RUF003
+        J_diag[:, 1] = -dlnAdt - (ru / r) * gamma_star * dlnAdx  # ∂R/∂E
+        J_diag[:, 2] = -dlnAdt  # ∂R/∂ρ  # noqa: RUF003
         return J_diag.reshape(
             1, 3 * n
         )  # shape (1, 3n): banded with 0 lower and upper bandwidth

--- a/src/stanshock/models/area_change.py
+++ b/src/stanshock/models/area_change.py
@@ -13,9 +13,9 @@ class AreaChange(FastSlowSource):
     def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
         super().__init__(**precompute_steps)
         assert self.geometry is not None
-        self.shape_update = (-1, 3)
+        self.shape_output = (-1, 3)
         self.jac = self.source_fast_jacobian_banded
-        self.x: Array = self.geometry.xc[self.idx_domain]
+        self.x: Array = self.geometry.xc[self.idx_input]
 
         # For geometries with no area change, replace the source term with a no-op
         self.no_area_change: bool = (
@@ -35,8 +35,8 @@ class AreaChange(FastSlowSource):
             idx_update_implicit = np.where(dlnA_dt != 0.0)[0]
             idx_update_explicit = np.where(dlnA_dt == 0.0)[0]
 
-        self.idx_update_implicit = idx_update_implicit
-        self.idx_update_explicit = idx_update_explicit
+        self.idx_output_implicit = idx_update_implicit
+        self.idx_output_explicit = idx_update_explicit
 
     def before_time_integration(
         self,
@@ -51,7 +51,7 @@ class AreaChange(FastSlowSource):
             time, state_array, gamma_star, e0_star
         )
 
-        state_array_local = np.reshape(state_array_local, self.shape_domain)
+        state_array_local = np.reshape(state_array_local, self.shape_input)
         state_compact = state_array_local[:, :3].copy()
         n = self.physics.n_scalars_rho_sum
         if n > 1:
@@ -74,7 +74,7 @@ class AreaChange(FastSlowSource):
     ) -> tuple[Array, Array | None, Array | None]:
         """Apply density update to all scalars."""
         assert self.physics is not None
-        state_array_local = np.reshape(state_array_local, shape=self.shape_update)
+        state_array_local = np.reshape(state_array_local, shape=self.shape_output)
         state_array_local = np.pad(
             state_array_local, ((0, 0), (0, self.physics.n_scalars - 1)), mode="edge"
         )
@@ -92,9 +92,9 @@ class AreaChange(FastSlowSource):
 
     def add_source(self, y: Array, dy: Array) -> Array:
         """Add (2D) source term to the (1D) state array."""
-        dy = np.reshape(dy, self.shape_update)
-        state_array_local = np.reshape(y, self.shape_update)
-        state_array_local[self.idx_update, self.idx_source] += dy
+        dy = np.reshape(dy, self.shape_output)
+        state_array_local = np.reshape(y, self.shape_output)
+        state_array_local[self.idx_output, self.idx_source] += dy
         return np.ravel(state_array_local)
 
     def precompute_for_source(
@@ -112,7 +112,7 @@ class AreaChange(FastSlowSource):
     ]:
         assert self.physics is not None
         _ = time
-        state_array_local = np.reshape(state_array_local, shape=self.shape_update)
+        state_array_local = np.reshape(state_array_local, shape=self.shape_output)
         ru = state_array_local[:, 0]
         re_t = state_array_local[:, 1]
         r = state_array_local[:, 2]
@@ -155,12 +155,12 @@ class AreaChange(FastSlowSource):
         """Transform the RHS into standard format."""
         assert self.physics is not None
         rhs = self.source(time, state_array_local, gamma_star, e0_star)
-        rhs = np.reshape(rhs, self.shape_update)
+        rhs = np.reshape(rhs, self.shape_output)
         rhs = np.pad(rhs, ((0, 0), (0, self.physics.n_scalars - 1)), mode="edge")
         rhs[:, 2:] *= self.composition_frozen
 
-        rhs_full = np.zeros(self.shape_domain)
-        rhs_full[self.idx_update, :] = rhs
+        rhs_full = np.zeros(self.shape_input)
+        rhs_full[self.idx_output, :] = rhs
 
         return np.ravel(rhs_full)
 
@@ -177,7 +177,7 @@ class AreaChange(FastSlowSource):
         assert self.geometry is not None
         assert state_array_local is not None
         _ = face_states, avg_face_states, face_gradients
-        state_array_local = np.reshape(state_array_local, shape=self.shape_update)
+        state_array_local = np.reshape(state_array_local, shape=self.shape_output)
         rhs_compact: Array = np.zeros_like(state_array_local)
 
         if self.geometry.dlnA_dx is not None:
@@ -189,7 +189,7 @@ class AreaChange(FastSlowSource):
             u: Array = state.velocity
             p: Array = state.pressure
 
-            x: Array = self.x[self.idx_update_explicit]
+            x: Array = self.x[self.idx_output_explicit]
             dlnA_dx: Array | float = self.geometry.dlnA_dx(time, x)
 
             rhs_compact[:, 0] -= u * ru * dlnA_dx
@@ -211,8 +211,8 @@ class AreaChange(FastSlowSource):
         assert self.geometry is not None
         assert state_array_local is not None
         _ = face_states, avg_face_states, face_gradients
-        x: Array = self.x[self.idx_update_implicit]
-        state_array_local = np.reshape(state_array_local, shape=self.shape_update)
+        x: Array = self.x[self.idx_output_implicit]
+        state_array_local = np.reshape(state_array_local, shape=self.shape_output)
         rhs_compact: Array = np.zeros_like(state_array_local)
 
         # create quasi-1D right hand side
@@ -248,9 +248,9 @@ class AreaChange(FastSlowSource):
         assert self.geometry is not None
         assert gamma_star is not None
         _ = e0_star
-        x: Array = self.geometry.xc[self.idx_update_implicit]
+        x: Array = self.geometry.xc[self.idx_output_implicit]
         n: int = len(x)
-        state_array_local = np.reshape(state_array_local, shape=self.shape_update)
+        state_array_local = np.reshape(state_array_local, shape=self.shape_output)
         ru: Array = state_array_local[:, 0]
         r: Array = state_array_local[:, 2]
         # rE: Array = y[2 * n : 3 * n]

--- a/src/stanshock/models/area_change.py
+++ b/src/stanshock/models/area_change.py
@@ -31,7 +31,7 @@ class AreaChange(FastSlowSource):
         idx_implicit: Index = np.array([], dtype=np.int64)
 
         if self.geometry.dlnA_dt is not None:
-            x = self.geometry.xc[self.idx_domain]
+            x = self.geometry.xc[self.idx_update]
             dlnA_dt: Array | float = self.geometry.dlnA_dt(time, x)
             assert isinstance(dlnA_dt, np.ndarray)
             idx_implicit = np.where(dlnA_dt != 0.0)[0]
@@ -40,10 +40,45 @@ class AreaChange(FastSlowSource):
         self.idx_implicit = idx_implicit
         self.idx_explicit = idx_explicit
 
-    def precompute(
+    def before_time_integration(
         self,
         time: float,
         state_array: Array,
+        update_double_flux: bool = True,
+    ) -> tuple[Array, Array | None, Array | None]:
+        """Replace species transport equations with mass continuity."""
+        state_array_local, gamma_star, e0_star = super().before_time_integration(
+            time, state_array, update_double_flux
+        )
+
+        assert self.physics is not None
+        state_compact = state_array_local[:, :3].copy()
+        n = self.physics.n_scalars_rho_sum
+        if n > 1:
+            state_compact[:, 2] = np.sum(state_array_local[:, 2 : 2 + n], axis=1)
+
+        # Store the frozen composition
+        self.composition_frozen = state_array_local[:, 2:] / state_compact[:, 2:3]
+
+        return state_compact, gamma_star, e0_star
+
+    def after_time_integration(
+        self, state_array: Array, state_array_local: Array
+    ) -> Array:
+        """Apply density update to all scalars."""
+        assert self.physics is not None
+        state_array_local = np.pad(
+            state_array_local, (0, (0, self.physics.n_scalars - 1)), mode="edge"
+        )
+        state_array_local[:, 2:] *= self.composition_frozen
+        state_array[self.idx_domain] = np.ravel(state_array_local)
+
+        return state_array
+
+    def precompute_for_source(
+        self,
+        time: float,
+        state_array_local: Array,
         gamma_star: Array | None = None,
         e0_star: Array | None = None,
     ) -> tuple[
@@ -53,40 +88,36 @@ class AreaChange(FastSlowSource):
         FluidState | None,
         FluidState | None,
     ]:
-        state_array, state, _, _, _ = super().precompute(
-            time, state_array, gamma_star, e0_star
+        _ = time
+        ru = state_array_local[:, 0]
+        re_t = state_array_local[:, 1]
+        r = state_array_local[:, 2]
+
+        u = ru / r
+        e_int = (re_t / r) - 0.5 * u**2.0
+
+        state = FluidState(
+            shape=(state_array_local.shape[0],),
+            density=r,
+            velocity=u,
+            internal_energy=e_int,
+            composition=self.composition_frozen,
+            gamma_star=gamma_star,
+            e0_star=e0_star,
         )
-        assert state is not None
-        assert state.density is not None
-        assert state.pressure is not None
 
-        idx = self.idx_domain
-        state_array = state_array[idx]
-
-        state0_compact = np.zeros((state_array.shape[0], 4))
-        state0_compact[:, 0] = state.density[idx]
-        state0_compact[:, 1] = state_array[:, 0]
-        state0_compact[:, 2] = state_array[:, 1]
-        state0_compact[:, 3] = state.pressure[idx]
-
-        return state0_compact, state, None, None, None
+        return state_array_local, state, None, None, None
 
     def source(
         self,
         time: float,
-        state_array: Array,
+        state_array_local: Array,
         gamma_star: Array | None = None,
         e0_star: Array | None = None,
     ) -> Array:
-        rhs_full = np.zeros_like(state_array)
         if self.no_area_change:
-            return rhs_full
-
-        state_array, state, _, _, _ = self.precompute(
-            time, state_array, gamma_star, e0_star
-        )
-
-        return self.source_implementation(time, state_array, state, None, None, None)
+            return np.zeros_like(state_array_local)
+        return super().source(time, state_array_local, gamma_star, e0_star)
 
         # # Integrate fast terms implicitly
         # if idx_implicit.size != 0:
@@ -103,50 +134,21 @@ class AreaChange(FastSlowSource):
         #     # Solve
         #     self.integrator.integrate(t=time + dt)
 
-        #     # Store RHS source term
-        #     rhs_compact: Array = (self.integrator.y - y0) / dt
-        #     rhs[idx_implicit, 0:2] += rhs_compact[:, 1:]  # ru and re_t
-        #     rhs[idx_implicit, 2:] += (
-        #         rhs_compact[:, 0:1] * Y0[idx_implicit, :]
-        #     )  # rY sources
-
-        # # Add slow source terms
-        # rhs_compact = self.source_slow(
-        #     time=time, state0_compact=state0_compact, state=state, idx=idx_explicit
-        # )
-        # rhs[idx_explicit, 0:2] += rhs_compact[idx_explicit, 1:3]  # ru and re_t
-        # rhs[idx_explicit, 2:] += (
-        #     rhs_compact[idx_explicit, 0:1] * Y0[idx_explicit, :]
-        # )  # rY sources
-
-        # return rhs
-
-    def postcompute(self, state_array: Array, state: FluidState) -> Array:
-        """Undo any transforms to the state array during precompute steps."""
-        state_array_full = np.zeros(self.shape)
-
-        assert state.composition is not None
-        Y = state.composition
-        state_array_full[:, 0:2] = state_array[:, 1:3]  # ru and re_t
-        state_array_full[:, 2:] = state_array[:, 0:1] * Y
-
-        return np.ravel(state_array_full)
-
     def source_slow(
         self,
         time: float,
-        state_array: Array | None,
+        state_array_local: Array | None,
         state: FluidState | None,
         face_states: FluidState | None,
         avg_face_states: FluidState | None,
         face_gradients: FluidState | None,
     ) -> Array:
         """Area change contributions to RHS."""
-        assert state_array is not None
+        assert state_array_local is not None
         _ = face_states, avg_face_states, face_gradients
         idx = self.idx_explicit
-        state_array = state_array[idx, :]
-        rhs_compact: Array = np.zeros_like(state_array)
+        state_array_local = state_array_local[idx, :]
+        rhs_compact: Array = np.zeros_like(state_array_local)
 
         if self.geometry.dlnA_dx is not None:
             assert state is not None
@@ -155,12 +157,12 @@ class AreaChange(FastSlowSource):
 
             x: Array = self.geometry.xc[idx]
             dlnA_dx: Array | float = self.geometry.dlnA_dx(time, x)
-            rhs_compact[:, 0] -= state_array[:, 1] * dlnA_dx
+            rhs_compact[:, 0] -= state_array_local[:, 1] * dlnA_dx
             rhs_compact[:, 1] -= (
-                state_array[:, 1] ** 2.0 / state_array[:, 0]
+                state_array_local[:, 1] ** 2.0 / state_array_local[:, 0]
             ) * dlnA_dx
             rhs_compact[:, 2] -= (
-                state.velocity[idx] * (state_array[:, 2] + state.pressure[idx])
+                state.velocity[idx] * (state_array_local[:, 2] + state.pressure[idx])
             ) * dlnA_dx
 
         return rhs_compact
@@ -168,24 +170,24 @@ class AreaChange(FastSlowSource):
     def source_fast(
         self,
         time: float,
-        state_array: Array | None,
+        state_array_local: Array | None,
         state: FluidState | None,
         face_states: FluidState | None,
         avg_face_states: FluidState | None,
         face_gradients: FluidState | None,
     ) -> Array:
         """Fast source terms for quasi-1D geometry."""
-        assert state_array is not None
+        assert state_array_local is not None
         _ = face_states, avg_face_states, face_gradients
         x: Array = self.geometry.xc[self.idx_implicit]
         n: int = len(x)
-        r: Array = state_array[0:n]
-        ru: Array = state_array[n : 2 * n]
-        rE: Array = state_array[2 * n : 3 * n]
+        r: Array = state_array_local[0:n]
+        ru: Array = state_array_local[n : 2 * n]
+        rE: Array = state_array_local[2 * n : 3 * n]
         assert state is not None
         assert state.pressure is not None
         p: Array = state.pressure
-        rhs: Array = np.zeros_like(state_array)
+        rhs: Array = np.zeros_like(state_array_local)
 
         # create quasi-1D right hand side
         if self.geometry.dlnA_dt is not None:

--- a/src/stanshock/models/area_change.py
+++ b/src/stanshock/models/area_change.py
@@ -12,6 +12,7 @@ class AreaChange(FastSlowSource):
 
     def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
         super().__init__(**precompute_steps)
+        assert self.geometry is not None
         self.shape_update = (-1, 3)
         self.jac = self.source_fast_jacobian_banded
         self.x: Array = self.geometry.xc[self.idx_domain]
@@ -21,20 +22,21 @@ class AreaChange(FastSlowSource):
             self.geometry.dlnA_dt is None and self.geometry.dlnA_dx is None
         )
 
-    def update_indices(self, time: float, state: FluidState) -> None:
+    def update_indices(self, time: float, state: FluidState | None) -> None:
         """Divide domain between explicit and implicit source terms."""
+        assert self.geometry is not None
         _ = state
-        idx_explicit: Index = np.s_[:]
-        idx_implicit: Index = np.array([], dtype=np.int64)
+        idx_update_implicit: Index = np.array([], dtype=np.int64)
+        idx_update_explicit: Index = np.s_[:]
 
         if self.geometry.dlnA_dt is not None:
             dlnA_dt: Array | float = self.geometry.dlnA_dt(time, self.x)
             assert isinstance(dlnA_dt, np.ndarray)
-            idx_implicit = np.where(dlnA_dt != 0.0)[0]
-            idx_explicit = np.where(dlnA_dt == 0.0)[0]
+            idx_update_implicit = np.where(dlnA_dt != 0.0)[0]
+            idx_update_explicit = np.where(dlnA_dt == 0.0)[0]
 
-        self.idx_implicit = idx_implicit
-        self.idx_explicit = idx_explicit
+        self.idx_update_implicit = idx_update_implicit
+        self.idx_update_explicit = idx_update_explicit
 
     def before_time_integration(
         self,
@@ -44,6 +46,7 @@ class AreaChange(FastSlowSource):
         e0_star: Array | None,
     ) -> tuple[Array, Array | None, Array | None]:
         """Replace species transport equations with mass continuity."""
+        assert self.physics is not None
         state_array_local, gamma_star, e0_star = super().before_time_integration(
             time, state_array, gamma_star, e0_star
         )
@@ -70,6 +73,7 @@ class AreaChange(FastSlowSource):
         e0_star: Array | None,
     ) -> tuple[Array, Array | None, Array | None]:
         """Apply density update to all scalars."""
+        assert self.physics is not None
         state_array_local = np.reshape(state_array_local, shape=self.shape_update)
         state_array_local = np.pad(
             state_array_local, ((0, 0), (0, self.physics.n_scalars - 1)), mode="edge"
@@ -106,6 +110,7 @@ class AreaChange(FastSlowSource):
         FluidState | None,
         FluidState | None,
     ]:
+        assert self.physics is not None
         _ = time
         state_array_local = np.reshape(state_array_local, shape=self.shape_update)
         ru = state_array_local[:, 0]
@@ -148,6 +153,7 @@ class AreaChange(FastSlowSource):
         e0_star: Array | None = None,
     ) -> Array:
         """Transform the RHS into standard format."""
+        assert self.physics is not None
         rhs = self.source(time, state_array_local, gamma_star, e0_star)
         rhs = np.reshape(rhs, self.shape_update)
         rhs = np.pad(rhs, ((0, 0), (0, self.physics.n_scalars - 1)), mode="edge")
@@ -168,6 +174,7 @@ class AreaChange(FastSlowSource):
         face_gradients: FluidState | None,
     ) -> Array:
         """Area change contributions to RHS."""
+        assert self.geometry is not None
         assert state_array_local is not None
         _ = face_states, avg_face_states, face_gradients
         state_array_local = np.reshape(state_array_local, shape=self.shape_update)
@@ -182,7 +189,7 @@ class AreaChange(FastSlowSource):
             u: Array = state.velocity
             p: Array = state.pressure
 
-            x: Array = self.x[self.idx_explicit]
+            x: Array = self.x[self.idx_update_explicit]
             dlnA_dx: Array | float = self.geometry.dlnA_dx(time, x)
 
             rhs_compact[:, 0] -= u * ru * dlnA_dx
@@ -201,9 +208,10 @@ class AreaChange(FastSlowSource):
         face_gradients: FluidState | None,
     ) -> Array:
         """Fast source terms for quasi-1D geometry."""
+        assert self.geometry is not None
         assert state_array_local is not None
         _ = face_states, avg_face_states, face_gradients
-        x: Array = self.x[self.idx_implicit]
+        x: Array = self.x[self.idx_update_implicit]
         state_array_local = np.reshape(state_array_local, shape=self.shape_update)
         rhs_compact: Array = np.zeros_like(state_array_local)
 
@@ -237,9 +245,10 @@ class AreaChange(FastSlowSource):
         gamma_star: Array | None,
         e0_star: Array | None,
     ) -> Array:
+        assert self.geometry is not None
         assert gamma_star is not None
         _ = e0_star
-        x: Array = self.geometry.xc[self.idx_implicit]
+        x: Array = self.geometry.xc[self.idx_update_implicit]
         n: int = len(x)
         state_array_local = np.reshape(state_array_local, shape=self.shape_update)
         ru: Array = state_array_local[:, 0]

--- a/src/stanshock/models/boundary_layer.py
+++ b/src/stanshock/models/boundary_layer.py
@@ -7,7 +7,7 @@ from scipy.optimize import root
 
 from stanshock.physics.fluid_base import FluidState
 from stanshock.system.backend import Array, Index, Unpack
-from stanshock.system.base import PrecomputeSteps, RightHandSide
+from stanshock.system.base import PrecomputeStepName, PrecomputeSteps, RightHandSide
 
 
 class SkinFriction:
@@ -57,6 +57,8 @@ class SkinFriction:
 
 
 class BoundaryLayer(RightHandSide):
+    PRECOMPUTE_STEPS: tuple[PrecomputeStepName, ...] = ("geometry", "physics")
+
     def __init__(
         self,
         wall_temperature: Array | float | None = None,
@@ -136,6 +138,8 @@ class BoundaryLayer(RightHandSide):
         assert state.density is not None
         assert state.velocity is not None
         rhs = np.zeros((*state.shape, 2))
+        hydraulic_diameter = self.geometry.hydraulic_diameter(time)
+        characteristic_length = self.geometry.characteristic_length(time)
 
         x = self.geometry.xc[self.idx_domain]
         characteristic_length = self.geometry.characteristic_length(time, x)

--- a/src/stanshock/models/boundary_layer.py
+++ b/src/stanshock/models/boundary_layer.py
@@ -75,6 +75,7 @@ class BoundaryLayer(RightHandSide):
 
         # Provides momentum and energy source terms
         self.idx_source: Index = np.array([0, 1])
+        self.shape_update = (self.shape_update[0], 2)
 
     def get_nusselt_number(self, Re: Array, Pr: Array, cf: Array) -> Array:
         """
@@ -138,10 +139,7 @@ class BoundaryLayer(RightHandSide):
         assert state.density is not None
         assert state.velocity is not None
         rhs = np.zeros((*state.shape, 2))
-        hydraulic_diameter = self.geometry.hydraulic_diameter(time)
-        characteristic_length = self.geometry.characteristic_length(time)
-
-        x = self.geometry.xc[self.idx_update]
+        x = self.geometry.xc[self.idx_domain]
         characteristic_length = self.geometry.characteristic_length(time, x)
         hydraulic_diameter = self.geometry.hydraulic_diameter(time, x)
 
@@ -167,4 +165,4 @@ class BoundaryLayer(RightHandSide):
 
             rhs[:, 1] = -4.0 / hydraulic_diameter * qloss
 
-        return rhs
+        return np.ravel(rhs)

--- a/src/stanshock/models/boundary_layer.py
+++ b/src/stanshock/models/boundary_layer.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from typing import cast
+
 import numpy as np
 from scipy.optimize import root
 
-from stanshock.physics.fluid_base import FluidPhysics, FluidState
-from stanshock.system.backend import Array
-from stanshock.system.base import RightHandSide
-from stanshock.system.geometry import Geometry
+from stanshock.physics.fluid_base import FluidState
+from stanshock.system.backend import Array, Index, Unpack
+from stanshock.system.base import PrecomputeSteps, RightHandSide
 
 
 class SkinFriction:
@@ -21,19 +22,19 @@ class SkinFriction:
             cf = numpy array of the skin friction coefficient
     """
 
-    def __init__(self, ReCrit=2300, ReMax=1e9):
+    def __init__(self, ReCrit: float = 2300, ReMax: float = 1e9) -> None:
         # store the values and compute the Reynolds number table
         self.ReMax = ReMax
         self.ReCrit = ReCrit
         self.ReTable = np.logspace(np.log10(self.ReCrit), np.log10(ReMax))
 
         # define the residual of the Karman-Nikuradse function and its derivative
-        def f(x):
-            return 2.46 * x * np.log(self.ReTable * x) + 0.3 * x - 1.0
+        def f(x: Array) -> Array:
+            return cast(Array, 2.46 * x * np.log(self.ReTable * x) + 0.3 * x - 1.0)
 
-        def jac(x):
+        def jac(x: Array) -> Array:
             dx = 2.46 * (np.log(self.ReTable * x) + 1.0) + 0.3
-            return np.diagflat(dx)
+            return cast(Array, np.diagflat(dx))
 
         # use the scipy root finding method
         x0 = 1.0 / (2.236 * np.log(self.ReTable) - 4.639)  # use fit for initial value
@@ -41,7 +42,7 @@ class SkinFriction:
             root(f, x0, jac=jac).x
         ) ** 2.0 * 2.0  # grid of values for interpolation
 
-    def __call__(self, Re):
+    def __call__(self, Re: Array) -> Array:
         cf = np.zeros_like(Re)
         laminarIndices = np.logical_and(Re > 0.0, Re <= self.ReCrit)
         cf[laminarIndices] = 16.0 / Re[laminarIndices]
@@ -58,18 +59,22 @@ class SkinFriction:
 class BoundaryLayer(RightHandSide):
     def __init__(
         self,
-        geometry: Geometry,
-        wall_temperature=None,
-        skin_friction_coefficient=None,
+        wall_temperature: Array | float | None = None,
+        skin_friction_coefficient: SkinFriction | None = None,
+        **precompute_steps: Unpack[PrecomputeSteps],
     ) -> None:
-        self.geometry = geometry
+        super().__init__(**precompute_steps)
         self.wall_temperature = wall_temperature
-        self.skin_friction_coefficient = skin_friction_coefficient
 
-        if self.skin_friction_coefficient is None:
+        if skin_friction_coefficient is None:
             self.skin_friction_coefficient = SkinFriction()  # initialize the functor
+        else:
+            self.skin_friction_coefficient = skin_friction_coefficient
 
-    def get_nusselt_number(self, Re, Pr, cf):
+        # Provides momentum and energy source terms
+        self.idx_source: Index = np.array([0, 1])
+
+    def get_nusselt_number(self, Re: Array, Pr: Array, cf: Array) -> Array:
         """
         This function defines the nusselt Number as a function of the
         Reynolds number. These functions are empirical correlations taken
@@ -88,11 +93,11 @@ class BoundaryLayer(RightHandSide):
         Nu = np.zeros_like(Re)
 
         # laminar portion of the flow
-        laminarIndices = np.logical_and(Re > 0.0, Re <= ReCrit)
+        laminarIndices: Index = np.logical_and(Re > 0.0, Re <= ReCrit)
         Nu[laminarIndices] = 3.657  # from the analytical solution
 
         # low turbulent portion of the flow (accounts for isothermal wall)
-        lowTurbulentIndices = np.logical_and(Re > ReCrit, Re <= ReLowTurbulent)
+        lowTurbulentIndices: Index = np.logical_and(Re > ReCrit, Re <= ReLowTurbulent)
         ReLT, PrLT = Re[lowTurbulentIndices], Pr[lowTurbulentIndices]
         Nu[lowTurbulentIndices] = (
             0.021 * PrLT**0.5 * ReLT**0.8
@@ -115,18 +120,30 @@ class BoundaryLayer(RightHandSide):
         )
         return Nu
 
-    def source_from_primitives(
-        self, time: float, state: FluidState, physics: FluidPhysics
+    def source_implementation(
+        self,
+        time: float,
+        state_array: Array | None,
+        state: FluidState | None,
+        face_states: FluidState | None,
+        avg_face_states: FluidState | None,
+        face_gradients: FluidState | None,
     ) -> Array:
         """Boundary layer contribution to RHS."""
-        hydraulic_diameter = self.geometry.hydraulic_diameter(time)
-        characteristic_length = self.geometry.characteristic_length(time)
+        _ = time, state_array, face_states, avg_face_states, face_gradients
+        assert self.physics is not None
+        assert state is not None
+        assert state.density is not None
+        assert state.velocity is not None
+        rhs = np.zeros((*state.shape, 2))
 
-        rhs = np.zeros((*state.shape, 2 + physics.n_scalars))
+        x = self.geometry.xc[self.idx_domain]
+        characteristic_length = self.geometry.characteristic_length(time, x)
+        hydraulic_diameter = self.geometry.hydraulic_diameter(time, x)
 
         # Compute gas properties
-        T = state.temperature = physics.get_temperature(state)
-        mu = physics.get_mu(state)
+        T = state.temperature = self.physics.get_temperature(state)
+        mu = self.physics.get_mu(state)
 
         # Shear stress on wall
         Re = abs(state.density * state.velocity * characteristic_length / mu)
@@ -138,8 +155,8 @@ class BoundaryLayer(RightHandSide):
 
         # Stanton number and heat transfer to wall
         if self.wall_temperature is not None:
-            cp = physics.get_cp(state)
-            k = physics.get_thermal_conductivity(state)
+            cp = self.physics.get_cp(state)
+            k = self.physics.get_thermal_conductivity(state)
             Pr = cp * mu / k
             Nu = self.get_nusselt_number(Re, Pr, cf)
             qloss = Nu * k / characteristic_length * (T - self.wall_temperature)

--- a/src/stanshock/models/boundary_layer.py
+++ b/src/stanshock/models/boundary_layer.py
@@ -125,14 +125,14 @@ class BoundaryLayer(RightHandSide):
     def source_implementation(
         self,
         time: float,
-        state_array: Array | None,
+        state_array_local: Array | None,
         state: FluidState | None,
         face_states: FluidState | None,
         avg_face_states: FluidState | None,
         face_gradients: FluidState | None,
     ) -> Array:
         """Boundary layer contribution to RHS."""
-        _ = time, state_array, face_states, avg_face_states, face_gradients
+        _ = time, state_array_local, face_states, avg_face_states, face_gradients
         assert self.physics is not None
         assert state is not None
         assert state.density is not None
@@ -141,7 +141,7 @@ class BoundaryLayer(RightHandSide):
         hydraulic_diameter = self.geometry.hydraulic_diameter(time)
         characteristic_length = self.geometry.characteristic_length(time)
 
-        x = self.geometry.xc[self.idx_domain]
+        x = self.geometry.xc[self.idx_update]
         characteristic_length = self.geometry.characteristic_length(time, x)
         hydraulic_diameter = self.geometry.hydraulic_diameter(time, x)
 

--- a/src/stanshock/models/boundary_layer.py
+++ b/src/stanshock/models/boundary_layer.py
@@ -75,7 +75,7 @@ class BoundaryLayer(RightHandSide):
 
         # Provides momentum and energy source terms
         self.idx_source: Index = np.array([0, 1])
-        self.shape_update = (self.shape_update[0], 2)
+        self.shape_output = (self.shape_output[0], 2)
 
     def get_nusselt_number(self, Re: Array, Pr: Array, cf: Array) -> Array:
         """
@@ -139,7 +139,7 @@ class BoundaryLayer(RightHandSide):
         assert state.density is not None
         assert state.velocity is not None
         rhs = np.zeros((*state.shape, 2))
-        x = self.geometry.xc[self.idx_domain]
+        x = self.geometry.xc[self.idx_input]
         characteristic_length = self.geometry.characteristic_length(time, x)
         hydraulic_diameter = self.geometry.hydraulic_diameter(time, x)
 

--- a/src/stanshock/models/jicf.py
+++ b/src/stanshock/models/jicf.py
@@ -12,7 +12,6 @@ from tqdm import tqdm
 from tqdm_joblib import tqdm_joblib
 
 from stanshock.physics.flamelet import FPVTable
-from stanshock.physics.fluid_base import FluidPhysics
 from stanshock.system.backend import Array
 from stanshock.system.base import RightHandSide
 
@@ -878,20 +877,17 @@ class JICModel(RightHandSide):
 
     def source(
         self,
-        _time: float,
-        state_array: Array,
-        _physics: FluidPhysics,
-        _gamma_star: Array,
-        _e0_star: Array,
+        time: float,
+        state_array_local: Array | None,
+        gamma_star: Array | None = None,
+        e0_star: Array | None = None,
     ) -> Array:
-        """
-        This method computes a fuel injector source term to target the desired
-        mixture fraction profile.
-        """
-        rhs = np.zeros_like(state_array)
+        """Compute a fuel injector source term to target the desired mixture fraction profile."""
+        _ = time, gamma_star, e0_star
+        rhs = np.zeros_like(state_array_local)
 
-        rho = state_array[:, 2]
-        rhoZ = state_array[:, 3]
+        rho = state_array_local[:, 2]
+        rhoZ = state_array_local[:, 3]
 
         Z = rhoZ / rho
         mdot_inj = np.interp(

--- a/src/stanshock/numerics/face_average.py
+++ b/src/stanshock/numerics/face_average.py
@@ -30,12 +30,12 @@ class SimpleAverage(FaceAverage):
         if "rho" in self.state_variables:
             assert face_states.density is not None
             r = 0.5 * (face_states.density[0, :] + face_states.density[1, :])
-        
+
         P = None
         if "P" in self.state_variables:
             assert face_states.pressure is not None
             P = 0.5 * (face_states.pressure[0, :] + face_states.pressure[1, :])
-        
+
         T = None
         if "T" in self.state_variables:
             assert face_states.temperature is not None
@@ -43,7 +43,7 @@ class SimpleAverage(FaceAverage):
 
         assert face_states.velocity is not None
         u = 0.5 * (face_states.velocity[0, :] + face_states.velocity[1, :])
-        
+
         assert face_states.composition is not None
         Y = 0.5 * (face_states.composition[0, :] + face_states.composition[1, :])
 
@@ -63,21 +63,20 @@ class RoeAverage(FaceAverage):
         self.physics = physics
 
     def roe_average(self, D: Array, phi: Array) -> Array:
-        """Perform Roe-average to phi, given square root of the density ratio, D.
-        """
-        return (D*phi[1] + phi[0]) / (D + 1.0)
+        """Perform Roe-average to phi, given square root of the density ratio, D."""
+        return (D * phi[1] + phi[0]) / (D + 1.0)
 
     def __call__(self, face_states: FluidState) -> FluidState:
         assert face_states.density is not None
         D = np.sqrt(face_states.density[1, :] / face_states.density[0, :])
         r = np.sqrt(face_states.density[0, :] * face_states.density[1, :])
-        
+
         assert face_states.pressure is not None
         P = self.roe_average(D, face_states.pressure)
 
         assert face_states.velocity is not None
         u = self.roe_average(D, face_states.velocity)
-        
+
         assert face_states.composition is not None
         Y = self.roe_average(D[:, None], face_states.composition)
 

--- a/src/stanshock/numerics/face_average.py
+++ b/src/stanshock/numerics/face_average.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Literal
+
+import numpy as np
+
+from stanshock.physics.fluid_base import FluidPhysics, FluidState
+from stanshock.system.backend import Array
+
+
+class FaceAverage(ABC):
+    @abstractmethod
+    def __call__(self, face_states: FluidState) -> FluidState:
+        """Average the left & right extrapolated states at the faces."""
+
+
+class SimpleAverage(FaceAverage):
+    def __init__(
+        self, state_variables: Literal["T-P", "rho-P", "rho-T"] = "rho-P"
+    ) -> None:
+        """Simple averaging to the face.
+
+        Uses the specified state variables for the thermodynamic state.
+        """
+        self.state_variables = state_variables
+
+    def __call__(self, face_states: FluidState) -> FluidState:
+        r = None
+        if "rho" in self.state_variables:
+            assert face_states.density is not None
+            r = 0.5 * (face_states.density[0, :] + face_states.density[1, :])
+        
+        P = None
+        if "P" in self.state_variables:
+            assert face_states.pressure is not None
+            P = 0.5 * (face_states.pressure[0, :] + face_states.pressure[1, :])
+        
+        T = None
+        if "T" in self.state_variables:
+            assert face_states.temperature is not None
+            T = 0.5 * (face_states.temperature[0, :] + face_states.temperature[1, :])
+
+        assert face_states.velocity is not None
+        u = 0.5 * (face_states.velocity[0, :] + face_states.velocity[1, :])
+        
+        assert face_states.composition is not None
+        Y = 0.5 * (face_states.composition[0, :] + face_states.composition[1, :])
+
+        return FluidState(
+            shape=u.shape,
+            density=r,
+            pressure=P,
+            temperature=T,
+            composition=Y,
+            velocity=u,
+        )
+
+
+class RoeAverage(FaceAverage):
+    def __init__(self, physics: FluidPhysics) -> None:
+        """Apply Roe-averaging to face states."""
+        self.physics = physics
+
+    def roe_average(self, D: Array, phi: Array) -> Array:
+        """Perform Roe-average to phi, given square root of the density ratio, D.
+        """
+        return (D*phi[1] + phi[0]) / (D + 1.0)
+
+    def __call__(self, face_states: FluidState) -> FluidState:
+        assert face_states.density is not None
+        D = np.sqrt(face_states.density[1, :] / face_states.density[0, :])
+        r = np.sqrt(face_states.density[0, :] * face_states.density[1, :])
+        
+        assert face_states.pressure is not None
+        P = self.roe_average(D, face_states.pressure)
+
+        assert face_states.velocity is not None
+        u = self.roe_average(D, face_states.velocity)
+        
+        assert face_states.composition is not None
+        Y = self.roe_average(D[:, None], face_states.composition)
+
+        return FluidState(
+            shape=u.shape,
+            density=r,
+            pressure=P,
+            composition=Y,
+            velocity=u,
+        )

--- a/src/stanshock/numerics/gradient.py
+++ b/src/stanshock/numerics/gradient.py
@@ -16,7 +16,7 @@ class Gradient(ABC):
         """Compute property gradients across the interior cell faces."""
 
 
-class CentralDifference:
+class CentralDifference(Gradient):
     def __init__(self, n_ghost_layers: int = 1) -> None:
         self.n_ghost_layers = n_ghost_layers
 

--- a/src/stanshock/numerics/inviscid_flux.py
+++ b/src/stanshock/numerics/inviscid_flux.py
@@ -6,12 +6,9 @@ from typing import cast
 import numpy as np
 from numba import double, njit
 
-from stanshock.numerics.boundary_conditions import BoundaryConditions
-from stanshock.numerics.face_extrapolation import FaceExtrapolator
-from stanshock.physics.fluid_base import FluidPhysics, FluidState
-from stanshock.system.backend import Array, TypeAlias
-from stanshock.system.base import RightHandSide
-from stanshock.system.geometry import Geometry
+from stanshock.physics.fluid_base import FluidState
+from stanshock.system.backend import Array, TypeAlias, Unpack
+from stanshock.system.base import PrecomputeStepName, PrecomputeSteps, RightHandSide
 
 # Global variables (parameters) used by the solver
 mn = 2  # number of 1D Euler equations
@@ -278,45 +275,36 @@ def hllc_flux_vectorized(
 
 
 class InviscidFlux(RightHandSide):
+    PRECOMPUTE_STEPS: tuple[PrecomputeStepName, ...] = (
+        "boundary_conditions",
+        "face_extrapolator",
+        "geometry",
+        "physics",
+    )
+
     def __init__(
         self,
-        face_extrapolator: FaceExtrapolator,
-        boundary_conditions: BoundaryConditions,
         riemann_solver: RiemannSolver,
-        geometry: Geometry,
+        **precompute_steps: Unpack[PrecomputeSteps],
     ) -> None:
-        self.face_extrapolator = face_extrapolator
-        self.boundary_conditions = boundary_conditions
+        super().__init__(**precompute_steps)
+        assert self.geometry is not None
         self.riemann_solver = riemann_solver
-        self.dx: Array | float = geometry.dx
+        self.dx: Array | float = self.geometry.dx
         if isinstance(self.dx, np.ndarray):
-            self.dx = self.dx[geometry.idx_cells]
+            self.dx = self.dx[self.geometry.idx_cells]
 
-    def source(
+    def source_implementation(
         self,
         time: float,
-        state_array: Array,
-        physics: FluidPhysics,
-        gamma_star: Array | None = None,
-        e0_star: Array | None = None,
+        state_array: Array | None,
+        state: FluidState | None,
+        face_states: FluidState | None,
+        avg_face_states: FluidState | None,
+        face_gradients: FluidState | None,
     ) -> Array:
-        state_array = self.boundary_conditions.update_ghost_layers(time, state_array)
-
-        state: FluidState = physics.conservative_to_primitive(
-            state_array, gamma_star, e0_star
-        )
-        state.gamma_star = gamma_star
-        state.e0_star = e0_star
-        state = self.boundary_conditions.update_ghost_states(time, state)
-
-        face_states: FluidState = self.face_extrapolator(state)
-        face_states = self.boundary_conditions.update_face_states(time, face_states)
-
-        return self.source_from_primitives(time, face_states, physics)
-
-    def source_from_primitives(
-        self, time: float, face_states: FluidState, _physics: FluidPhysics
-    ) -> Array:
+        _ = state_array, state, avg_face_states, face_gradients
+        assert face_states is not None
         assert face_states.density is not None
         assert face_states.velocity is not None
         assert face_states.pressure is not None
@@ -345,8 +333,14 @@ class InviscidFlux(RightHandSide):
             face_states.e0_star[0, :],
         )
 
-        self.boundary_conditions.update_face_flux(time, left_face_flux)
-        self.boundary_conditions.update_face_flux(time, right_face_flux)
+        # Allow any SpecifiedFlux BCs to directly override face fluxes
+        if self.boundary_conditions is not None:
+            left_face_flux = self.boundary_conditions.update_face_flux(
+                time, left_face_flux
+            )
+            right_face_flux = self.boundary_conditions.update_face_flux(
+                time, right_face_flux
+            )
 
         return cast(
             Array,

--- a/src/stanshock/numerics/inviscid_flux.py
+++ b/src/stanshock/numerics/inviscid_flux.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import cast
 
 import numpy as np
 from numba import double, njit
@@ -283,9 +282,7 @@ class InviscidFlux(RightHandSide):
     )
 
     def __init__(
-        self,
-        riemann_solver: RiemannSolver,
-        **precompute_steps: Unpack[PrecomputeSteps],
+        self, riemann_solver: RiemannSolver, **precompute_steps: Unpack[PrecomputeSteps]
     ) -> None:
         super().__init__(**precompute_steps)
         assert self.geometry is not None
@@ -297,13 +294,13 @@ class InviscidFlux(RightHandSide):
     def source_implementation(
         self,
         time: float,
-        state_array: Array | None,
+        state_array_local: Array | None,
         state: FluidState | None,
         face_states: FluidState | None,
         avg_face_states: FluidState | None,
         face_gradients: FluidState | None,
     ) -> Array:
-        _ = state_array, state, avg_face_states, face_gradients
+        _ = state_array_local, state, avg_face_states, face_gradients
         assert face_states is not None
         assert face_states.density is not None
         assert face_states.velocity is not None
@@ -342,8 +339,4 @@ class InviscidFlux(RightHandSide):
                 time, right_face_flux
             )
 
-        return cast(
-            Array,
-            (left_face_flux[:-1, :] - right_face_flux[1:, :])
-            / self.dx,  # Central difference
-        )
+        return (left_face_flux[:-1, :] - right_face_flux[1:, :]) / self.dx

--- a/src/stanshock/numerics/inviscid_flux.py
+++ b/src/stanshock/numerics/inviscid_flux.py
@@ -339,4 +339,4 @@ class InviscidFlux(RightHandSide):
                 time, right_face_flux
             )
 
-        return (left_face_flux[:-1, :] - right_face_flux[1:, :]) / self.dx
+        return np.ravel((left_face_flux[:-1, :] - right_face_flux[1:, :]) / self.dx)

--- a/src/stanshock/numerics/time_integration.py
+++ b/src/stanshock/numerics/time_integration.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from stanshock.physics.fluid_base import FluidPhysics
 from stanshock.system.backend import Array
-from stanshock.system.base import RightHandSide
+from stanshock.system.base import FastSlowSource, RightHandSide
 
 
 class TimeIntegrator(ABC):
@@ -19,7 +19,6 @@ class TimeIntegrator(ABC):
         dt: float,
         time: float,
         state_array: Array,
-        physics: FluidPhysics,
         gamma_star: Array,
         e0_star: Array,
     ) -> tuple[float, Array]:
@@ -27,7 +26,7 @@ class TimeIntegrator(ABC):
 
 
 class ScipyIVP(TimeIntegrator):
-    def __init__(self, rhs: RightHandSide, method: str = "LSODA", **kwargs) -> None:
+    def __init__(self, rhs: RightHandSide, method: str = "LSODA", **kwargs) -> None:  # type: ignore[no-untyped-def]
         """Interface to SciPy's IVP solvers.
 
         The specific solver can be selected with the `method` input, and additional
@@ -49,25 +48,26 @@ class ScipyIVP(TimeIntegrator):
         dt: float,
         time: float,
         state_array: Array,
-        physics: FluidPhysics,
         gamma_star: Array,
         e0_star: Array,
     ) -> tuple[float, Array]:
-        # integrator = self.integrator(self.rhs.source).set_integrator("lsoda")
-        # integrator.set_initial_value(y=state_array, t=time)
-        # integrator.set_f_params(args=(physics, gamma_star))
-        # integrator.integrate(t=time + dt)
+        y0, state0, _, _, _ = self.rhs.precompute(
+            time, state_array, gamma_star, e0_star
+        )
+        assert state0 is not None
 
         results = self.integrator(
             fun=self.rhs.source,
             t_span=(time, time + dt),
-            y0=state_array.flatten(),
+            y0=y0,
             method=self.method,
-            args=(physics, gamma_star, e0_star),
+            args=(gamma_star, e0_star),
             **self.solver_options,
         )
 
-        return results.t[-1], results.y[:, -1]
+        state_array = self.rhs.postcompute(results.y[:, -1], state0)
+
+        return results.t[-1], state_array
 
 
 class RungeKuttaBase(TimeIntegrator):
@@ -79,12 +79,11 @@ class RungeKuttaBase(TimeIntegrator):
         dt: float,
         time: float,
         state_array: Array,
-        physics: FluidPhysics,
         gamma_star: Array,
         e0_star: Array,
     ) -> tuple[float, Array]:
         t = time
-        y = state_array.flatten()
+        y: Array = np.ravel(state_array)
 
         t0 = t + 0
         y0 = y.copy()
@@ -94,8 +93,7 @@ class RungeKuttaBase(TimeIntegrator):
 
             dydt = self.rhs.source(
                 time=t,
-                state_array=state_array,
-                physics=physics,
+                state_array=y,
                 gamma_star=gamma_star,
                 e0_star=e0_star,
             )
@@ -106,7 +104,7 @@ class RungeKuttaBase(TimeIntegrator):
             if a != 0.0:
                 y += a * y0
 
-            y += c * dt * dydt
+            y = self.rhs.add_source(y, c * dt * dydt)
 
             t = t0 + d * dt
 
@@ -173,7 +171,6 @@ class StrangSplitting(TimeIntegrator):
         dt: float,
         time: float,
         state_array: Array,
-        physics: FluidPhysics,
         gamma_star: Array,
         e0_star: Array,
     ) -> tuple[float, Array]:
@@ -184,7 +181,6 @@ class StrangSplitting(TimeIntegrator):
             dt=0.5 * dt,
             time=time,
             state_array=y,
-            physics=physics,
             gamma_star=gamma_star,
             e0_star=e0_star,
         )
@@ -194,7 +190,6 @@ class StrangSplitting(TimeIntegrator):
             dt=dt,
             time=time,
             state_array=y,
-            physics=physics,
             gamma_star=gamma_star,
             e0_star=e0_star,
         )
@@ -204,7 +199,6 @@ class StrangSplitting(TimeIntegrator):
             dt=0.5 * dt,
             time=time + 0.5 * dt,
             state_array=y,
-            physics=physics,
             gamma_star=gamma_star,
             e0_star=e0_star,
         )
@@ -219,12 +213,19 @@ class LieSplitting(TimeIntegrator):
         self.operators = operators
         self.update_double_flux = update_double_flux
 
+        # Get fluid physics from any of the operators
+        self.physics: FluidPhysics | None = None
+        if self.update_double_flux:
+            for operator in operators:
+                if operator.rhs.physics is not None:
+                    self.physics = operator.rhs.physics
+                    break
+
     def advance(
         self,
         dt: float,
         time: float,
         state_array: Array,
-        physics: FluidPhysics,
         gamma_star: Array,
         e0_star: Array,
     ) -> tuple[float, Array]:
@@ -235,15 +236,56 @@ class LieSplitting(TimeIntegrator):
                 dt=dt,
                 time=time,
                 state_array=y,
-                physics=physics,
                 gamma_star=gamma_star,
                 e0_star=e0_star,
             )
 
             # Optionally: Update the double flux variables
             if self.update_double_flux:
-                state = physics.conservative_to_primitive(y, gamma_star, e0_star)
-                state.temperature = physics.get_temperature(state)
-                gamma_star, e0_star = physics.get_double_flux_variables(state)
+                assert self.physics is not None
+                state = self.physics.conservative_to_primitive(y, gamma_star, e0_star)
+                state.temperature = self.physics.get_temperature(state)
+                gamma_star, e0_star = self.physics.get_double_flux_variables(state)
 
         return time + dt, y
+
+
+class FastSlowIntegrator(TimeIntegrator):
+    def __init__(
+        self,
+        rhs: RightHandSide,
+        fast_integrator: type[TimeIntegrator] = ScipyIVP,
+        slow_integrator: type[TimeIntegrator] = ForwardEuler,
+    ) -> None:
+        """Apply different integrators to stiff and non-stiff terms."""
+        self.rhs = rhs
+        self.fast_integrator = fast_integrator(self.rhs)
+        self.slow_integrator = slow_integrator(self.rhs)
+
+    def advance(
+        self,
+        dt: float,
+        time: float,
+        state_array: Array,
+        gamma_star: Array,
+        e0_star: Array,
+    ) -> tuple[float, Array]:
+        assert isinstance(self.rhs, FastSlowSource)
+        y_full = np.zeros_like(state_array)
+        self.rhs.update_indices(time)
+
+        # Integrate fast terms
+        self.rhs.mode = "fast"
+        _, y_fast = self.fast_integrator.advance(
+            dt, time, state_array, gamma_star, e0_star
+        )
+        y_full = self.rhs.add_source(y_full, y_fast)
+
+        # Integrate slow terms
+        self.rhs.mode = "slow"
+        _, y_slow = self.slow_integrator.advance(
+            dt, time, state_array, gamma_star, e0_star
+        )
+        y_full = self.rhs.add_source(y_full, y_slow)
+
+        return time + dt, y_full

--- a/src/stanshock/numerics/time_integration.py
+++ b/src/stanshock/numerics/time_integration.py
@@ -67,7 +67,7 @@ class ScipyIVP(TimeIntegrator):
         )
 
         results = self.integrator(
-            fun=self.rhs.source,
+            fun=self.rhs.source_full,
             t_span=(time, time + dt),
             y0=y0,
             method=self.method,
@@ -186,7 +186,7 @@ class SSPRK3(SimpleRungeKuttaBase):
 
     References
     ----------
-    Dale E. Durran, “Numerical Methods for Fluid Dynamics”, Springer.
+    Dale E. Durran, "Numerical Methods for Fluid Dynamics", Springer.
     Second Edition.
     """
 
@@ -356,7 +356,7 @@ class OperatorSplitting(TimeIntegrator):
 
 
 class StrangSplitting(OperatorSplitting):
-    """Classical Strang-Splitting approach.
+    """Classical second-order operator-splitting approach by Strang.
 
     In this approach, the first operator is integrated to the midpoint, then
     the second operator is integrated for the full time step, and finally the
@@ -368,8 +368,15 @@ class StrangSplitting(OperatorSplitting):
 
 
 class SymmetricallyWeightedSequentialSplitting(OperatorSplitting):
-    """This approach applies Strang splitting twice, swapping the operators and
+    """Second-order operator splitting approach from Csomós et. al [1].
+
+    This approach applies Strang splitting twice, swapping the operators and
     then averaging the results together to make the approach symmetric.
+
+    References
+    ----------
+    [1] Csomós et al. 2005. "Weighted sequential splittings and their analysis."
+        Comput. Math. with Appl. 50, 7 (2005), 1017-1031.
     """
 
     stages = (
@@ -380,6 +387,19 @@ class SymmetricallyWeightedSequentialSplitting(OperatorSplitting):
 
 
 class ThirdOrderSplitting(OperatorSplitting):
+    """Third-order operator splitting approach from Jia and Li [1].
+
+    Essentially a weighted combination of a symmetric Lie-splitting and symmetric
+    Strang-splitting approach. Note that third-order accuracy has not been
+    observed in practice with this scheme, so there may be some error in its
+    implementation or constraints on achieving third-order convergence.
+
+    References
+    ----------
+    [1] Jia et al. 2011. "A third accurate operator splitting method."
+        Math. Comput. Model. 53, 1-2 (2011), 387-396.
+    """
+
     stages: tuple[tuple[tuple[int, float], ...], ...] = (
         ((0, 0.5), (1, 1.0), (0, 0.5)),
         ((1, 0.5), (0, 1.0), (1, 0.5)),
@@ -390,8 +410,9 @@ class ThirdOrderSplitting(OperatorSplitting):
 
 
 class LieSplitting(OperatorSplitting):
-    """Simplest splitting approach, in which each term is integrated in
-    sequence.
+    """First-order operator splitting approach by Lie.
+
+    Simplest splitting approach, in which each term is integrated in sequence.
     """
 
     def __init__(
@@ -409,6 +430,22 @@ class LieSplitting(OperatorSplitting):
 
 
 class StrangSplittingOld(TimeIntegrator):
+    """Deprecated implementation of Strang splitting.
+
+    This specifies a transport and reaction operator, where the Strang approach
+    is more general than this. In fact, the order of the operators can be safely
+    swapped; however, there have been publications [1,2] which indicate lower
+    error is achieved when the stiff terms (the reactions) take the half steps.
+
+    References
+    ----------
+    [1] Ren et al. 2014. "Dynamic adaptive chemistry with operator splitting
+        schemes for reactive flow simulations." J. Comput. Phys. 263,
+        (April 2014), 19-36.
+    [2] Sportisse. 2000. "An Analysis of Operator Splitting Techniques in the
+        Stiff Case." J. Comput. Phys. 161, 1 (2000), 140-168.
+    """
+
     def __init__(
         self, transport_operator: TimeIntegrator, reaction_operator: TimeIntegrator
     ) -> None:
@@ -423,8 +460,8 @@ class StrangSplittingOld(TimeIntegrator):
         gamma_star: Array | None,
         e0_star: Array | None,
     ) -> tuple[float, Array, Array | None, Array | None]:
-        # Take half-step with transport terms
-        _, state_array, _, _ = self.transport_operator.advance(
+        # Take half-step with reaction terms
+        _, state_array, _, _ = self.reaction_operator.advance(
             dt=0.5 * dt,
             time=time,
             state_array=state_array,
@@ -432,8 +469,8 @@ class StrangSplittingOld(TimeIntegrator):
             e0_star=e0_star,
         )
 
-        # Take full-step with reaction terms
-        t, state_array, _, _ = self.reaction_operator.advance(
+        # Take full-step with transport terms
+        t, state_array, _, _ = self.transport_operator.advance(
             dt=dt,
             time=time,
             state_array=state_array,
@@ -441,8 +478,8 @@ class StrangSplittingOld(TimeIntegrator):
             e0_star=e0_star,
         )
 
-        # Take half-step with transport terms
-        _, state_array, gamma_star, e0_star = self.transport_operator.advance(
+        # Take half-step with reaction terms
+        _, state_array, gamma_star, e0_star = self.reaction_operator.advance(
             dt=0.5 * dt,
             time=time + 0.5 * dt,
             state_array=state_array,
@@ -493,9 +530,9 @@ class LieSplittingOld(TimeIntegrator):
 class FastSlowIntegrator(TimeIntegrator):
     def __init__(
         self,
-        rhs: RightHandSide,
+        rhs: FastSlowSource,
         fast_integrator: type[TimeIntegrator] = ScipyIVP,
-        slow_integrator: type[TimeIntegrator] = ForwardEuler,
+        slow_integrator: type[TimeIntegrator] = MidpointMethod,
     ) -> None:
         """Apply different integrators to stiff and non-stiff terms."""
         self.rhs: RightHandSide = rhs
@@ -512,17 +549,17 @@ class FastSlowIntegrator(TimeIntegrator):
     ) -> tuple[float, Array, Array | None, Array | None]:
         assert isinstance(self.rhs, FastSlowSource)
 
+        # Integrate slow terms
+        self.rhs.mode = "slow"
+        _, state_array, gamma_star, e0_star = self.slow_integrator.advance(
+            dt, time, state_array, gamma_star, e0_star
+        )
+
         # Integrate fast terms
         self.rhs.mode = "fast"
         if len(state_array[self.rhs.idx_update_implicit]) > 0:
             _, state_array, gamma_star, e0_star = self.fast_integrator.advance(
                 dt, time, state_array, gamma_star, e0_star
             )
-
-        # Integrate slow terms
-        self.rhs.mode = "slow"
-        _, state_array, gamma_star, e0_star = self.slow_integrator.advance(
-            dt, time, state_array, gamma_star, e0_star
-        )
 
         return time + dt, state_array, gamma_star, e0_star

--- a/src/stanshock/numerics/time_integration.py
+++ b/src/stanshock/numerics/time_integration.py
@@ -283,7 +283,7 @@ class FastSlowIntegrator(TimeIntegrator):
 
         # Integrate fast terms
         self.rhs.mode = "fast"
-        if len(state_array[self.rhs.idx_implicit]) > 0:
+        if len(state_array[self.rhs.idx_update_implicit]) > 0:
             _, state_array, gamma_star, e0_star = self.fast_integrator.advance(
                 dt, time, state_array, gamma_star, e0_star
             )

--- a/src/stanshock/numerics/time_integration.py
+++ b/src/stanshock/numerics/time_integration.py
@@ -19,8 +19,8 @@ class TimeIntegrator(ABC):
         dt: float,
         time: float,
         state_array: Array,
-        gamma_star: Array,
-        e0_star: Array,
+        gamma_star: Array | None,
+        e0_star: Array | None,
     ) -> tuple[float, Array]:
         """Integrate the state from `time` to `time+dt` given the rhs."""
 
@@ -48,16 +48,16 @@ class ScipyIVP(TimeIntegrator):
         dt: float,
         time: float,
         state_array: Array,
-        gamma_star: Array,
-        e0_star: Array,
+        gamma_star: Array | None,
+        e0_star: Array | None,
     ) -> tuple[float, Array]:
-        y0, state0, _, _, _ = self.rhs.precompute(
+        y0, state0, _, _, _ = self.rhs.precompute_for_source(
             time, state_array, gamma_star, e0_star
         )
         assert state0 is not None
 
         results = self.integrator(
-            fun=self.rhs.source,
+            fun=self.rhs.source_full,
             t_span=(time, time + dt),
             y0=y0,
             method=self.method,
@@ -79,8 +79,8 @@ class RungeKuttaBase(TimeIntegrator):
         dt: float,
         time: float,
         state_array: Array,
-        gamma_star: Array,
-        e0_star: Array,
+        gamma_star: Array | None,
+        e0_star: Array | None,
     ) -> tuple[float, Array]:
         t = time
         y: Array = np.ravel(state_array)
@@ -93,7 +93,7 @@ class RungeKuttaBase(TimeIntegrator):
 
             dydt = self.rhs.source(
                 time=t,
-                state_array=y,
+                state_array_local=y,
                 gamma_star=gamma_star,
                 e0_star=e0_star,
             )
@@ -171,10 +171,10 @@ class StrangSplitting(TimeIntegrator):
         dt: float,
         time: float,
         state_array: Array,
-        gamma_star: Array,
-        e0_star: Array,
+        gamma_star: Array | None,
+        e0_star: Array | None,
     ) -> tuple[float, Array]:
-        y = state_array.flatten()
+        y: Array = state_array.flatten()
 
         # Take half-step with transport terms
         _, y = self.transport_operator.advance(
@@ -226,10 +226,10 @@ class LieSplitting(TimeIntegrator):
         dt: float,
         time: float,
         state_array: Array,
-        gamma_star: Array,
-        e0_star: Array,
+        gamma_star: Array | None,
+        e0_star: Array | None,
     ) -> tuple[float, Array]:
-        y = state_array.flatten()
+        y: Array = state_array.flatten()
 
         for operator in self.operators:
             _, y = operator.advance(
@@ -243,7 +243,10 @@ class LieSplitting(TimeIntegrator):
             # Optionally: Update the double flux variables
             if self.update_double_flux:
                 assert self.physics is not None
-                state = self.physics.conservative_to_primitive(y, gamma_star, e0_star)
+                state_array = y.reshape(operator.rhs.shape)
+                state = self.physics.conservative_to_primitive(
+                    state_array, gamma_star, e0_star
+                )
                 state.temperature = self.physics.get_temperature(state)
                 gamma_star, e0_star = self.physics.get_double_flux_variables(state)
 
@@ -267,25 +270,29 @@ class FastSlowIntegrator(TimeIntegrator):
         dt: float,
         time: float,
         state_array: Array,
-        gamma_star: Array,
-        e0_star: Array,
+        gamma_star: Array | None,
+        e0_star: Array | None,
     ) -> tuple[float, Array]:
         assert isinstance(self.rhs, FastSlowSource)
-        y_full = np.zeros_like(state_array)
-        self.rhs.update_indices(time)
 
         # Integrate fast terms
         self.rhs.mode = "fast"
-        _, y_fast = self.fast_integrator.advance(
-            dt, time, state_array, gamma_star, e0_star
+        state_array_local, gamma_star, e0_star = self.rhs.before_time_integration(
+            time, state_array
         )
-        y_full = self.rhs.add_source(y_full, y_fast)
+        _, state_array_local = self.fast_integrator.advance(
+            dt, time, state_array_local, gamma_star, e0_star
+        )
+        state_array = self.rhs.after_time_integration(state_array, state_array_local)
 
         # Integrate slow terms
         self.rhs.mode = "slow"
-        _, y_slow = self.slow_integrator.advance(
+        state_array_local, gamma_star, e0_star = self.rhs.before_time_integration(
+            time, state_array
+        )
+        _, state_array_local = self.slow_integrator.advance(
             dt, time, state_array, gamma_star, e0_star
         )
-        y_full = self.rhs.add_source(y_full, y_slow)
+        state_array = self.rhs.after_time_integration(state_array, state_array_local)
 
-        return time + dt, y_full
+        return time + dt, state_array

--- a/src/stanshock/numerics/time_integration.py
+++ b/src/stanshock/numerics/time_integration.py
@@ -21,12 +21,13 @@ class TimeIntegrator(ABC):
         state_array: Array,
         physics: FluidPhysics,
         gamma_star: Array,
+        e0_star: Array,
     ) -> tuple[float, Array]:
         """Integrate the state from `time` to `time+dt` given the rhs."""
 
 
 class ScipyIVP(TimeIntegrator):
-    def __init__(self, rhs: RightHandSide, method: str="LSODA", **kwargs) -> None:
+    def __init__(self, rhs: RightHandSide, method: str = "LSODA", **kwargs) -> None:
         """Interface to SciPy's IVP solvers.
 
         The specific solver can be selected with the `method` input, and additional
@@ -50,6 +51,7 @@ class ScipyIVP(TimeIntegrator):
         state_array: Array,
         physics: FluidPhysics,
         gamma_star: Array,
+        e0_star: Array,
     ) -> tuple[float, Array]:
         # integrator = self.integrator(self.rhs.source).set_integrator("lsoda")
         # integrator.set_initial_value(y=state_array, t=time)
@@ -58,10 +60,10 @@ class ScipyIVP(TimeIntegrator):
 
         results = self.integrator(
             fun=self.rhs.source,
-            t_span=(time, time+dt),
+            t_span=(time, time + dt),
             y0=state_array.flatten(),
             method=self.method,
-            args=(physics, gamma_star),
+            args=(physics, gamma_star, e0_star),
             **self.solver_options,
         )
 
@@ -79,6 +81,7 @@ class RungeKuttaBase(TimeIntegrator):
         state_array: Array,
         physics: FluidPhysics,
         gamma_star: Array,
+        e0_star: Array,
     ) -> tuple[float, Array]:
         t = time
         y = state_array.flatten()
@@ -94,6 +97,7 @@ class RungeKuttaBase(TimeIntegrator):
                 state_array=state_array,
                 physics=physics,
                 gamma_star=gamma_star,
+                e0_star=e0_star,
             )
 
             if b != 1.0:
@@ -171,6 +175,7 @@ class StrangSplitting(TimeIntegrator):
         state_array: Array,
         physics: FluidPhysics,
         gamma_star: Array,
+        e0_star: Array,
     ) -> tuple[float, Array]:
         y = state_array.flatten()
 
@@ -181,6 +186,7 @@ class StrangSplitting(TimeIntegrator):
             state_array=y,
             physics=physics,
             gamma_star=gamma_star,
+            e0_star=e0_star,
         )
 
         # Take full-step with reaction terms
@@ -190,6 +196,7 @@ class StrangSplitting(TimeIntegrator):
             state_array=y,
             physics=physics,
             gamma_star=gamma_star,
+            e0_star=e0_star,
         )
 
         # Take half-step with transport terms
@@ -199,15 +206,18 @@ class StrangSplitting(TimeIntegrator):
             state_array=y,
             physics=physics,
             gamma_star=gamma_star,
+            e0_star=e0_star,
         )
 
         return t, y
 
 
 class LieSplitting(TimeIntegrator):
-    def __init__(self, operators: list[TimeIntegrator], update_gamma_star: bool=False) -> None:
+    def __init__(
+        self, operators: list[TimeIntegrator], update_double_flux: bool = False
+    ) -> None:
         self.operators = operators
-        self.update_gamma_star = update_gamma_star
+        self.update_double_flux = update_double_flux
 
     def advance(
         self,
@@ -216,18 +226,24 @@ class LieSplitting(TimeIntegrator):
         state_array: Array,
         physics: FluidPhysics,
         gamma_star: Array,
+        e0_star: Array,
     ) -> tuple[float, Array]:
         y = state_array.flatten()
 
         for operator in self.operators:
             _, y = operator.advance(
-                dt=dt, time=time, state_array=y, physics=physics, gamma_star=gamma_star
+                dt=dt,
+                time=time,
+                state_array=y,
+                physics=physics,
+                gamma_star=gamma_star,
+                e0_star=e0_star,
             )
 
-            # Optionally: Update the gamma_star value
-            if self.update_gamma_star:
-                state = physics.conservative_to_primitive(y, gamma_star)
+            # Optionally: Update the double flux variables
+            if self.update_double_flux:
+                state = physics.conservative_to_primitive(y, gamma_star, e0_star)
                 state.temperature = physics.get_temperature(state)
-                gamma_star = physics.get_gamma(state)
+                gamma_star, e0_star = physics.get_double_flux_variables(state)
 
-        return time+dt, y
+        return time + dt, y

--- a/src/stanshock/numerics/time_integration.py
+++ b/src/stanshock/numerics/time_integration.py
@@ -557,7 +557,7 @@ class FastSlowIntegrator(TimeIntegrator):
 
         # Integrate fast terms
         self.rhs.mode = "fast"
-        if len(state_array[self.rhs.idx_update_implicit]) > 0:
+        if len(state_array[self.rhs.idx_output_implicit]) > 0:
             _, state_array, gamma_star, e0_star = self.fast_integrator.advance(
                 dt, time, state_array, gamma_star, e0_star
             )

--- a/src/stanshock/numerics/time_integration.py
+++ b/src/stanshock/numerics/time_integration.py
@@ -148,7 +148,7 @@ class ForwardEuler(RungeKuttaBase):
 
 class MidpointMethod(RungeKuttaBase):
     n_rk_stage: int = 2
-    rk_coeff: Array = np.array([[0.0, 0.5, 0.5, 0.5], [0.0, 1.0, 1.0, 1.0]])
+    rk_coeff: Array = np.array([[0.0, 1.0, 0.5, 0.5], [1.0, 0.0, 1.0, 1.0]])
 
 
 class HeunsMethod(RungeKuttaBase):
@@ -173,18 +173,6 @@ class SSPRK3(RungeKuttaBase):
             [0.0, 1.0, 1.0, 1.0],
             [0.75, 0.25, 0.25, 0.5],
             [1.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0, 1.0],
-        ]
-    )
-
-
-class RK4(RungeKuttaBase):
-    n_rk_stage: int = 4
-    rk_coeff: Array = np.array(
-        [
-            [0.0, 1.0, 0.5, 0.5],
-            [0.5, 0.5, 1.0 / 6.0, 0.5],
-            [0.5, 0.5, 1.0 / 3.0, 1.0],
-            [0.0, 1.0, 1.0 / 6.0, 1.0],
         ]
     )
 

--- a/src/stanshock/numerics/time_integration.py
+++ b/src/stanshock/numerics/time_integration.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+from stanshock.physics.fluid_base import FluidPhysics
+from stanshock.system.backend import Array
+from stanshock.system.base import RightHandSide
+
+
+class TimeIntegrator(ABC):
+    def __init__(self, rhs: RightHandSide) -> None:
+        self.rhs = rhs
+
+    @abstractmethod
+    def advance(
+        self,
+        dt: float,
+        time: float,
+        state_array: Array,
+        physics: FluidPhysics,
+        gamma_star: Array,
+    ) -> tuple[float, Array]:
+        """Integrate the state from `time` to `time+dt` given the rhs."""
+
+
+class ScipyIVP(TimeIntegrator):
+    def __init__(self, rhs: RightHandSide, method: str="LSODA", **kwargs) -> None:
+        """Interface to SciPy's IVP solvers.
+
+        The specific solver can be selected with the `method` input, and additional
+        solver options can be passed in as keyword arguments. See documentation for
+        `scipy.integrate.solve_ivp`.
+        """
+        # from scipy.integrate import ode
+        from scipy.integrate import solve_ivp
+
+        # self.integrator = ode
+        self.integrator = solve_ivp
+
+        self.rhs = rhs
+        self.method = method
+        self.solver_options = kwargs
+
+    def advance(
+        self,
+        dt: float,
+        time: float,
+        state_array: Array,
+        physics: FluidPhysics,
+        gamma_star: Array,
+    ) -> tuple[float, Array]:
+        # integrator = self.integrator(self.rhs.source).set_integrator("lsoda")
+        # integrator.set_initial_value(y=state_array, t=time)
+        # integrator.set_f_params(args=(physics, gamma_star))
+        # integrator.integrate(t=time + dt)
+
+        results = self.integrator(
+            fun=self.rhs.source,
+            t_span=(time, time+dt),
+            y0=state_array.flatten(),
+            method=self.method,
+            args=(physics, gamma_star),
+            **self.solver_options,
+        )
+
+        return results.t[-1], results.y[:, -1]
+
+
+class RungeKuttaBase(TimeIntegrator):
+    n_rk_stage: int = 0
+    rk_coeff: Array = np.zeros((1, 4))
+
+    def advance(
+        self,
+        dt: float,
+        time: float,
+        state_array: Array,
+        physics: FluidPhysics,
+        gamma_star: Array,
+    ) -> tuple[float, Array]:
+        t = time
+        y = state_array.flatten()
+
+        t0 = t + 0
+        y0 = y.copy()
+
+        for i_rk_stage in range(self.n_rk_stage):
+            a, b, c, d = self.rk_coeff[i_rk_stage]
+
+            dydt = self.rhs.source(
+                time=t,
+                state_array=state_array,
+                physics=physics,
+                gamma_star=gamma_star,
+            )
+
+            if b != 1.0:
+                y *= b
+
+            if a != 0.0:
+                y += a * y0
+
+            y += c * dt * dydt
+
+            t = t0 + d * dt
+
+        return t, y
+
+
+class ForwardEuler(RungeKuttaBase):
+    n_rk_stage: int = 1
+    rk_coeff: Array = np.array([[0.0, 1.0, 1.0, 1.0]])
+
+
+class MidpointMethod(RungeKuttaBase):
+    n_rk_stage: int = 2
+    rk_coeff: Array = np.array([[0.0, 0.5, 0.5, 0.5], [0.0, 1.0, 1.0, 1.0]])
+
+
+class HeunsMethod(RungeKuttaBase):
+    n_rk_stage: int = 2
+    rk_coeff: Array = np.array([[0.0, 1.0, 1.0, 1.0], [0.5, 0.5, 0.5, 1.0]])
+
+
+class SSPRK3(RungeKuttaBase):
+    """
+    3rd-order strong stability preserving Runge Kutta (SSPRK3). This scheme is
+    stable for CFL <= 1.
+
+    References
+    ----------
+    Dale E. Durran, “Numerical Methods for Fluid Dynamics”, Springer.
+    Second Edition.
+    """
+
+    n_rk_stage: int = 3
+    rk_coeff: Array = np.array(
+        [
+            [0.0, 1.0, 1.0, 1.0],
+            [0.75, 0.25, 0.25, 0.5],
+            [1.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0, 1.0],
+        ]
+    )
+
+
+class RK4(RungeKuttaBase):
+    n_rk_stage: int = 4
+    rk_coeff: Array = np.array(
+        [
+            [0.0, 1.0, 0.5, 0.5],
+            [0.5, 0.5, 1.0 / 6.0, 0.5],
+            [0.5, 0.5, 1.0 / 3.0, 1.0],
+            [0.0, 1.0, 1.0 / 6.0, 1.0],
+        ]
+    )
+
+
+class StrangSplitting(TimeIntegrator):
+    def __init__(
+        self, transport_operator: TimeIntegrator, reaction_operator: TimeIntegrator
+    ) -> None:
+        self.transport_operator = transport_operator
+        self.reaction_operator = reaction_operator
+
+    def advance(
+        self,
+        dt: float,
+        time: float,
+        state_array: Array,
+        physics: FluidPhysics,
+        gamma_star: Array,
+    ) -> tuple[float, Array]:
+        y = state_array.flatten()
+
+        # Take half-step with transport terms
+        _, y = self.transport_operator.advance(
+            dt=0.5 * dt,
+            time=time,
+            state_array=y,
+            physics=physics,
+            gamma_star=gamma_star,
+        )
+
+        # Take full-step with reaction terms
+        t, y = self.reaction_operator.advance(
+            dt=dt,
+            time=time,
+            state_array=y,
+            physics=physics,
+            gamma_star=gamma_star,
+        )
+
+        # Take half-step with transport terms
+        _, y = self.transport_operator.advance(
+            dt=0.5 * dt,
+            time=time + 0.5 * dt,
+            state_array=y,
+            physics=physics,
+            gamma_star=gamma_star,
+        )
+
+        return t, y
+
+
+class LieSplitting(TimeIntegrator):
+    def __init__(self, operators: list[TimeIntegrator], update_gamma_star: bool=False) -> None:
+        self.operators = operators
+        self.update_gamma_star = update_gamma_star
+
+    def advance(
+        self,
+        dt: float,
+        time: float,
+        state_array: Array,
+        physics: FluidPhysics,
+        gamma_star: Array,
+    ) -> tuple[float, Array]:
+        y = state_array.flatten()
+
+        for operator in self.operators:
+            _, y = operator.advance(
+                dt=dt, time=time, state_array=y, physics=physics, gamma_star=gamma_star
+            )
+
+            # Optionally: Update the gamma_star value
+            if self.update_gamma_star:
+                state = physics.conservative_to_primitive(y, gamma_star)
+                state.temperature = physics.get_temperature(state)
+                gamma_star = physics.get_gamma(state)
+
+        return time+dt, y

--- a/src/stanshock/numerics/time_integration.py
+++ b/src/stanshock/numerics/time_integration.py
@@ -89,9 +89,32 @@ class ScipyIVP(TimeIntegrator):
         return time, state_array, gamma_star, e0_star
 
 
-class RungeKuttaBase(TimeIntegrator):
+class SimpleRungeKuttaBase(TimeIntegrator):
+    """Simplified form for explicit Runge-Kutta approaches.
+
+    This base class implements a simplified form of the Runge-Kutta equations,
+    where each stage requires only the initial value, `y0`, the current `y`
+    value computed by the previous stage, and the corresponding gradient. This
+    is in contrast to the standard approach in which gradients from all prior
+    steps must be retained.
+
+    Coefficients `(a, b, c, d)` determine he update from stage `i` to `i+1` as:
+
+    ```
+    y[i+1] = a*y0 + b*y[i] + c*dt*rhs(t[i], y[i])
+    t[i+1] = t0 + d*dt
+    ```
+
+    Note that not all explicit Runge-Kutta methods can be expressed in this
+    format. Each approach is implemented via the following class attributes:
+
+    `n_rk_stage`: Number of stages.
+    `rk_coeff`: Array of shape `(n_rk_stage, 4)`, where each row provides
+                the coefficients `(a, b, c, d)` for its corresponding stage.
+    """
+
     n_rk_stage: int = 0
-    rk_coeff: Array = np.zeros((1, 4))
+    rk_coeff: Array = np.zeros((0, 4))
 
     def advance(
         self,
@@ -101,12 +124,12 @@ class RungeKuttaBase(TimeIntegrator):
         gamma_star: Array | None,
         e0_star: Array | None,
     ) -> tuple[float, Array, Array | None, Array | None]:
-        t = time
+        t0 = time
         y0, gamma_star_local, e0_star_local = self.rhs.before_time_integration(
-            t, state_array, gamma_star, e0_star
+            t0, state_array, gamma_star, e0_star
         )
 
-        t0 = t + 0
+        t = t0 + 0
         y = y0.copy()
 
         for i_rk_stage in range(self.n_rk_stage):
@@ -141,22 +164,22 @@ class RungeKuttaBase(TimeIntegrator):
         return t, state_array, gamma_star, e0_star
 
 
-class ForwardEuler(RungeKuttaBase):
+class ForwardEuler(SimpleRungeKuttaBase):
     n_rk_stage: int = 1
     rk_coeff: Array = np.array([[0.0, 1.0, 1.0, 1.0]])
 
 
-class MidpointMethod(RungeKuttaBase):
+class MidpointMethod(SimpleRungeKuttaBase):
     n_rk_stage: int = 2
     rk_coeff: Array = np.array([[0.0, 1.0, 0.5, 0.5], [1.0, 0.0, 1.0, 1.0]])
 
 
-class HeunsMethod(RungeKuttaBase):
+class HeunsMethod(SimpleRungeKuttaBase):
     n_rk_stage: int = 2
     rk_coeff: Array = np.array([[0.0, 1.0, 1.0, 1.0], [0.5, 0.5, 0.5, 1.0]])
 
 
-class SSPRK3(RungeKuttaBase):
+class SSPRK3(SimpleRungeKuttaBase):
     """
     3rd-order strong stability preserving Runge Kutta (SSPRK3). This scheme is
     stable for CFL <= 1.
@@ -177,7 +200,215 @@ class SSPRK3(RungeKuttaBase):
     )
 
 
-class StrangSplitting(TimeIntegrator):
+class RungeKuttaBase(TimeIntegrator):
+    """Explicit Runge-Kutta methods using Butcher tableau.
+
+    Simply set the following class attributes on a derived class:
+
+    `n_rk_stage`: Number of stages.
+    `butcher`: Butcher tableau for the method with `n_rk_stage + 1` rows and
+               `n_rk_stage` columns. The extra row stores the `b` coefficients.
+    `c`: The `c` coefficients, which determine the intermediate time steps.
+    """
+
+    n_rk_stage: int = 0
+    butcher: Array = np.zeros((n_rk_stage + 1, n_rk_stage))
+    c: Array = np.zeros((n_rk_stage + 1,))
+
+    def advance(
+        self,
+        dt: float,
+        time: float,
+        state_array: Array,
+        gamma_star: Array | None,
+        e0_star: Array | None,
+    ) -> tuple[float, Array, Array | None, Array | None]:
+        t0 = time
+        y0, gamma_star_local, e0_star_local = self.rhs.before_time_integration(
+            t0, state_array, gamma_star, e0_star
+        )
+
+        t = t0 + 0
+        y = y0.copy()
+        k = []
+
+        for i_rk_stage in range(1, self.n_rk_stage + 1):
+            # Compute gradient from previous stage
+            k_stage = self.rhs.source(
+                time=t,
+                state_array_local=y,
+                gamma_star=gamma_star_local,
+                e0_star=e0_star_local,
+            )
+            k += [k_stage]
+
+            # Update state and time for current stage
+            t = t0 + self.c[i_rk_stage] * dt
+            y = y0.copy()
+            for j in range(i_rk_stage):
+                y = self.rhs.add_source(y, self.butcher[i_rk_stage, j] * k[j] * dt)
+
+        state_array, gamma_star, e0_star = self.rhs.after_time_integration(
+            time=t,
+            state_array_local=y,
+            gamma_star_local=gamma_star_local,
+            e0_star_local=e0_star_local,
+            state_array=state_array,
+            gamma_star=gamma_star,
+            e0_star=e0_star,
+        )
+        return t, state_array, gamma_star, e0_star
+
+
+class RK4(RungeKuttaBase):
+    """ "Classic" 4th-order Runge-Kutta scheme."""
+
+    n_rk_stage: int = 4
+    butcher: Array = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0],
+            [0.5, 0.0, 0.0, 0.0],
+            [0.0, 0.5, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [1.0 / 6.0, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 6.0],
+        ]
+    )
+    c: Array = np.array([0.0, 0.5, 0.5, 1.0, 1.0])
+
+
+class OperatorSplitting(TimeIntegrator):
+    """Base class for operator-splitting approaches.
+
+    Takes in a tuple of two or more operators (`TimeIntegrator` objects) to be
+    integrated together using an operator-splitting approach.
+
+    In each stage of the approach multiple operators are applied sequentially,
+    and in some approaches the results across multiple stages are averaged
+    together for improved accuracy or stability.
+    """
+
+    stages: tuple[tuple[tuple[int, float], ...], ...] = ()
+    stage_coeffs: tuple[float, ...] = ()
+
+    def __init__(
+        self,
+        operators: tuple[TimeIntegrator, ...],
+        update_double_flux: bool = False,
+    ) -> None:
+        self.operators = operators
+        self.update_double_flux: bool = update_double_flux
+
+    def advance(
+        self,
+        dt: float,
+        time: float,
+        state_array: Array,
+        gamma_star: Array | None,
+        e0_star: Array | None,
+    ) -> tuple[float, Array, Array | None, Array | None]:
+        # Initialize final values
+        state_array_final = np.zeros_like(state_array)
+        gamma_star_final = np.zeros_like(gamma_star) if gamma_star is not None else None
+        e0_star_final = np.zeros_like(e0_star) if e0_star is not None else None
+
+        # Initialize intermediate double-flux variables
+        gamma_star_stage: Array | None = None
+        e0_star_stage: Array | None = None
+        gamma_star_temp: Array | None = None
+        e0_star_temp: Array | None = None
+
+        for istage, stage in enumerate(self.stages):
+            state_array_stage = state_array.copy()
+            if gamma_star is not None and e0_star is not None:
+                gamma_star_stage = gamma_star.copy()
+                e0_star_stage = e0_star.copy()
+
+            for ioperator, cdt in stage:
+                advance = self.operators[ioperator].advance
+
+                _, state_array_stage, gamma_star_temp, e0_star_temp = advance(
+                    dt=cdt * dt,
+                    time=time,
+                    state_array=state_array_stage,
+                    gamma_star=gamma_star_stage,
+                    e0_star=e0_star_stage,
+                )
+
+                # Optionally: Update the double flux variables after each step
+                if self.update_double_flux:
+                    gamma_star_stage, e0_star_stage = gamma_star_temp, e0_star_temp
+
+            # Otherwise, only update the double flux at the end
+            if not self.update_double_flux:
+                gamma_star_stage, e0_star_stage = gamma_star_temp, e0_star_temp
+
+            # Accumulate data from each stage
+            coeff = self.stage_coeffs[istage]
+            state_array_final = state_array_final + coeff * state_array_stage
+
+            if gamma_star_stage is not None and gamma_star_final is not None:
+                gamma_star_final = gamma_star_final + coeff * gamma_star_stage
+
+            if e0_star_stage is not None and e0_star_final is not None:
+                e0_star_final = e0_star_final + coeff * e0_star_stage
+
+        return time + dt, state_array_final, gamma_star_final, e0_star_final
+
+
+class StrangSplitting(OperatorSplitting):
+    """Classical Strang-Splitting approach.
+
+    In this approach, the first operator is integrated to the midpoint, then
+    the second operator is integrated for the full time step, and finally the
+    first operator is integrated from the midpoint to the end.
+    """
+
+    stages = (((0, 0.5), (1, 1.0), (0, 0.5)),)
+    stage_coeffs = (1.0,)
+
+
+class SymmetricallyWeightedSequentialSplitting(OperatorSplitting):
+    """This approach applies Strang splitting twice, swapping the operators and
+    then averaging the results together to make the approach symmetric.
+    """
+
+    stages = (
+        ((0, 0.5), (1, 1.0), (0, 0.5)),
+        ((1, 0.5), (0, 1.0), (1, 0.5)),
+    )
+    stage_coeffs = (0.5, 0.5)
+
+
+class ThirdOrderSplitting(OperatorSplitting):
+    stages: tuple[tuple[tuple[int, float], ...], ...] = (
+        ((0, 0.5), (1, 1.0), (0, 0.5)),
+        ((1, 0.5), (0, 1.0), (1, 0.5)),
+        ((0, 1.0), (1, 1.0)),
+        ((1, 1.0), (0, 1.0)),
+    )
+    stage_coeffs: tuple[float, ...] = (-1.0 / 6.0, -1.0 / 6.0, 2.0 / 3.0, 2.0 / 3.0)
+
+
+class LieSplitting(OperatorSplitting):
+    """Simplest splitting approach, in which each term is integrated in
+    sequence.
+    """
+
+    def __init__(
+        self,
+        operators: tuple[TimeIntegrator, ...],
+        update_double_flux: bool = False,
+    ) -> None:
+        self.operators = operators
+        self.update_double_flux: bool = update_double_flux
+
+        n_operators = len(self.operators)
+        self.stages = (tuple((i, 1.0) for i in range(n_operators)),)
+        # self.stage_coeffs = tuple(i for i in range(n_operators))
+        self.stage_coeffs = (1.0,)
+
+
+class StrangSplittingOld(TimeIntegrator):
     def __init__(
         self, transport_operator: TimeIntegrator, reaction_operator: TimeIntegrator
     ) -> None:
@@ -222,7 +453,7 @@ class StrangSplitting(TimeIntegrator):
         return t, state_array, gamma_star, e0_star
 
 
-class LieSplitting(TimeIntegrator):
+class LieSplittingOld(TimeIntegrator):
     def __init__(
         self, operators: list[TimeIntegrator], update_double_flux: bool = False
     ) -> None:

--- a/src/stanshock/numerics/time_integration.py
+++ b/src/stanshock/numerics/time_integration.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 import numpy as np
 
-from stanshock.physics.fluid_base import FluidPhysics
-from stanshock.system.backend import Array
+from stanshock.system.backend import Array, Unpack
 from stanshock.system.base import FastSlowSource, RightHandSide
+
+if TYPE_CHECKING:
+    from scipy.integrate._ivp.ivp import _IVPMethod, _SolverOptions
 
 
 class TimeIntegrator(ABC):
@@ -21,27 +24,35 @@ class TimeIntegrator(ABC):
         state_array: Array,
         gamma_star: Array | None,
         e0_star: Array | None,
-    ) -> tuple[float, Array]:
+    ) -> tuple[float, Array, Array | None, Array | None]:
         """Integrate the state from `time` to `time+dt` given the rhs."""
 
 
 class ScipyIVP(TimeIntegrator):
-    def __init__(self, rhs: RightHandSide, method: str = "LSODA", **kwargs) -> None:  # type: ignore[no-untyped-def]
+    def __init__(
+        self,
+        rhs: RightHandSide,
+        method: _IVPMethod = "LSODA",
+        **options: Unpack[_SolverOptions],
+    ) -> None:
         """Interface to SciPy's IVP solvers.
 
         The specific solver can be selected with the `method` input, and additional
         solver options can be passed in as keyword arguments. See documentation for
         `scipy.integrate.solve_ivp`.
         """
-        # from scipy.integrate import ode
         from scipy.integrate import solve_ivp
 
-        # self.integrator = ode
         self.integrator = solve_ivp
 
         self.rhs = rhs
+        self.solver_options = options
+
+        if self.rhs.jac is not None:
+            self.solver_options["jac"] = self.rhs.jac
+            self.solver_options["lband"] = 0
+            self.solver_options["uband"] = 0
         self.method = method
-        self.solver_options = kwargs
 
     def advance(
         self,
@@ -50,24 +61,32 @@ class ScipyIVP(TimeIntegrator):
         state_array: Array,
         gamma_star: Array | None,
         e0_star: Array | None,
-    ) -> tuple[float, Array]:
-        y0, state0, _, _, _ = self.rhs.precompute_for_source(
+    ) -> tuple[float, Array, Array | None, Array | None]:
+        y0, gamma_star_local, e0_star_local = self.rhs.before_time_integration(
             time, state_array, gamma_star, e0_star
         )
-        assert state0 is not None
 
         results = self.integrator(
-            fun=self.rhs.source_full,
+            fun=self.rhs.source,
             t_span=(time, time + dt),
             y0=y0,
             method=self.method,
-            args=(gamma_star, e0_star),
+            args=(gamma_star_local, e0_star_local),
             **self.solver_options,
         )
 
-        state_array = self.rhs.postcompute(results.y[:, -1], state0)
+        time = results.t[-1]
+        state_array, gamma_star, e0_star = self.rhs.after_time_integration(
+            time=time,
+            state_array_local=results.y[:, -1],
+            gamma_star_local=gamma_star_local,
+            e0_star_local=e0_star_local,
+            state_array=state_array,
+            gamma_star=gamma_star,
+            e0_star=e0_star,
+        )
 
-        return results.t[-1], state_array
+        return time, state_array, gamma_star, e0_star
 
 
 class RungeKuttaBase(TimeIntegrator):
@@ -81,12 +100,14 @@ class RungeKuttaBase(TimeIntegrator):
         state_array: Array,
         gamma_star: Array | None,
         e0_star: Array | None,
-    ) -> tuple[float, Array]:
+    ) -> tuple[float, Array, Array | None, Array | None]:
         t = time
-        y: Array = np.ravel(state_array)
+        y0, gamma_star_local, e0_star_local = self.rhs.before_time_integration(
+            t, state_array, gamma_star, e0_star
+        )
 
         t0 = t + 0
-        y0 = y.copy()
+        y = y0.copy()
 
         for i_rk_stage in range(self.n_rk_stage):
             a, b, c, d = self.rk_coeff[i_rk_stage]
@@ -94,21 +115,30 @@ class RungeKuttaBase(TimeIntegrator):
             dydt = self.rhs.source(
                 time=t,
                 state_array_local=y,
-                gamma_star=gamma_star,
-                e0_star=e0_star,
+                gamma_star=gamma_star_local,
+                e0_star=e0_star_local,
             )
 
             if b != 1.0:
-                y *= b
+                y = b * y
 
             if a != 0.0:
-                y += a * y0
+                y = y + a * y0
 
             y = self.rhs.add_source(y, c * dt * dydt)
 
             t = t0 + d * dt
 
-        return t, y
+        state_array, gamma_star, e0_star = self.rhs.after_time_integration(
+            time=time,
+            state_array_local=y,
+            gamma_star_local=gamma_star_local,
+            e0_star_local=e0_star_local,
+            state_array=state_array,
+            gamma_star=gamma_star,
+            e0_star=e0_star,
+        )
+        return t, state_array, gamma_star, e0_star
 
 
 class ForwardEuler(RungeKuttaBase):
@@ -163,8 +193,8 @@ class StrangSplitting(TimeIntegrator):
     def __init__(
         self, transport_operator: TimeIntegrator, reaction_operator: TimeIntegrator
     ) -> None:
-        self.transport_operator = transport_operator
-        self.reaction_operator = reaction_operator
+        self.transport_operator: TimeIntegrator = transport_operator
+        self.reaction_operator: TimeIntegrator = reaction_operator
 
     def advance(
         self,
@@ -173,53 +203,43 @@ class StrangSplitting(TimeIntegrator):
         state_array: Array,
         gamma_star: Array | None,
         e0_star: Array | None,
-    ) -> tuple[float, Array]:
-        y: Array = state_array.flatten()
-
+    ) -> tuple[float, Array, Array | None, Array | None]:
         # Take half-step with transport terms
-        _, y = self.transport_operator.advance(
+        _, state_array, _, _ = self.transport_operator.advance(
             dt=0.5 * dt,
             time=time,
-            state_array=y,
+            state_array=state_array,
             gamma_star=gamma_star,
             e0_star=e0_star,
         )
 
         # Take full-step with reaction terms
-        t, y = self.reaction_operator.advance(
+        t, state_array, _, _ = self.reaction_operator.advance(
             dt=dt,
             time=time,
-            state_array=y,
+            state_array=state_array,
             gamma_star=gamma_star,
             e0_star=e0_star,
         )
 
         # Take half-step with transport terms
-        _, y = self.transport_operator.advance(
+        _, state_array, gamma_star, e0_star = self.transport_operator.advance(
             dt=0.5 * dt,
             time=time + 0.5 * dt,
-            state_array=y,
+            state_array=state_array,
             gamma_star=gamma_star,
             e0_star=e0_star,
         )
 
-        return t, y
+        return t, state_array, gamma_star, e0_star
 
 
 class LieSplitting(TimeIntegrator):
     def __init__(
         self, operators: list[TimeIntegrator], update_double_flux: bool = False
     ) -> None:
-        self.operators = operators
-        self.update_double_flux = update_double_flux
-
-        # Get fluid physics from any of the operators
-        self.physics: FluidPhysics | None = None
-        if self.update_double_flux:
-            for operator in operators:
-                if operator.rhs.physics is not None:
-                    self.physics = operator.rhs.physics
-                    break
+        self.operators: list[TimeIntegrator] = operators
+        self.update_double_flux: bool = update_double_flux
 
     def advance(
         self,
@@ -228,29 +248,27 @@ class LieSplitting(TimeIntegrator):
         state_array: Array,
         gamma_star: Array | None,
         e0_star: Array | None,
-    ) -> tuple[float, Array]:
-        y: Array = state_array.flatten()
-
+    ) -> tuple[float, Array, Array | None, Array | None]:
+        gamma_star_temp: Array | None = None
+        e0_star_temp: Array | None = None
         for operator in self.operators:
-            _, y = operator.advance(
+            _, state_array, gamma_star_temp, e0_star_temp = operator.advance(
                 dt=dt,
                 time=time,
-                state_array=y,
+                state_array=state_array,
                 gamma_star=gamma_star,
                 e0_star=e0_star,
             )
 
-            # Optionally: Update the double flux variables
+            # Optionally: Update the double flux variables after each step
             if self.update_double_flux:
-                assert self.physics is not None
-                state_array = y.reshape(operator.rhs.shape)
-                state = self.physics.conservative_to_primitive(
-                    state_array, gamma_star, e0_star
-                )
-                state.temperature = self.physics.get_temperature(state)
-                gamma_star, e0_star = self.physics.get_double_flux_variables(state)
+                gamma_star, e0_star = gamma_star_temp, e0_star_temp
 
-        return time + dt, y
+        # Otherwise, only update the double flux at the end
+        if not self.update_double_flux:
+            gamma_star, e0_star = gamma_star_temp, e0_star_temp
+
+        return time + dt, state_array, gamma_star, e0_star
 
 
 class FastSlowIntegrator(TimeIntegrator):
@@ -261,9 +279,9 @@ class FastSlowIntegrator(TimeIntegrator):
         slow_integrator: type[TimeIntegrator] = ForwardEuler,
     ) -> None:
         """Apply different integrators to stiff and non-stiff terms."""
-        self.rhs = rhs
-        self.fast_integrator = fast_integrator(self.rhs)
-        self.slow_integrator = slow_integrator(self.rhs)
+        self.rhs: RightHandSide = rhs
+        self.fast_integrator: TimeIntegrator = fast_integrator(self.rhs)
+        self.slow_integrator: TimeIntegrator = slow_integrator(self.rhs)
 
     def advance(
         self,
@@ -272,27 +290,20 @@ class FastSlowIntegrator(TimeIntegrator):
         state_array: Array,
         gamma_star: Array | None,
         e0_star: Array | None,
-    ) -> tuple[float, Array]:
+    ) -> tuple[float, Array, Array | None, Array | None]:
         assert isinstance(self.rhs, FastSlowSource)
 
         # Integrate fast terms
         self.rhs.mode = "fast"
-        state_array_local, gamma_star, e0_star = self.rhs.before_time_integration(
-            time, state_array
-        )
-        _, state_array_local = self.fast_integrator.advance(
-            dt, time, state_array_local, gamma_star, e0_star
-        )
-        state_array = self.rhs.after_time_integration(state_array, state_array_local)
+        if len(state_array[self.rhs.idx_implicit]) > 0:
+            _, state_array, gamma_star, e0_star = self.fast_integrator.advance(
+                dt, time, state_array, gamma_star, e0_star
+            )
 
         # Integrate slow terms
         self.rhs.mode = "slow"
-        state_array_local, gamma_star, e0_star = self.rhs.before_time_integration(
-            time, state_array
-        )
-        _, state_array_local = self.slow_integrator.advance(
+        _, state_array, gamma_star, e0_star = self.slow_integrator.advance(
             dt, time, state_array, gamma_star, e0_star
         )
-        state_array = self.rhs.after_time_integration(state_array, state_array_local)
 
-        return time + dt, state_array
+        return time + dt, state_array, gamma_star, e0_star

--- a/src/stanshock/numerics/viscous_flux.py
+++ b/src/stanshock/numerics/viscous_flux.py
@@ -2,75 +2,47 @@ from __future__ import annotations
 
 import numpy as np
 
-from stanshock.numerics.boundary_conditions import BoundaryConditions
-from stanshock.numerics.face_extrapolation import FaceExtrapolator
-from stanshock.numerics.gradient import Gradient
-from stanshock.physics.fluid_base import FluidPhysics, FluidState
-from stanshock.system.backend import Array
-from stanshock.system.base import RightHandSide
-from stanshock.system.geometry import Geometry
+from stanshock.physics.fluid_base import FluidState
+from stanshock.system.backend import Array, Unpack
+from stanshock.system.base import PrecomputeStepName, PrecomputeSteps, RightHandSide
 
 
 class ViscousFlux(RightHandSide):
+    PRECOMPUTE_STEPS: tuple[PrecomputeStepName, ...] = (
+        "geometry",
+        "physics",
+        "boundary_conditions",
+        "face_extrapolator",
+        "face_average",
+        "gradient",
+    )
+
     def __init__(
         self,
-        boundary_conditions: BoundaryConditions,
-        face_extrapolator: FaceExtrapolator,
-        geometry: Geometry,
-        gradient: Gradient,
+        **precompute_steps: Unpack[PrecomputeSteps],
     ) -> None:
-        self.face_extrapolator = face_extrapolator
-        self.boundary_conditions = boundary_conditions
-        self.geometry = geometry
-        self.gradient = gradient
+        super().__init__(**precompute_steps)
         self.F = 1.0
-
-    def source(
-        self,
-        time: float,
-        state_array: Array,
-        physics: FluidPhysics,
-        gamma_star: Array,
-        e0_star: Array,
-    ) -> Array:
-        state_array = self.boundary_conditions.update_ghost_layers(time, state_array)
-
-        state: FluidState = physics.conservative_to_primitive(
-            state_array, gamma_star, e0_star
-        )
-
-        face_states: FluidState = self.face_extrapolator(state)
-        face_states = self.boundary_conditions.update_face_states(time, face_states)
-
-        state.temperature = physics.get_temperature(state)
-        face_gradients: FluidState = self.gradient.face_gradients(state, self.geometry)
-
-        # Average the left and right face states - simple rho-P average for now
-        r = 0.5 * (face_states.density[0, :] + face_states.density[1, :])
-        P = 0.5 * (face_states.pressure[0, :] + face_states.pressure[1, :])
-        Y = 0.5 * (face_states.composition[0, :] + face_states.composition[1, :])
-        u = 0.5 * (face_states.velocity[0, :] + face_states.velocity[1, :])
-        avg_face_states = FluidState(
-            shape=r.shape,
-            density=r,
-            pressure=P,
-            composition=Y,
-            velocity=u,
-        )
-
-        return self.source_implementation(physics, avg_face_states, face_gradients)
 
     def source_implementation(
         self,
-        physics: FluidPhysics,
-        avg_face_states: FluidState,
-        face_gradients: FluidState,
+        time: float,
+        state_array: Array | None,
+        state: FluidState | None,
+        face_states: FluidState | None,
+        avg_face_states: FluidState | None,
+        face_gradients: FluidState | None,
     ) -> Array:
+        _ = time, state_array, state, face_states
+        assert self.physics is not None
+        assert avg_face_states is not None
+        assert face_gradients is not None
+
         # Compute properties at the extrapolated cell faces
-        viscosity = physics.get_mu(avg_face_states)
-        conductivity = physics.get_thermal_conductivity(avg_face_states) * self.F
-        diffusivities = physics.get_mass_diffusivity(avg_face_states) * self.F
-        enthalpies = physics.get_species_enthalpies(avg_face_states)
+        viscosity = self.physics.get_mu(avg_face_states)
+        conductivity = self.physics.get_thermal_conductivity(avg_face_states) * self.F
+        diffusivities = self.physics.get_mass_diffusivity(avg_face_states) * self.F
+        enthalpies = self.physics.get_species_enthalpies(avg_face_states)
         density = avg_face_states.density
         Y = avg_face_states.mass_fractions
 
@@ -85,14 +57,14 @@ class ViscousFlux(RightHandSide):
         diffusive_mass_flux = density[:, None] * diffusivities * dYdx
 
         # Apply correction-velocity to preserve mass continuity
-        if physics.n_scalars_rho_sum > 1:
+        if self.physics.n_scalars_rho_sum > 1:
             correction = np.sum(
-                diffusive_mass_flux[:, : physics.n_scalars_rho_sum],
+                diffusive_mass_flux[:, : self.physics.n_scalars_rho_sum],
                 axis=-1,
                 keepdims=True,
             )
-            diffusive_mass_flux[:, : physics.n_scalars_rho_sum] -= (
-                Y[:, : physics.n_scalars_rho_sum] * correction
+            diffusive_mass_flux[:, : self.physics.n_scalars_rho_sum] -= (
+                Y[:, : self.physics.n_scalars_rho_sum] * correction
             )
 
         # Compute energy flux due to mass diffusion

--- a/src/stanshock/numerics/viscous_flux.py
+++ b/src/stanshock/numerics/viscous_flux.py
@@ -17,23 +17,20 @@ class ViscousFlux(RightHandSide):
         "gradient",
     )
 
-    def __init__(
-        self,
-        **precompute_steps: Unpack[PrecomputeSteps],
-    ) -> None:
+    def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
         super().__init__(**precompute_steps)
         self.F = 1.0
 
     def source_implementation(
         self,
         time: float,
-        state_array: Array | None,
+        state_array_local: Array | None,
         state: FluidState | None,
         face_states: FluidState | None,
         avg_face_states: FluidState | None,
         face_gradients: FluidState | None,
     ) -> Array:
-        _ = time, state_array, state, face_states
+        _ = time, state_array_local, state, face_states
         assert self.physics is not None
         assert avg_face_states is not None
         assert face_gradients is not None

--- a/src/stanshock/physics/cantera_interface.py
+++ b/src/stanshock/physics/cantera_interface.py
@@ -131,6 +131,8 @@ class CanteraInterface(FluidPhysics):
         gamma = state.gamma
         if gamma is None:
             gamma = self.get_gamma(state)
+        assert state.pressure is not None
+        assert state.density is not None
         state.sound_speed = np.sqrt(gamma * state.pressure / state.density)
         return state.sound_speed
 

--- a/src/stanshock/physics/cantera_interface.py
+++ b/src/stanshock/physics/cantera_interface.py
@@ -149,23 +149,19 @@ class CanteraInterface(FluidPhysics):
 class ConstantVolumeChemistry(RightHandSide):
     PRECOMPUTE_STEPS: tuple[PrecomputeStepName, ...] = ("geometry", "physics")
 
-    def __init__(
-        self,
-        **precompute_steps: Unpack[PrecomputeSteps],
-    ) -> None:
+    def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
         super().__init__(**precompute_steps)
         assert self.physics is not None
         self.idx_source: Index = np.arange(1, self.physics.n_scalars + 2)
 
         # Define some parameters to be set during precompute step
         self.density0: Array = np.zeros((0,))
-        self.shape_initial: tuple[int, ...] = (0, 0)
         self.shape_subset: tuple[int, ...] = (0, 0)
 
-    def precompute(
+    def precompute_for_source(
         self,
         time: float,
-        state_array: Array,
+        state_array_local: Array,
         gamma_star: Array | None = None,
         e0_star: Array | None = None,
     ) -> tuple[
@@ -179,14 +175,14 @@ class ConstantVolumeChemistry(RightHandSide):
         _ = time
         assert self.physics is not None
         n_species = self.physics.n_scalars
-        state_array = state_array.reshape((-1, n_species + 2))
-        self.shape_initial = state_array.shape
+        state_array_local = state_array_local.reshape(self.shape)
+        self.shape = state_array_local.shape
 
-        state_array = state_array[self.idx_domain]
-        self.shape_subset = state_array.shape
+        state_array_local = state_array_local[self.idx_update]
+        self.shape_subset = state_array_local.shape
 
         state: FluidState = self.physics.conservative_to_primitive(
-            state_array, gamma_star, e0_star
+            state_array_local, gamma_star, e0_star
         )
 
         assert state.density is not None
@@ -201,20 +197,20 @@ class ConstantVolumeChemistry(RightHandSide):
     def source(
         self,
         time: float,
-        state_array: Array,
+        state_array_local: Array,
         gamma_star: Array | None = None,
         e0_star: Array | None = None,
     ) -> Array:
         _ = time, gamma_star, e0_star
         assert self.physics is not None
 
-        temperature = state_array[:, -1]
+        temperature = state_array_local[:, -1]
 
         state: FluidState = FluidState(
             shape=(self.shape_subset[0],),
             density=self.density0,
             temperature=temperature,
-            composition=state_array[:, :-1],
+            composition=state_array_local[:, :-1],
         )
         wdot: Array = self.physics.get_source_terms(state)
 
@@ -232,19 +228,23 @@ class ConstantVolumeChemistry(RightHandSide):
 
         return np.ravel(dydt)
 
-    def postcompute(self, state_array: Array, y: Array, state: FluidState) -> Array:
+    def postcompute(self, state_array_local: Array, state: FluidState) -> Array:
         # Compute state from initial density and updated mass fractions + temperature
         assert self.physics is not None
-        state._cache_valid = False
-        state.pressure = None
-        state.composition = y[:, :-1]
-        state.temperature = y[:, -1]
+        state: FluidState = FluidState(
+            shape=(self.shape_subset[0],),
+            density=self.density0,
+            temperature=state_array_local[:, -1],
+            composition=state_array_local[:, :-1],
+        )
         state.pressure = self.physics.get_pressure(state)
 
-        y = self.physics.primitive_to_conservative(state)
+        state_array_local = self.physics.primitive_to_conservative(state)
 
         # Update the state array
-        state_array = state_array.reshape(self.shape_initial)
-        state_array[self.idx_domain, self.idx_source] = y[:, self.idx_source]
+        state_array_full = np.zeros(self.shape)
+        state_array_full[self.idx_update, self.idx_source] = state_array_local[
+            :, self.idx_source
+        ]
 
-        return np.ravel(state_array)
+        return np.ravel(state_array_local)

--- a/src/stanshock/physics/cantera_interface.py
+++ b/src/stanshock/physics/cantera_interface.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import numpy as np
-from cantera import Solution, SolutionArray
+from cantera import Solution, SolutionArray, gas_constant
 
 from stanshock.physics.fluid_base import FluidPhysics, FluidState
-from stanshock.system.backend import Array, Composition
+from stanshock.system.backend import Array, Composition, Index, Unpack
+from stanshock.system.base import PrecomputeStepName, PrecomputeSteps, RightHandSide
 
 
 class CanteraInterface(FluidPhysics):
@@ -143,3 +144,107 @@ class CanteraInterface(FluidPhysics):
         """Compute reaction source terms corresponding to transported scalars."""
         state = self.set_state(state)
         return self.sol.net_production_rates
+
+
+class ConstantVolumeChemistry(RightHandSide):
+    PRECOMPUTE_STEPS: tuple[PrecomputeStepName, ...] = ("geometry", "physics")
+
+    def __init__(
+        self,
+        **precompute_steps: Unpack[PrecomputeSteps],
+    ) -> None:
+        super().__init__(**precompute_steps)
+        assert self.physics is not None
+        self.idx_source: Index = np.arange(1, self.physics.n_scalars + 2)
+
+        # Define some parameters to be set during precompute step
+        self.density0: Array = np.zeros((0,))
+        self.shape_initial: tuple[int, ...] = (0, 0)
+        self.shape_subset: tuple[int, ...] = (0, 0)
+
+    def precompute(
+        self,
+        time: float,
+        state_array: Array,
+        gamma_star: Array | None = None,
+        e0_star: Array | None = None,
+    ) -> tuple[
+        Array,
+        FluidState | None,
+        FluidState | None,
+        FluidState | None,
+        FluidState | None,
+    ]:
+        """Store temperature and mass fractions in the state array."""
+        _ = time
+        assert self.physics is not None
+        n_species = self.physics.n_scalars
+        state_array = state_array.reshape((-1, n_species + 2))
+        self.shape_initial = state_array.shape
+
+        state_array = state_array[self.idx_domain]
+        self.shape_subset = state_array.shape
+
+        state: FluidState = self.physics.conservative_to_primitive(
+            state_array, gamma_star, e0_star
+        )
+
+        assert state.density is not None
+        self.density0 = state.density
+
+        state_array_new: Array = np.zeros((self.shape_subset[0], n_species + 1))
+        state_array_new[:, :-1] = state.composition
+        state_array_new[:, -1] = self.physics.get_temperature(state)
+
+        return state_array_new, state, None, None, None
+
+    def source(
+        self,
+        time: float,
+        state_array: Array,
+        gamma_star: Array | None = None,
+        e0_star: Array | None = None,
+    ) -> Array:
+        _ = time, gamma_star, e0_star
+        assert self.physics is not None
+
+        temperature = state_array[:, -1]
+
+        state: FluidState = FluidState(
+            shape=(self.shape_subset[0],),
+            density=self.density0,
+            temperature=temperature,
+            composition=state_array[:, :-1],
+        )
+        wdot: Array = self.physics.get_source_terms(state)
+
+        eRT = self.physics.sol.standard_int_energies_RT
+        cv = self.physics.get_cp(state) / self.physics.get_gamma(state)
+
+        dydt: Array = np.zeros(self.shape_subset)
+        dydt[:, :-1] = (
+            wdot * self.physics.gas.molecular_weights[None, :] / self.density0[:, None]
+        )
+        dydt[:, -1] = (
+            -np.sum(eRT * wdot, axis=-1, keepdims=True)
+            * (gas_constant * temperature / (self.density0 * cv))[:, None]
+        )
+
+        return np.ravel(dydt)
+
+    def postcompute(self, state_array: Array, y: Array, state: FluidState) -> Array:
+        # Compute state from initial density and updated mass fractions + temperature
+        assert self.physics is not None
+        state._cache_valid = False
+        state.pressure = None
+        state.composition = y[:, :-1]
+        state.temperature = y[:, -1]
+        state.pressure = self.physics.get_pressure(state)
+
+        y = self.physics.primitive_to_conservative(state)
+
+        # Update the state array
+        state_array = state_array.reshape(self.shape_initial)
+        state_array[self.idx_domain, self.idx_source] = y[:, self.idx_source]
+
+        return np.ravel(state_array)

--- a/src/stanshock/physics/cantera_interface.py
+++ b/src/stanshock/physics/cantera_interface.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import numpy as np
-from cantera import Solution, SolutionArray, gas_constant
+from cantera import Solution, SolutionArray
 
 from stanshock.physics.fluid_base import FluidPhysics, FluidState
-from stanshock.system.backend import Array, Composition, Index, Unpack
-from stanshock.system.base import PrecomputeStepName, PrecomputeSteps, RightHandSide
+from stanshock.system.backend import Array, Composition
 
 
 class CanteraInterface(FluidPhysics):
@@ -144,107 +143,3 @@ class CanteraInterface(FluidPhysics):
         """Compute reaction source terms corresponding to transported scalars."""
         state = self.set_state(state)
         return self.sol.net_production_rates
-
-
-class ConstantVolumeChemistry(RightHandSide):
-    PRECOMPUTE_STEPS: tuple[PrecomputeStepName, ...] = ("geometry", "physics")
-
-    def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
-        super().__init__(**precompute_steps)
-        assert self.physics is not None
-        self.idx_source: Index = np.arange(1, self.physics.n_scalars + 2)
-
-        # Define some parameters to be set during precompute step
-        self.density0: Array = np.zeros((0,))
-        self.shape_subset: tuple[int, ...] = (0, 0)
-
-    def precompute_for_source(
-        self,
-        time: float,
-        state_array_local: Array,
-        gamma_star: Array | None = None,
-        e0_star: Array | None = None,
-    ) -> tuple[
-        Array,
-        FluidState | None,
-        FluidState | None,
-        FluidState | None,
-        FluidState | None,
-    ]:
-        """Store temperature and mass fractions in the state array."""
-        _ = time
-        assert self.physics is not None
-        n_species = self.physics.n_scalars
-        state_array_local = state_array_local.reshape(self.shape)
-        self.shape = state_array_local.shape
-
-        state_array_local = state_array_local[self.idx_update]
-        self.shape_subset = state_array_local.shape
-
-        state: FluidState = self.physics.conservative_to_primitive(
-            state_array_local, gamma_star, e0_star
-        )
-
-        assert state.density is not None
-        self.density0 = state.density
-
-        state_array_new: Array = np.zeros((self.shape_subset[0], n_species + 1))
-        state_array_new[:, :-1] = state.composition
-        state_array_new[:, -1] = self.physics.get_temperature(state)
-
-        return state_array_new, state, None, None, None
-
-    def source(
-        self,
-        time: float,
-        state_array_local: Array,
-        gamma_star: Array | None = None,
-        e0_star: Array | None = None,
-    ) -> Array:
-        _ = time, gamma_star, e0_star
-        assert self.physics is not None
-
-        temperature = state_array_local[:, -1]
-
-        state: FluidState = FluidState(
-            shape=(self.shape_subset[0],),
-            density=self.density0,
-            temperature=temperature,
-            composition=state_array_local[:, :-1],
-        )
-        wdot: Array = self.physics.get_source_terms(state)
-
-        eRT = self.physics.sol.standard_int_energies_RT
-        cv = self.physics.get_cp(state) / self.physics.get_gamma(state)
-
-        dydt: Array = np.zeros(self.shape_subset)
-        dydt[:, :-1] = (
-            wdot * self.physics.gas.molecular_weights[None, :] / self.density0[:, None]
-        )
-        dydt[:, -1] = (
-            -np.sum(eRT * wdot, axis=-1, keepdims=True)
-            * (gas_constant * temperature / (self.density0 * cv))[:, None]
-        )
-
-        return np.ravel(dydt)
-
-    def postcompute(self, state_array_local: Array, state: FluidState) -> Array:
-        # Compute state from initial density and updated mass fractions + temperature
-        assert self.physics is not None
-        state: FluidState = FluidState(
-            shape=(self.shape_subset[0],),
-            density=self.density0,
-            temperature=state_array_local[:, -1],
-            composition=state_array_local[:, :-1],
-        )
-        state.pressure = self.physics.get_pressure(state)
-
-        state_array_local = self.physics.primitive_to_conservative(state)
-
-        # Update the state array
-        state_array_full = np.zeros(self.shape)
-        state_array_full[self.idx_update, self.idx_source] = state_array_local[
-            :, self.idx_source
-        ]
-
-        return np.ravel(state_array_local)

--- a/src/stanshock/physics/chemistry_source.py
+++ b/src/stanshock/physics/chemistry_source.py
@@ -35,12 +35,14 @@ class ChemistrySource(RightHandSide):
 class ConstantVolumeChemistry(RightHandSide):
     def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
         super().__init__(**precompute_steps)
+        assert self.physics is not None
+        assert self.geometry is not None
 
         # Restrict the domain to the cells
         n_species = self.physics.n_scalars
         self.idx_domain = self.geometry.idx_cells
         self.idx_update = np.s_[:]
-        self.shape_subset: tuple[int, ...] = (self.shape_update[0], n_species + 1)
+        self.shape_update = (self.shape_update[0], n_species + 1)
 
         # Define density and velocity as constants to be set before time integration
         self.density_initial: Array = np.zeros((0,))
@@ -54,12 +56,13 @@ class ConstantVolumeChemistry(RightHandSide):
         e0_star: Array | None,
     ) -> tuple[Array, Array | None, Array | None]:
         """Store temperature and mass fractions in the state array."""
+        assert self.physics is not None
         state_array_local, gamma_star_local, e0_star_local = (
             super().before_time_integration(time, state_array, gamma_star, e0_star)
         )
 
         state = self.physics.conservative_to_primitive(
-            state_array_local.reshape(self.shape_update),
+            state_array_local.reshape(self.shape_domain),
             gamma_star_local,
             e0_star_local,
         )
@@ -70,7 +73,7 @@ class ConstantVolumeChemistry(RightHandSide):
         self.velocity_initial = state.velocity
 
         assert state.composition is not None
-        state_array_new: Array = np.zeros(self.shape_subset)
+        state_array_new: Array = np.zeros(self.shape_update)
         state_array_new[:, 0] = self.physics.get_temperature(state)
         state_array_new[:, 1:] = state.composition
 
@@ -87,16 +90,11 @@ class ConstantVolumeChemistry(RightHandSide):
         e0_star: Array | None,
     ) -> tuple[Array, Array | None, Array | None]:
         # Compute conservative state from initial density and updated mass fractions + temperature
-        state_array_local = np.reshape(state_array_local, self.shape_subset)
-        state: FluidState = FluidState(
-            shape=(self.shape_subset[0],),
-            density=self.density_initial,
-            velocity=self.velocity_initial,
-            temperature=state_array_local[:, 0],
-            composition=state_array_local[:, 1:],
-            gamma_star=gamma_star_local,
-            e0_star=e0_star_local,
+        _, state, _, _, _ = self.precompute_for_source(
+            time, state_array_local, gamma_star_local, e0_star_local
         )
+        assert state is not None
+        assert self.physics is not None
         state.pressure = self.physics.get_pressure(state)
         state_array_local = self.physics.primitive_to_conservative(state)
 
@@ -133,14 +131,16 @@ class ConstantVolumeChemistry(RightHandSide):
     ]:
         """Store temperature and mass fractions in the state array."""
         _ = time, gamma_star, e0_star
-        state_array_local = state_array_local.reshape(self.shape_subset)
+        state_array_local = state_array_local.reshape(self.shape_update)
 
         state: FluidState = FluidState(
-            shape=(self.shape_subset[0],),
+            shape=(self.shape_update[0],),
             density=self.density_initial,
             velocity=self.velocity_initial,
             temperature=state_array_local[:, 0],
             composition=state_array_local[:, 1:],
+            gamma_star=gamma_star,
+            e0_star=e0_star,
         )
 
         return np.ravel(state_array_local), state, None, None, None
@@ -164,7 +164,7 @@ class ConstantVolumeChemistry(RightHandSide):
         eRT = self.physics.sol.standard_int_energies_RT
         cv = self.physics.get_cp(state) / self.physics.get_gamma(state)
 
-        dydt: Array = np.zeros(self.shape_subset)
+        dydt: Array = np.zeros(self.shape_update)
         dydt[:, 0] = -np.sum(eRT * wdot, axis=-1) * (
             gas_constant * temperature / (self.density_initial * cv)
         )

--- a/src/stanshock/physics/chemistry_source.py
+++ b/src/stanshock/physics/chemistry_source.py
@@ -40,9 +40,9 @@ class ConstantVolumeChemistry(RightHandSide):
 
         # Restrict the domain to the cells
         n_species = self.physics.n_scalars
-        self.idx_domain = self.geometry.idx_cells
-        self.idx_update = np.s_[:]
-        self.shape_domain = self.shape_update = (self.shape_update[0], n_species + 1)
+        self.idx_input = self.geometry.idx_cells
+        self.idx_output = np.s_[:]
+        self.shape_input = self.shape_output = (self.shape_output[0], n_species + 1)
 
         # Define density and velocity as constants to be set before time integration
         self.density_initial: Array = np.zeros((0,))
@@ -73,7 +73,7 @@ class ConstantVolumeChemistry(RightHandSide):
         self.velocity_initial = state.velocity
 
         assert state.composition is not None
-        state_array_new: Array = np.zeros(self.shape_update)
+        state_array_new: Array = np.zeros(self.shape_output)
         state_array_new[:, 0] = self.physics.get_temperature(state)
         state_array_new[:, 1:] = state.composition
 
@@ -103,13 +103,13 @@ class ConstantVolumeChemistry(RightHandSide):
             gamma_star_local, e0_star_local = self.physics.get_double_flux_variables(
                 state
             )
-            gamma_star[self.idx_domain] = gamma_star_local
+            gamma_star[self.idx_input] = gamma_star_local
             assert e0_star is not None
-            e0_star[self.idx_domain] = e0_star_local
+            e0_star[self.idx_input] = e0_star_local
 
         # Update the state array
         state_array = np.reshape(state_array, self.shape_full)
-        state_array[self.idx_domain] = state_array_local
+        state_array[self.idx_input] = state_array_local
 
         # Update the domain indices for next time step
         self.update_indices(time, state)
@@ -131,10 +131,10 @@ class ConstantVolumeChemistry(RightHandSide):
     ]:
         """Store temperature and mass fractions in the state array."""
         _ = time, gamma_star, e0_star
-        state_array_local = state_array_local.reshape(self.shape_update)
+        state_array_local = state_array_local.reshape(self.shape_output)
 
         state: FluidState = FluidState(
-            shape=(self.shape_update[0],),
+            shape=(self.shape_output[0],),
             density=self.density_initial,
             velocity=self.velocity_initial,
             temperature=state_array_local[:, 0],
@@ -164,7 +164,7 @@ class ConstantVolumeChemistry(RightHandSide):
         eRT = self.physics.sol.standard_int_energies_RT
         cv = self.physics.get_cp(state) / self.physics.get_gamma(state)
 
-        dydt: Array = np.zeros(self.shape_update)
+        dydt: Array = np.zeros(self.shape_output)
         dydt[:, 0] = -np.sum(eRT * wdot, axis=-1) * (
             gas_constant * temperature / (self.density_initial * cv)
         )

--- a/src/stanshock/physics/chemistry_source.py
+++ b/src/stanshock/physics/chemistry_source.py
@@ -42,7 +42,7 @@ class ConstantVolumeChemistry(RightHandSide):
         n_species = self.physics.n_scalars
         self.idx_domain = self.geometry.idx_cells
         self.idx_update = np.s_[:]
-        self.shape_update = (self.shape_update[0], n_species + 1)
+        self.shape_domain = self.shape_update = (self.shape_update[0], n_species + 1)
 
         # Define density and velocity as constants to be set before time integration
         self.density_initial: Array = np.zeros((0,))
@@ -62,7 +62,7 @@ class ConstantVolumeChemistry(RightHandSide):
         )
 
         state = self.physics.conservative_to_primitive(
-            state_array_local.reshape(self.shape_domain),
+            state_array_local.reshape(self.shape_full),
             gamma_star_local,
             e0_star_local,
         )

--- a/src/stanshock/physics/chemistry_source.py
+++ b/src/stanshock/physics/chemistry_source.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import numpy as np
+from cantera import gas_constant
+
+from stanshock.physics.fluid_base import FluidState
+from stanshock.system.backend import Array, Index, Unpack
+from stanshock.system.base import PrecomputeSteps, RightHandSide
+
+
+class ChemistrySource(RightHandSide):
+    PRECOMPUTE_STEPS = ("geometry", "physics")
+
+    def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
+        super().__init__(**precompute_steps)
+        self.idx_source = np.s_[2:]
+
+    def source_implementation(
+        self,
+        time: float,
+        state_array_local: Array | None,
+        state: FluidState | None,
+        face_states: FluidState | None,
+        avg_face_states: FluidState | None,
+        face_gradients: FluidState | None,
+    ) -> Array:
+        """Compute the temporal gradient of the current state of the system."""
+        _ = time, state_array_local, face_states, avg_face_states, face_gradients
+        assert self.physics is not None
+        assert state is not None
+        return self.physics.get_source_terms(state)
+
+
+class ConstantVolumeChemistry(RightHandSide):
+    PRECOMPUTE_STEPS = ("geometry", "physics")
+
+    def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
+        super().__init__(**precompute_steps)
+        assert self.physics is not None
+        self.idx_source: Index = np.arange(1, self.physics.n_scalars + 2)
+
+        # Define some parameters to be set during precompute step
+        self.density0: Array = np.zeros((0,))
+        self.shape_subset: tuple[int, ...] = (0, 0)
+
+    def precompute_for_source(
+        self,
+        time: float,
+        state_array_local: Array,
+        gamma_star: Array | None = None,
+        e0_star: Array | None = None,
+    ) -> tuple[
+        Array,
+        FluidState | None,
+        FluidState | None,
+        FluidState | None,
+        FluidState | None,
+    ]:
+        """Store temperature and mass fractions in the state array."""
+        _ = time
+        assert self.physics is not None
+        n_species = self.physics.n_scalars
+        state_array_local = state_array_local.reshape(self.shape)
+        self.shape = state_array_local.shape
+
+        state_array_local = state_array_local[self.idx_update]
+        self.shape_subset = state_array_local.shape
+
+        state: FluidState = self.physics.conservative_to_primitive(
+            state_array_local, gamma_star, e0_star
+        )
+
+        assert state.density is not None
+        self.density0 = state.density
+
+        state_array_new: Array = np.zeros((self.shape_subset[0], n_species + 1))
+        state_array_new[:, :-1] = state.composition
+        state_array_new[:, -1] = self.physics.get_temperature(state)
+
+        return state_array_new, state, None, None, None
+
+    def source(
+        self,
+        time: float,
+        state_array_local: Array,
+        gamma_star: Array | None = None,
+        e0_star: Array | None = None,
+    ) -> Array:
+        _ = time, gamma_star, e0_star
+        assert self.physics is not None
+
+        temperature = state_array_local[:, -1]
+
+        state: FluidState = FluidState(
+            shape=(self.shape_subset[0],),
+            density=self.density0,
+            temperature=temperature,
+            composition=state_array_local[:, :-1],
+        )
+        wdot: Array = self.physics.get_source_terms(state)
+
+        eRT = self.physics.sol.standard_int_energies_RT
+        cv = self.physics.get_cp(state) / self.physics.get_gamma(state)
+
+        dydt: Array = np.zeros(self.shape_subset)
+        dydt[:, :-1] = (
+            wdot * self.physics.gas.molecular_weights[None, :] / self.density0[:, None]
+        )
+        dydt[:, -1] = (
+            -np.sum(eRT * wdot, axis=-1, keepdims=True)
+            * (gas_constant * temperature / (self.density0 * cv))[:, None]
+        )
+
+        return np.ravel(dydt)
+
+    def postcompute(self, state_array_local: Array, state: FluidState) -> Array:
+        # Compute state from initial density and updated mass fractions + temperature
+        assert self.physics is not None
+        state: FluidState = FluidState(
+            shape=(self.shape_subset[0],),
+            density=self.density0,
+            temperature=state_array_local[:, -1],
+            composition=state_array_local[:, :-1],
+        )
+        state.pressure = self.physics.get_pressure(state)
+
+        state_array_local = self.physics.primitive_to_conservative(state)
+
+        # Update the state array
+        state_array_full = np.zeros(self.shape)
+        state_array_full[self.idx_update, self.idx_source] = state_array_local[
+            :, self.idx_source
+        ]
+
+        return np.ravel(state_array_local)

--- a/src/stanshock/physics/chemistry_source.py
+++ b/src/stanshock/physics/chemistry_source.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import numpy as np
 from cantera import gas_constant
 
+from stanshock.physics.cantera_interface import CanteraInterface
 from stanshock.physics.fluid_base import FluidState
-from stanshock.system.backend import Array, Index, Unpack
+from stanshock.system.backend import Array, Unpack
 from stanshock.system.base import PrecomputeSteps, RightHandSide
 
 
@@ -32,16 +33,90 @@ class ChemistrySource(RightHandSide):
 
 
 class ConstantVolumeChemistry(RightHandSide):
-    PRECOMPUTE_STEPS = ("geometry", "physics")
-
     def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
         super().__init__(**precompute_steps)
-        assert self.physics is not None
-        self.idx_source: Index = np.arange(1, self.physics.n_scalars + 2)
 
-        # Define some parameters to be set during precompute step
-        self.density0: Array = np.zeros((0,))
-        self.shape_subset: tuple[int, ...] = (0, 0)
+        # Restrict the domain to the cells
+        n_species = self.physics.n_scalars
+        self.idx_domain = self.geometry.idx_cells
+        self.idx_update = np.s_[:]
+        self.shape_subset: tuple[int, ...] = (self.shape_update[0], n_species + 1)
+
+        # Define density and velocity as constants to be set before time integration
+        self.density_initial: Array = np.zeros((0,))
+        self.velocity_initial: Array = np.zeros((0,))
+
+    def before_time_integration(
+        self,
+        time: float,
+        state_array: Array,
+        gamma_star: Array | None,
+        e0_star: Array | None,
+    ) -> tuple[Array, Array | None, Array | None]:
+        """Store temperature and mass fractions in the state array."""
+        state_array_local, gamma_star_local, e0_star_local = (
+            super().before_time_integration(time, state_array, gamma_star, e0_star)
+        )
+
+        state = self.physics.conservative_to_primitive(
+            state_array_local.reshape(self.shape_update),
+            gamma_star_local,
+            e0_star_local,
+        )
+
+        assert state.density is not None
+        self.density_initial = state.density
+        assert state.velocity is not None
+        self.velocity_initial = state.velocity
+
+        assert state.composition is not None
+        state_array_new: Array = np.zeros(self.shape_subset)
+        state_array_new[:, 0] = self.physics.get_temperature(state)
+        state_array_new[:, 1:] = state.composition
+
+        return np.ravel(state_array_new), gamma_star_local, e0_star_local
+
+    def after_time_integration(
+        self,
+        time: float,
+        state_array_local: Array,
+        gamma_star_local: Array | None,
+        e0_star_local: Array | None,
+        state_array: Array,
+        gamma_star: Array | None,
+        e0_star: Array | None,
+    ) -> tuple[Array, Array | None, Array | None]:
+        # Compute conservative state from initial density and updated mass fractions + temperature
+        state_array_local = np.reshape(state_array_local, self.shape_subset)
+        state: FluidState = FluidState(
+            shape=(self.shape_subset[0],),
+            density=self.density_initial,
+            velocity=self.velocity_initial,
+            temperature=state_array_local[:, 0],
+            composition=state_array_local[:, 1:],
+            gamma_star=gamma_star_local,
+            e0_star=e0_star_local,
+        )
+        state.pressure = self.physics.get_pressure(state)
+        state_array_local = self.physics.primitive_to_conservative(state)
+
+        # Update double-flux variables
+        if gamma_star is not None:
+            gamma_star_local, e0_star_local = self.physics.get_double_flux_variables(
+                state
+            )
+            gamma_star[self.idx_domain] = gamma_star_local
+            assert e0_star is not None
+            e0_star[self.idx_domain] = e0_star_local
+
+        # Update the state array
+        state_array = np.reshape(state_array, self.shape_full)
+        state_array[self.idx_domain] = state_array_local
+
+        # Update the domain indices for next time step
+        self.update_indices(time, state)
+
+        return np.ravel(state_array), gamma_star, e0_star
 
     def precompute_for_source(
         self,
@@ -57,79 +132,46 @@ class ConstantVolumeChemistry(RightHandSide):
         FluidState | None,
     ]:
         """Store temperature and mass fractions in the state array."""
-        _ = time
-        assert self.physics is not None
-        n_species = self.physics.n_scalars
-        state_array_local = state_array_local.reshape(self.shape)
-        self.shape = state_array_local.shape
-
-        state_array_local = state_array_local[self.idx_update]
-        self.shape_subset = state_array_local.shape
-
-        state: FluidState = self.physics.conservative_to_primitive(
-            state_array_local, gamma_star, e0_star
-        )
-
-        assert state.density is not None
-        self.density0 = state.density
-
-        state_array_new: Array = np.zeros((self.shape_subset[0], n_species + 1))
-        state_array_new[:, :-1] = state.composition
-        state_array_new[:, -1] = self.physics.get_temperature(state)
-
-        return state_array_new, state, None, None, None
-
-    def source(
-        self,
-        time: float,
-        state_array_local: Array,
-        gamma_star: Array | None = None,
-        e0_star: Array | None = None,
-    ) -> Array:
         _ = time, gamma_star, e0_star
-        assert self.physics is not None
-
-        temperature = state_array_local[:, -1]
+        state_array_local = state_array_local.reshape(self.shape_subset)
 
         state: FluidState = FluidState(
             shape=(self.shape_subset[0],),
-            density=self.density0,
-            temperature=temperature,
-            composition=state_array_local[:, :-1],
+            density=self.density_initial,
+            velocity=self.velocity_initial,
+            temperature=state_array_local[:, 0],
+            composition=state_array_local[:, 1:],
         )
+
+        return np.ravel(state_array_local), state, None, None, None
+
+    def source_implementation(
+        self,
+        time: float,
+        state_array_local: Array | None,
+        state: FluidState | None,
+        face_states: FluidState | None,
+        avg_face_states: FluidState | None,
+        face_gradients: FluidState | None,
+    ) -> Array:
+        _ = time, state_array_local, face_states, avg_face_states, face_gradients
+        assert isinstance(self.physics, CanteraInterface)
+        assert state is not None
+        assert state.temperature is not None
+        temperature = state.temperature
         wdot: Array = self.physics.get_source_terms(state)
 
         eRT = self.physics.sol.standard_int_energies_RT
         cv = self.physics.get_cp(state) / self.physics.get_gamma(state)
 
         dydt: Array = np.zeros(self.shape_subset)
-        dydt[:, :-1] = (
-            wdot * self.physics.gas.molecular_weights[None, :] / self.density0[:, None]
+        dydt[:, 0] = -np.sum(eRT * wdot, axis=-1) * (
+            gas_constant * temperature / (self.density_initial * cv)
         )
-        dydt[:, -1] = (
-            -np.sum(eRT * wdot, axis=-1, keepdims=True)
-            * (gas_constant * temperature / (self.density0 * cv))[:, None]
+        dydt[:, 1:] = (
+            wdot
+            * self.physics.gas.molecular_weights[None, :]
+            / self.density_initial[:, None]
         )
 
         return np.ravel(dydt)
-
-    def postcompute(self, state_array_local: Array, state: FluidState) -> Array:
-        # Compute state from initial density and updated mass fractions + temperature
-        assert self.physics is not None
-        state: FluidState = FluidState(
-            shape=(self.shape_subset[0],),
-            density=self.density0,
-            temperature=state_array_local[:, -1],
-            composition=state_array_local[:, :-1],
-        )
-        state.pressure = self.physics.get_pressure(state)
-
-        state_array_local = self.physics.primitive_to_conservative(state)
-
-        # Update the state array
-        state_array_full = np.zeros(self.shape)
-        state_array_full[self.idx_update, self.idx_source] = state_array_local[
-            :, self.idx_source
-        ]
-
-        return np.ravel(state_array_local)

--- a/src/stanshock/physics/fluid_base.py
+++ b/src/stanshock/physics/fluid_base.py
@@ -297,14 +297,14 @@ class ChemistrySource(RightHandSide):
     def source_implementation(
         self,
         time: float,
-        state_array: Array | None,
+        state_array_local: Array | None,
         state: FluidState | None,
         face_states: FluidState | None,
         avg_face_states: FluidState | None,
         face_gradients: FluidState | None,
     ) -> Array:
         """Compute the temporal gradient of the current state of the system."""
-        _ = time, state_array, face_states, avg_face_states, face_gradients
+        _ = time, state_array_local, face_states, avg_face_states, face_gradients
         assert self.physics is not None
         assert state is not None
         return self.physics.get_source_terms(state)

--- a/src/stanshock/physics/fluid_base.py
+++ b/src/stanshock/physics/fluid_base.py
@@ -81,11 +81,13 @@ class FluidPhysics(ABC):
 
     def get_double_flux_variables(self, state: FluidState) -> tuple[Array, Array]:
         """Compute effective specific heat ratio, gamma*, and reference energy, e_0^*."""
-        assert state.internal_energy is not None
         assert state.pressure is not None
         assert state.density is not None
         # Valid for any ideal gas, g* = rho*c^2/p = g
         state.gamma_star = self.get_gamma(state)
+        if state.internal_energy is None:
+            state.internal_energy = self.get_internal_energy(state)
+        assert state.internal_energy is not None
         state.e0_star = state.internal_energy - state.pressure / (
             state.density * (state.gamma_star - 1.0)
         )

--- a/src/stanshock/physics/fluid_base.py
+++ b/src/stanshock/physics/fluid_base.py
@@ -5,10 +5,8 @@ from dataclasses import dataclass
 
 import cantera as ct
 import numpy as np
-from typing_extensions import Unpack
 
 from stanshock.system.backend import Array, Composition
-from stanshock.system.base import PrecomputeSteps, RightHandSide
 
 
 @dataclass
@@ -285,26 +283,3 @@ class FluidPhysics(ABC):
     @abstractmethod
     def get_source_terms(self, state: FluidState) -> Array:
         """Compute reaction source terms corresponding to transported scalars."""
-
-
-class ChemistrySource(RightHandSide):
-    PRECOMPUTE_STEPS = ("geometry", "physics")
-
-    def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
-        super().__init__(**precompute_steps)
-        self.idx_source = np.s_[2:]
-
-    def source_implementation(
-        self,
-        time: float,
-        state_array_local: Array | None,
-        state: FluidState | None,
-        face_states: FluidState | None,
-        avg_face_states: FluidState | None,
-        face_gradients: FluidState | None,
-    ) -> Array:
-        """Compute the temporal gradient of the current state of the system."""
-        _ = time, state_array_local, face_states, avg_face_states, face_gradients
-        assert self.physics is not None
-        assert state is not None
-        return self.physics.get_source_terms(state)

--- a/src/stanshock/physics/fluid_base.py
+++ b/src/stanshock/physics/fluid_base.py
@@ -281,3 +281,17 @@ class FluidPhysics(ABC):
     @abstractmethod
     def get_source_terms(self, state: FluidState) -> Array:
         """Compute reaction source terms corresponding to transported scalars."""
+
+
+class ChemistrySource:
+    def source(
+        self,
+        _time: float,
+        state_array: Array,
+        physics: FluidPhysics,
+        gamma_star: Array | None = None,
+        e0_star: Array | None = None,
+    ) -> Array:
+        """Compute the temporal gradient of the current state of the system."""
+        state = physics.conservative_to_primitive(state_array, gamma_star, e0_star)
+        return physics.get_source_terms(state)

--- a/src/stanshock/physics/fluid_base.py
+++ b/src/stanshock/physics/fluid_base.py
@@ -5,9 +5,10 @@ from dataclasses import dataclass
 
 import cantera as ct
 import numpy as np
+from typing_extensions import Unpack
 
 from stanshock.system.backend import Array, Composition
-from stanshock.system.base import RightHandSide
+from stanshock.system.base import PrecomputeSteps, RightHandSide
 
 
 @dataclass
@@ -62,6 +63,9 @@ class FluidPhysics(ABC):
         self.prog_def: Composition | None = (
             prog_def  # Progress variable molar composition
         )
+        self.Z_weights: Array = np.zeros(self.gas.n_species)
+        self.Z_offset: float = 0.0
+        self.prog_weights: Array = np.zeros(self.gas.n_species)
 
         if self.ox_def is not None and self.fuel_def is not None:
             self.initialize_bilger_mixture_fraction()
@@ -134,12 +138,13 @@ class FluidPhysics(ABC):
         """Compute coefficients defining Bilger mixture fraction."""
         assert self.ox_def is not None
         assert self.fuel_def is not None
-        self.Z_weights: Array = np.zeros(self.gas.n_species)
-        self.Z_offset: float = 0.0
+
+        self.Z_weights = np.zeros(self.gas.n_species)
+        self.Z_offset = 0.0
         denom = 0.0
 
         # Set the values for C, H, and O:
-        stoich = {
+        stoich: dict[str, float] = {
             "C": 2.0,
             "H": 0.5,
             "O": -1.0,
@@ -179,7 +184,7 @@ class FluidPhysics(ABC):
 
     def initialize_progress_variable(self, prog_def: Composition) -> None:
         """Set coefficients defining progress variable."""
-        self.prog_weights: Array = np.zeros(self.gas.n_species)
+        self.prog_weights = np.zeros(self.gas.n_species)
 
         for sp, val in prog_def.items():
             self.prog_weights[self.gas.species_index(sp)] = val
@@ -211,14 +216,12 @@ class FluidPhysics(ABC):
 
     def get_normalized_progress_variable(self, Z: Array, C: Array) -> Array:
         _ = Z, C
-        msg = f"Normalized progress variable not implemented for {self.__class__}."
+        msg = f"Normalized progress variable not implemented for {self.__class__.__name__}."
         raise NotImplementedError(msg)
 
     def lookup(self, var: str, state: FluidState) -> Array:
         _ = var, state
-        msg = (
-            f"Looking up a variable by string is not implemented for {self.__class__}."
-        )
+        msg = f"Looking up a variable by string is not implemented for {self.__class__.__name__}."
         raise NotImplementedError(msg)
 
     def primitive_to_conservative(self, state: FluidState) -> Array:
@@ -286,6 +289,10 @@ class FluidPhysics(ABC):
 
 class ChemistrySource(RightHandSide):
     PRECOMPUTE_STEPS = ("geometry", "physics")
+
+    def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
+        super().__init__(**precompute_steps)
+        self.idx_source = np.s_[2:]
 
     def source_implementation(
         self,

--- a/src/stanshock/physics/fluid_base.py
+++ b/src/stanshock/physics/fluid_base.py
@@ -7,6 +7,7 @@ import cantera as ct
 import numpy as np
 
 from stanshock.system.backend import Array, Composition
+from stanshock.system.base import RightHandSide
 
 
 @dataclass
@@ -283,15 +284,20 @@ class FluidPhysics(ABC):
         """Compute reaction source terms corresponding to transported scalars."""
 
 
-class ChemistrySource:
-    def source(
+class ChemistrySource(RightHandSide):
+    PRECOMPUTE_STEPS = ("geometry", "physics")
+
+    def source_implementation(
         self,
-        _time: float,
-        state_array: Array,
-        physics: FluidPhysics,
-        gamma_star: Array | None = None,
-        e0_star: Array | None = None,
+        time: float,
+        state_array: Array | None,
+        state: FluidState | None,
+        face_states: FluidState | None,
+        avg_face_states: FluidState | None,
+        face_gradients: FluidState | None,
     ) -> Array:
         """Compute the temporal gradient of the current state of the system."""
-        state = physics.conservative_to_primitive(state_array, gamma_star, e0_star)
-        return physics.get_source_terms(state)
+        _ = time, state_array, face_states, avg_face_states, face_gradients
+        assert self.physics is not None
+        assert state is not None
+        return self.physics.get_source_terms(state)

--- a/src/stanshock/physics/thermotable.py
+++ b/src/stanshock/physics/thermotable.py
@@ -222,10 +222,21 @@ class ThermoTable(CanteraInterface):
         return state.temperature
 
     def get_pressure(self, state: FluidState) -> Array:
-        assert state.temperature is not None
+        if state.pressure is not None:
+            return state.pressure
+
         assert state.density is not None
-        R = self.get_specific_gas_constant(state)
-        state.pressure = state.temperature * R * state.density
+        if state.gamma_star is not None and state.internal_energy is not None:
+            assert state.e0_star is not None
+            state.pressure = (
+                (state.gamma_star - 1.0)
+                * state.density
+                * (state.internal_energy - state.e0_star)
+            )
+        else:
+            assert state.temperature is not None
+            R = self.get_specific_gas_constant(state)
+            state.pressure = state.temperature * R * state.density
         return state.pressure
 
     def get_species_enthalpies(self, state: FluidState) -> Array:

--- a/src/stanshock/system/backend.py
+++ b/src/stanshock/system/backend.py
@@ -1,10 +1,24 @@
 from __future__ import annotations
 
+import sys
 from typing import TypeAlias
 
 import numpy as np
 
-__all__: list[str] = ["Array", "Composition", "Index", "TypeAlias", "np"]
+if sys.version_info >= (3, 13):
+    from typing import NotRequired, Unpack
+else:
+    from typing_extensions import NotRequired, Unpack
+
+__all__: list[str] = [
+    "Array",
+    "Composition",
+    "Index",
+    "NotRequired",
+    "TypeAlias",
+    "Unpack",
+    "np",
+]
 
 # Define the Array type for use in type hints to make future changes easier
 Array: TypeAlias = np.ndarray[tuple[int, ...], np.dtype[np.float64]]

--- a/src/stanshock/system/base.py
+++ b/src/stanshock/system/base.py
@@ -39,9 +39,9 @@ class RightHandSide:
     jac: Callable[[float, Array, Array | None, Array | None], Array] | None = None
 
     # Index into (2D) global state array to be accessed by this source term
-    idx_domain: Index
+    idx_input: Index
     # Index into (2D) local state array of cells to which the source term applies
-    idx_update: Index
+    idx_output: Index
     # Index into (2D) local state array of transport equations to update
     idx_source: Index
 
@@ -64,29 +64,29 @@ class RightHandSide:
         n_vars = self.physics.n_scalars + 2 if self.physics is not None else 1
 
         # Default to updating everything
-        self.idx_domain = np.s_[:]
-        self.idx_update = np.s_[:]
+        self.idx_input = np.s_[:]
+        self.idx_output = np.s_[:]
         self.idx_source = np.s_[:]
 
         if self.geometry is not None:
             if self.face_extrapolator is not None:
                 # Generally we want to include ghost layers when using face extrapolation
                 n_cells_input = self.geometry.n_cells
-                self.idx_domain = np.s_[:]
-                self.idx_update = self.geometry.idx_cells
+                self.idx_input = np.s_[:]
+                self.idx_output = self.geometry.idx_cells
             else:
                 # Otherwise we can drop the ghost cells
                 n_cells_input = self.geometry.n_cells_interior
-                self.idx_domain = self.geometry.idx_cells
-                self.idx_update = np.s_[:]
+                self.idx_input = self.geometry.idx_cells
+                self.idx_output = np.s_[:]
 
             # Don't update the ghost cells either way
             n_cells_output = self.geometry.n_cells_interior
 
         # How to reshape the state_array subsets
         self.shape_full: tuple[int, int] = (-1, n_vars)
-        self.shape_domain: tuple[int, int] = (n_cells_input, n_vars)
-        self.shape_update: tuple[int, int] = (n_cells_output, n_vars)
+        self.shape_input: tuple[int, int] = (n_cells_input, n_vars)
+        self.shape_output: tuple[int, int] = (n_cells_output, n_vars)
 
         # Ensure required routines were provided
         for step in self.REQUIRED_PRECOMPUTE_STEPS:
@@ -110,14 +110,14 @@ class RightHandSide:
         May include optional forward transforms.
         """
         _ = time
-        state_array_local = np.reshape(state_array, self.shape_full)[self.idx_domain]
+        state_array_local = np.reshape(state_array, self.shape_full)[self.idx_input]
 
         gamma_star_local: Array | None = None
         e0_star_local: Array | None = None
         if gamma_star is not None:
-            gamma_star_local = gamma_star[self.idx_domain]
+            gamma_star_local = gamma_star[self.idx_input]
         if e0_star is not None:
-            e0_star_local = e0_star[self.idx_domain]
+            e0_star_local = e0_star[self.idx_input]
 
         return np.ravel(state_array_local), gamma_star_local, e0_star_local
 
@@ -135,7 +135,7 @@ class RightHandSide:
 
         Can also apply any necessary inverse transforms.
         """
-        state_array_local = state_array_local.reshape(self.shape_domain)
+        state_array_local = state_array_local.reshape(self.shape_input)
 
         state = None
         if self.physics is not None:
@@ -151,14 +151,14 @@ class RightHandSide:
                     self.physics.get_double_flux_variables(state)
                 )
 
-                gamma_star[self.idx_domain] = gamma_star_local
+                gamma_star[self.idx_input] = gamma_star_local
                 assert e0_star is not None
-                e0_star[self.idx_domain] = e0_star_local
+                e0_star[self.idx_input] = e0_star_local
 
         state_array = np.reshape(state_array, self.shape_full)
-        state_array[self.idx_domain] = state_array_local
+        state_array[self.idx_input] = state_array_local
 
-        # Update the domain indices for next time step
+        # Update the input indices for next time step
         self.update_indices(time, state)
 
         return np.ravel(state_array), gamma_star, e0_star
@@ -177,7 +177,7 @@ class RightHandSide:
         FluidState | None,
     ]:
         """Perform all calculations which must occur prior to source term evaluation."""
-        state_array_local = np.reshape(state_array_local, self.shape_domain)
+        state_array_local = np.reshape(state_array_local, self.shape_input)
 
         if self.boundary_conditions is not None:
             state_array_local = self.boundary_conditions.update_ghost_layers(
@@ -234,9 +234,9 @@ class RightHandSide:
 
     def add_source(self, y: Array, dy: Array) -> Array:
         """Add (2D) source term to the (1D) state array."""
-        dy = np.reshape(dy, self.shape_update)
-        state_array_local = np.reshape(y, self.shape_domain)
-        state_array_local[self.idx_update, self.idx_source] += dy
+        dy = np.reshape(dy, self.shape_output)
+        state_array_local = np.reshape(y, self.shape_input)
+        state_array_local[self.idx_output, self.idx_source] += dy
         return np.ravel(state_array_local)
 
     def source_full(
@@ -273,9 +273,9 @@ class FastSlowSource(RightHandSide):
     _mode: FastSlowMode
 
     # By default, all locations and sources are set to slow:
-    idx_update_implicit: Index = np.array([], dtype=np.int64)
+    idx_output_implicit: Index = np.array([], dtype=np.int64)
     idx_source_implicit: Index = np.s_[:]
-    idx_update_explicit: Index = np.s_[:]
+    idx_output_explicit: Index = np.s_[:]
     idx_source_explicit: Index = np.s_[:]
 
     def __init__(
@@ -293,11 +293,11 @@ class FastSlowSource(RightHandSide):
     def mode(self, mode: FastSlowMode) -> None:
         self._mode = mode
         if mode == "fast":
-            self.idx_update = self.idx_update_implicit
+            self.idx_output = self.idx_output_implicit
             self.idx_source = self.idx_source_implicit
             self.source_implementation = self.source_fast
         elif mode == "slow":
-            self.idx_update = self.idx_update_explicit
+            self.idx_output = self.idx_output_explicit
             self.idx_source = self.idx_source_explicit
             self.source_implementation = self.source_slow
 
@@ -350,8 +350,8 @@ class CombinedSource(RightHandSide):
 
         # Don't modify the shapes, as the sources will handle that internally
         self.shape_full = max(source.shape_full for source in self.sources)
-        self.shape_domain = self.shape_update = self.shape_full
-        self.idx_domain = self.idx_update = np.s_[:]
+        self.shape_input = self.shape_output = self.shape_full
+        self.idx_input = self.idx_output = np.s_[:]
 
     def source(
         self,

--- a/src/stanshock/system/base.py
+++ b/src/stanshock/system/base.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import numpy as np
+
 from stanshock.physics.fluid_base import FluidPhysics, FluidState
 from stanshock.system.backend import Array
 
 
 class RightHandSide:
+    idx_domain = np.s_[:]
+    idx_source = np.s_[:]
+
     def source(
         self,
         time: float,
@@ -26,3 +31,29 @@ class RightHandSide:
         assert state.e0_star is not None
         state_array = physics.primitive_to_conservative(state)
         return self.source(time, state_array, physics, state.gamma_star, state.e0_star)
+
+
+class CombinedSource(RightHandSide):
+    def __init__(self, sources: list[RightHandSide]) -> None:
+        self.sources = sources
+
+    def source(
+        self,
+        time: float,
+        state_array: Array,
+        physics: FluidPhysics,
+        gamma_star: Array | None = None,
+        e0_star: Array | None = None,
+    ) -> Array:
+        rhs = np.zeros_like(state_array)
+
+        for source in self.sources:
+            rhs[source.idx_domain, source.idx_source] += source.source(
+                time=time,
+                state_array=state_array,
+                physics=physics,
+                gamma_star=gamma_star,
+                e0_star=e0_star,
+            )
+
+        return rhs

--- a/src/stanshock/system/base.py
+++ b/src/stanshock/system/base.py
@@ -1,36 +1,138 @@
 from __future__ import annotations
 
+from abc import abstractmethod
+from typing import ClassVar, Literal, TypedDict
+
 import numpy as np
 
+from stanshock.numerics.boundary_conditions import BoundaryConditions
+from stanshock.numerics.face_average import FaceAverage
+from stanshock.numerics.face_extrapolation import FaceExtrapolator
+from stanshock.numerics.gradient import Gradient
 from stanshock.physics.fluid_base import FluidPhysics, FluidState
-from stanshock.system.backend import Array
+from stanshock.system.backend import Array, Index, NotRequired, TypeAlias, Unpack
+from stanshock.system.geometry import Geometry
+
+# Define the optional precomputation steps to be called before a given source term
+PrecomputeStepName: TypeAlias = Literal[
+    "geometry",
+    "physics",
+    "boundary_conditions",
+    "face_extrapolator",
+    "face_average",
+    "gradient",
+]
+
+
+class PrecomputeSteps(TypedDict):
+    geometry: Geometry
+    physics: NotRequired[FluidPhysics]
+    boundary_conditions: NotRequired[BoundaryConditions]
+    face_extrapolator: NotRequired[FaceExtrapolator]
+    face_average: NotRequired[FaceAverage]
+    gradient: NotRequired[Gradient]
 
 
 class RightHandSide:
-    idx_domain = np.s_[:]
-    idx_source = np.s_[:]
+    REQUIRED_PRECOMPUTE_STEPS: ClassVar[tuple[PrecomputeStepName, ...]] = ("geometry",)
+
+    def __init__(
+        self,
+        **precompute_steps: Unpack[PrecomputeSteps],
+    ) -> None:
+        # Any precompute steps not provided will default to None
+        self.geometry = precompute_steps.get("geometry")
+        self.physics = precompute_steps.get("physics")
+        self.boundary_conditions = precompute_steps.get("boundary_conditions")
+        self.face_extrapolator = precompute_steps.get("face_extrapolator")
+        self.face_average = precompute_steps.get("face_average")
+        self.gradient = precompute_steps.get("gradient")
+
+        self.idx_domain: Index = self.geometry.idx_cells
+        self.idx_source: Index = np.s_[:]
+
+        # Ensure required routines were provided
+        for step in self.REQUIRED_PRECOMPUTE_STEPS:
+            if getattr(self, step) is None:
+                msg: str = f"Must provide {step} for {self.__class__.__name__}."
+                raise ValueError(msg)
+
+    def precompute(
+        self,
+        time: float,
+        state_array: Array,
+        gamma_star: Array | None = None,
+        e0_star: Array | None = None,
+    ) -> tuple[
+        Array,
+        FluidState | None,
+        FluidState | None,
+        FluidState | None,
+        FluidState | None,
+    ]:
+        """Perform all calculations which must occur prior to source term evaluation."""
+        if self.boundary_conditions is not None:
+            state_array = self.boundary_conditions.update_ghost_layers(
+                time, state_array
+            )
+
+        state: FluidState | None = None
+        if self.physics is not None:
+            state = self.physics.conservative_to_primitive(
+                state_array, gamma_star, e0_star
+            )
+            if self.boundary_conditions is not None:
+                state = self.boundary_conditions.update_ghost_states(time, state)
+
+        face_states: FluidState | None = None
+        avg_face_states: FluidState | None = None
+        if self.face_extrapolator is not None:
+            assert state is not None
+            face_states = self.face_extrapolator(state)
+            if self.boundary_conditions is not None:
+                face_states = self.boundary_conditions.update_face_states(
+                    time, face_states
+                )
+
+            if self.face_average is not None:
+                avg_face_states = self.face_average(face_states)
+
+        face_gradients: FluidState | None = None
+        if self.gradient is not None:
+            assert self.physics is not None
+            assert state is not None
+            state.temperature = self.physics.get_temperature(state)
+            face_gradients = self.gradient.face_gradients(state, self.geometry)
+
+        return state_array, state, face_states, avg_face_states, face_gradients
 
     def source(
         self,
         time: float,
         state_array: Array,
-        physics: FluidPhysics,
         gamma_star: Array | None = None,
         e0_star: Array | None = None,
     ) -> Array:
         """Compute the temporal gradient of the current state of the system."""
-        state = physics.conservative_to_primitive(state_array, gamma_star, e0_star)
-        state.gamma_star = gamma_star
-        state.e0_star = e0_star
-        return self.source_from_primitives(time, state, physics)
+        state_array, state, face_states, avg_face_states, face_gradients = (
+            self.precompute(time, state_array, gamma_star, e0_star)
+        )
 
-    def source_from_primitives(
-        self, time: float, state: FluidState, physics: FluidPhysics
+        return self.source_implementation(
+            time, state_array, state, face_states, avg_face_states, face_gradients
+        )
+
+    @abstractmethod
+    def source_implementation(
+        self,
+        time: float,
+        state_array: Array | None,
+        state: FluidState | None,
+        face_states: FluidState | None,
+        avg_face_states: FluidState | None,
+        face_gradients: FluidState | None,
     ) -> Array:
-        assert state.gamma_star is not None
-        assert state.e0_star is not None
-        state_array = physics.primitive_to_conservative(state)
-        return self.source(time, state_array, physics, state.gamma_star, state.e0_star)
+        """Concrete implementation of the source term calculation."""
 
 
 class CombinedSource(RightHandSide):
@@ -41,7 +143,6 @@ class CombinedSource(RightHandSide):
         self,
         time: float,
         state_array: Array,
-        physics: FluidPhysics,
         gamma_star: Array | None = None,
         e0_star: Array | None = None,
     ) -> Array:
@@ -51,7 +152,6 @@ class CombinedSource(RightHandSide):
             rhs[source.idx_domain, source.idx_source] += source.source(
                 time=time,
                 state_array=state_array,
-                physics=physics,
                 gamma_star=gamma_star,
                 e0_star=e0_star,
             )

--- a/src/stanshock/system/base.py
+++ b/src/stanshock/system/base.py
@@ -163,13 +163,6 @@ class RightHandSide:
 
         return np.ravel(state_array), gamma_star, e0_star
 
-    def add_source(self, y: Array, dy: Array) -> Array:
-        """Add (2D) source term to the (1D) state array."""
-        dy = np.reshape(dy, self.shape_update)
-        state_array_local = np.reshape(y, self.shape_domain)
-        state_array_local[self.idx_update, self.idx_source] += dy
-        return np.ravel(state_array_local)
-
     def precompute_for_source(
         self,
         time: float,
@@ -239,6 +232,13 @@ class RightHandSide:
             time, state_array_local, state, face_states, avg_face_states, face_gradients
         )
 
+    def add_source(self, y: Array, dy: Array) -> Array:
+        """Add (2D) source term to the (1D) state array."""
+        dy = np.reshape(dy, self.shape_update)
+        state_array_local = np.reshape(y, self.shape_domain)
+        state_array_local[self.idx_update, self.idx_source] += dy
+        return np.ravel(state_array_local)
+
     def source_full(
         self,
         time: float,
@@ -278,10 +278,12 @@ class FastSlowSource(RightHandSide):
     idx_update_explicit: Index = np.s_[:]
     idx_source_explicit: Index = np.s_[:]
 
-    def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
+    def __init__(
+        self, mode: FastSlowMode = "slow", **precompute_steps: Unpack[PrecomputeSteps]
+    ) -> None:
         """Split RHS into fast and slow source terms accessed by setting the mode."""
         super().__init__(**precompute_steps)
-        self.mode = "slow"
+        self.mode = mode
 
     @property
     def mode(self) -> FastSlowMode:

--- a/src/stanshock/system/base.py
+++ b/src/stanshock/system/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from collections.abc import Callable
 from typing import Literal, TypedDict
 
 import numpy as np
@@ -26,7 +27,7 @@ PrecomputeStepName: TypeAlias = Literal[
 
 class PrecomputeSteps(TypedDict):
     geometry: Geometry
-    physics: NotRequired[FluidPhysics]
+    physics: FluidPhysics
     boundary_conditions: NotRequired[BoundaryConditions]
     face_extrapolator: NotRequired[FaceExtrapolator]
     face_average: NotRequired[FaceAverage]
@@ -34,23 +35,44 @@ class PrecomputeSteps(TypedDict):
 
 
 class RightHandSide:
-    REQUIRED_PRECOMPUTE_STEPS: tuple[PrecomputeStepName, ...] = ("geometry",)
+    REQUIRED_PRECOMPUTE_STEPS: tuple[PrecomputeStepName, ...] = ("geometry", "physics")
+    jac: Callable[[float, Array, Array | None, Array | None], Array] | None = None
 
     def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
         # Any precompute steps not provided will default to None
-        self.geometry = precompute_steps.get("geometry")
-        self.physics = precompute_steps.get("physics")
+        self.geometry: Geometry = precompute_steps.get("geometry")
+        self.physics: FluidPhysics = precompute_steps.get("physics")
         self.boundary_conditions = precompute_steps.get("boundary_conditions")
         self.face_extrapolator = precompute_steps.get("face_extrapolator")
         self.face_average = precompute_steps.get("face_average")
         self.gradient = precompute_steps.get("gradient")
 
-        # Index into (1D) global state array to be accessed by this source term
-        self.idx_domain: Index = np.s_[:]
-        # Index of cells to which the source term applies
-        self.idx_update: Index = self.geometry.idx_cells
-        # Index of transport equations to update
-        self.idx_source: Index = np.s_[:]
+        n_vars = self.physics.n_scalars + 2
+
+        # How to reshape the state_array subsets
+        self.shape_full: tuple[int, int] = (-1, n_vars)
+        self.shape_domain: tuple[int, int] = (self.geometry.n_cells, n_vars)
+        self.shape_update: tuple[int, int] = (self.geometry.n_cells_interior, n_vars)
+
+        self.idx_domain: Index  # Index into (2D) global state array to be accessed by this source term
+        self.idx_update: Index  # Index into (2D) local state array of cells to which the source term applies
+        self.idx_source: (
+            Index  # Index into (2D) local state array of transport equations to update
+        )
+
+        if self.face_extrapolator is not None:
+            # Generally we want to include ghost layers when using face extrapolation
+            self.idx_domain = np.s_[:]
+            # And only update the interior cells
+            self.idx_update = self.geometry.idx_cells
+        else:
+            # Otherwise we can drop the ghost cells
+            self.idx_domain = self.geometry.idx_cells
+            self.shape_domain = (self.geometry.n_cells_interior, n_vars)
+            self.idx_update = np.s_[:]
+
+        # Default to updating all source terms
+        self.idx_source = np.s_[:]
 
         # Ensure required routines were provided
         for step in self.REQUIRED_PRECOMPUTE_STEPS:
@@ -58,54 +80,76 @@ class RightHandSide:
                 msg: str = f"Must provide {step} for {self.__class__.__name__}."
                 raise ValueError(msg)
 
-        if self.physics is not None:
-            self.shape: tuple[int, int] = (
-                self.geometry.n_cells,
-                self.physics.n_scalars + 2,
-            )
-        else:
-            self.shape = (self.geometry.n_cells, -1)
-
-    def update_indices(self, time: float) -> None:
-        """Hook to update time-varying idx_update indices."""
-        _ = time
+    def update_indices(self, time: float, state: FluidState) -> None:
+        """Hook to update time-varying indices."""
+        _ = time, state
 
     def before_time_integration(
         self,
         time: float,
         state_array: Array,
-        update_double_flux: bool = True,
+        gamma_star: Array | None,
+        e0_star: Array | None,
     ) -> tuple[Array, Array | None, Array | None]:
         """Extract the state_array to be operated on.
 
         May include optional forward transforms.
         """
-        self.update_indices(time)
+        _ = time
+        state_array_local = np.reshape(state_array, self.shape_full)[self.idx_domain]
 
-        state_array_local: Array = state_array[self.idx_domain].reshape(self.shape)
-        gamma_star = None
-        e0_star = None
-        if update_double_flux:
-            assert self.physics is not None
-            state = self.physics.conservative_to_primitive(state_array_local)
-            gamma_star, e0_star = self.physics.get_double_flux_variables(state)
+        gamma_star_local: Array | None = None
+        e0_star_local: Array | None = None
+        if gamma_star is not None:
+            gamma_star_local = gamma_star[self.idx_domain]
+        if e0_star is not None:
+            e0_star_local = e0_star[self.idx_domain]
 
-        return state_array_local, gamma_star, e0_star
+        return np.ravel(state_array_local), gamma_star_local, e0_star_local
 
     def after_time_integration(
-        self, state_array: Array, state_array_local: Array
-    ) -> Array:
+        self,
+        time: float,
+        state_array_local: Array,
+        gamma_star_local: Array | None,
+        e0_star_local: Array | None,
+        state_array: Array,
+        gamma_star: Array | None,
+        e0_star: Array | None,
+    ) -> tuple[Array, Array | None, Array | None]:
         """Insert the result back into the original state_array.
 
         Can also apply any necessary inverse transforms.
         """
-        state_array[self.idx_domain] = np.ravel(state_array_local)
+        state_array_local = state_array_local.reshape(self.shape_domain)
+        state = self.physics.conservative_to_primitive(
+            state_array_local, gamma_star_local, e0_star_local
+        )
+        # Update total energy if using double-flux method
+        if gamma_star is not None:
+            state.temperature = self.physics.get_temperature(state)
+            state.internal_energy = None
+            state_array_local = self.physics.primitive_to_conservative(state)
+            gamma_star_local, e0_star_local = self.physics.get_double_flux_variables(
+                state
+            )
 
-        return state_array
+            gamma_star[self.idx_domain] = gamma_star_local
+            assert e0_star is not None
+            e0_star[self.idx_domain] = e0_star_local
+
+        state_array = np.reshape(state_array, self.shape_full)
+        state_array[self.idx_domain] = state_array_local
+
+        # Update the domain indices for next time step
+        self.update_indices(time, state)
+
+        return np.ravel(state_array), gamma_star, e0_star
 
     def add_source(self, y: Array, dy: Array) -> Array:
         """Add (2D) source term to the (1D) state array."""
-        state_array_local = y.reshape(self.shape)
+        dy = np.reshape(dy, self.shape_update)
+        state_array_local = np.reshape(y, self.shape_domain)
         state_array_local[self.idx_update, self.idx_source] += dy
         return np.ravel(state_array_local)
 
@@ -124,7 +168,7 @@ class RightHandSide:
     ]:
         """Perform all calculations which must occur prior to source term evaluation."""
         assert self.physics is not None
-        state_array_local = state_array_local.reshape(self.shape)
+        state_array_local = state_array_local.reshape(self.shape_domain)
 
         if self.boundary_conditions is not None:
             state_array_local = self.boundary_conditions.update_ghost_layers(
@@ -143,6 +187,7 @@ class RightHandSide:
         avg_face_states: FluidState | None = None
         if self.face_extrapolator is not None:
             assert state is not None
+            state.gamma_star, state.e0_star = gamma_star, e0_star
             face_states = self.face_extrapolator(state)
             if self.boundary_conditions is not None:
                 face_states = self.boundary_conditions.update_face_states(
@@ -199,11 +244,6 @@ class RightHandSide:
     ) -> Array:
         """Concrete implementation of the source term calculation."""
 
-    def postcompute(self, state_array_local: Array, state: FluidState) -> Array:
-        """Undo any transforms to the state array during precompute steps."""
-        _ = state
-        return np.ravel(state_array_local)
-
 
 FastSlowMode: TypeAlias = Literal["fast", "slow"]
 
@@ -217,8 +257,8 @@ class FastSlowSource(RightHandSide):
         """Split RHS into fast and slow source terms accessed by setting the mode."""
         super().__init__(**precompute_steps)
         self.idx_implicit = np.array([], dtype=np.int64)
-        self.idx_explicit = self.geometry.idx_cells
-        self._mode = "slow"
+        self.idx_explicit = np.s_[:]
+        self.mode = "slow"
 
     @property
     def mode(self) -> FastSlowMode:

--- a/src/stanshock/system/base.py
+++ b/src/stanshock/system/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import ClassVar, Literal, TypedDict
+from typing import Literal, TypedDict
 
 import numpy as np
 
@@ -34,7 +34,7 @@ class PrecomputeSteps(TypedDict):
 
 
 class RightHandSide:
-    REQUIRED_PRECOMPUTE_STEPS: ClassVar[tuple[PrecomputeStepName, ...]] = ("geometry",)
+    REQUIRED_PRECOMPUTE_STEPS: tuple[PrecomputeStepName, ...] = ("geometry",)
 
     def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
         # Any precompute steps not provided will default to None
@@ -45,7 +45,11 @@ class RightHandSide:
         self.face_average = precompute_steps.get("face_average")
         self.gradient = precompute_steps.get("gradient")
 
-        self.idx_domain: Index = self.geometry.idx_cells
+        # Index into (1D) global state array to be accessed by this source term
+        self.idx_domain: Index = np.s_[:]
+        # Index of cells to which the source term applies
+        self.idx_update: Index = self.geometry.idx_cells
+        # Index of transport equations to update
         self.idx_source: Index = np.s_[:]
 
         # Ensure required routines were provided
@@ -63,19 +67,52 @@ class RightHandSide:
             self.shape = (self.geometry.n_cells, -1)
 
     def update_indices(self, time: float) -> None:
-        """Hook to update time-varying domain indices."""
+        """Hook to update time-varying idx_update indices."""
         _ = time
 
-    def add_source(self, y: Array, dy: Array) -> Array:
-        """Add (2D) source term to the (1D) state array."""
-        state_array = y.reshape(self.shape)
-        state_array[self.idx_domain, self.idx_source] += dy
-        return np.ravel(state_array)
-
-    def precompute(
+    def before_time_integration(
         self,
         time: float,
         state_array: Array,
+        update_double_flux: bool = True,
+    ) -> tuple[Array, Array | None, Array | None]:
+        """Extract the state_array to be operated on.
+
+        May include optional forward transforms.
+        """
+        self.update_indices(time)
+
+        state_array_local: Array = state_array[self.idx_domain].reshape(self.shape)
+        gamma_star = None
+        e0_star = None
+        if update_double_flux:
+            assert self.physics is not None
+            state = self.physics.conservative_to_primitive(state_array_local)
+            gamma_star, e0_star = self.physics.get_double_flux_variables(state)
+
+        return state_array_local, gamma_star, e0_star
+
+    def after_time_integration(
+        self, state_array: Array, state_array_local: Array
+    ) -> Array:
+        """Insert the result back into the original state_array.
+
+        Can also apply any necessary inverse transforms.
+        """
+        state_array[self.idx_domain] = np.ravel(state_array_local)
+
+        return state_array
+
+    def add_source(self, y: Array, dy: Array) -> Array:
+        """Add (2D) source term to the (1D) state array."""
+        state_array_local = y.reshape(self.shape)
+        state_array_local[self.idx_update, self.idx_source] += dy
+        return np.ravel(state_array_local)
+
+    def precompute_for_source(
+        self,
+        time: float,
+        state_array_local: Array,
         gamma_star: Array | None = None,
         e0_star: Array | None = None,
     ) -> tuple[
@@ -87,17 +124,17 @@ class RightHandSide:
     ]:
         """Perform all calculations which must occur prior to source term evaluation."""
         assert self.physics is not None
-        state_array = state_array.reshape(self.shape)
+        state_array_local = state_array_local.reshape(self.shape)
 
         if self.boundary_conditions is not None:
-            state_array = self.boundary_conditions.update_ghost_layers(
-                time, state_array
+            state_array_local = self.boundary_conditions.update_ghost_layers(
+                time, state_array_local
             )
 
         state: FluidState | None = None
         if self.physics is not None:
             state = self.physics.conservative_to_primitive(
-                state_array, gamma_star, e0_star
+                state_array_local, gamma_star, e0_star
             )
             if self.boundary_conditions is not None:
                 state = self.boundary_conditions.update_ghost_states(time, state)
@@ -122,39 +159,39 @@ class RightHandSide:
             state.temperature = self.physics.get_temperature(state)
             face_gradients = self.gradient.face_gradients(state, self.geometry)
 
-        return state_array, state, face_states, avg_face_states, face_gradients
+        return state_array_local, state, face_states, avg_face_states, face_gradients
 
     def source(
         self,
         time: float,
-        state_array: Array,
+        state_array_local: Array,
         gamma_star: Array | None = None,
         e0_star: Array | None = None,
     ) -> Array:
         """Compute the temporal gradient of the current state of the system."""
-        state_array, state, face_states, avg_face_states, face_gradients = (
-            self.precompute(time, state_array, gamma_star, e0_star)
+        state_array_local, state, face_states, avg_face_states, face_gradients = (
+            self.precompute_for_source(time, state_array_local, gamma_star, e0_star)
         )
 
         return self.source_implementation(
-            time, state_array, state, face_states, avg_face_states, face_gradients
+            time, state_array_local, state, face_states, avg_face_states, face_gradients
         )
 
     def source_full(
-        self, time: float, state_array: Array, gamma_star: Array, e0_star: Array
+        self, time: float, state_array_local: Array, gamma_star: Array, e0_star: Array
     ) -> Array:
         """Reshape the source term to match the state array."""
-        dydt = np.zeros_like(state_array)
+        dydt = np.zeros_like(state_array_local)
 
         return self.add_source(
-            dydt, self.source(time, state_array, gamma_star, e0_star)
+            dydt, self.source(time, state_array_local, gamma_star, e0_star)
         )
 
     @abstractmethod
     def source_implementation(
         self,
         time: float,
-        state_array: Array | None,
+        state_array_local: Array | None,
         state: FluidState | None,
         face_states: FluidState | None,
         avg_face_states: FluidState | None,
@@ -162,10 +199,10 @@ class RightHandSide:
     ) -> Array:
         """Concrete implementation of the source term calculation."""
 
-    def postcompute(self, state_array: Array, state: FluidState) -> Array:
+    def postcompute(self, state_array_local: Array, state: FluidState) -> Array:
         """Undo any transforms to the state array during precompute steps."""
         _ = state
-        return np.ravel(state_array)
+        return np.ravel(state_array_local)
 
 
 FastSlowMode: TypeAlias = Literal["fast", "slow"]
@@ -191,17 +228,17 @@ class FastSlowSource(RightHandSide):
     def mode(self, mode: FastSlowMode) -> None:
         self._mode = mode
         if mode == "fast":
-            self.idx_domain = self.idx_implicit
+            self.idx_update = self.idx_implicit
             self.source_implementation = self.source_fast
         elif mode == "slow":
-            self.idx_domain = self.idx_explicit
+            self.idx_update = self.idx_explicit
             self.source_implementation = self.source_slow
 
     @abstractmethod
     def source_slow(
         self,
         time: float,
-        state_array: Array | None,
+        state_array_local: Array | None,
         state: FluidState | None,
         face_states: FluidState | None,
         avg_face_states: FluidState | None,
@@ -213,7 +250,7 @@ class FastSlowSource(RightHandSide):
     def source_fast(
         self,
         time: float,
-        state_array: Array | None,
+        state_array_local: Array | None,
         state: FluidState | None,
         face_states: FluidState | None,
         avg_face_states: FluidState | None,
@@ -235,20 +272,20 @@ class CombinedSource(RightHandSide):
     def source(
         self,
         time: float,
-        state_array: Array,
+        state_array_local: Array,
         gamma_star: Array | None = None,
         e0_star: Array | None = None,
     ) -> Array:
-        rhs: Array = np.zeros_like(state_array)
+        rhs: Array = np.zeros_like(state_array_local)
 
-        state_array, state, face_states, avg_face_states, face_gradients = (
-            self.precompute(time, state_array, gamma_star, e0_star)
+        state_array_local, state, face_states, avg_face_states, face_gradients = (
+            self.precompute_for_source(time, state_array_local, gamma_star, e0_star)
         )
 
         for source in self.sources:
             dydt = source.source_implementation(
                 time=time,
-                state_array=state_array,
+                state_array_local=state_array_local,
                 state=state,
                 face_states=face_states,
                 avg_face_states=avg_face_states,

--- a/src/stanshock/system/base.py
+++ b/src/stanshock/system/base.py
@@ -36,10 +36,7 @@ class PrecomputeSteps(TypedDict):
 class RightHandSide:
     REQUIRED_PRECOMPUTE_STEPS: ClassVar[tuple[PrecomputeStepName, ...]] = ("geometry",)
 
-    def __init__(
-        self,
-        **precompute_steps: Unpack[PrecomputeSteps],
-    ) -> None:
+    def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
         # Any precompute steps not provided will default to None
         self.geometry = precompute_steps.get("geometry")
         self.physics = precompute_steps.get("physics")
@@ -57,6 +54,24 @@ class RightHandSide:
                 msg: str = f"Must provide {step} for {self.__class__.__name__}."
                 raise ValueError(msg)
 
+        if self.physics is not None:
+            self.shape: tuple[int, int] = (
+                self.geometry.n_cells,
+                self.physics.n_scalars + 2,
+            )
+        else:
+            self.shape = (self.geometry.n_cells, -1)
+
+    def update_indices(self, time: float) -> None:
+        """Hook to update time-varying domain indices."""
+        _ = time
+
+    def add_source(self, y: Array, dy: Array) -> Array:
+        """Add (2D) source term to the (1D) state array."""
+        state_array = y.reshape(self.shape)
+        state_array[self.idx_domain, self.idx_source] += dy
+        return np.ravel(state_array)
+
     def precompute(
         self,
         time: float,
@@ -71,6 +86,9 @@ class RightHandSide:
         FluidState | None,
     ]:
         """Perform all calculations which must occur prior to source term evaluation."""
+        assert self.physics is not None
+        state_array = state_array.reshape(self.shape)
+
         if self.boundary_conditions is not None:
             state_array = self.boundary_conditions.update_ghost_layers(
                 time, state_array
@@ -122,6 +140,16 @@ class RightHandSide:
             time, state_array, state, face_states, avg_face_states, face_gradients
         )
 
+    def source_full(
+        self, time: float, state_array: Array, gamma_star: Array, e0_star: Array
+    ) -> Array:
+        """Reshape the source term to match the state array."""
+        dydt = np.zeros_like(state_array)
+
+        return self.add_source(
+            dydt, self.source(time, state_array, gamma_star, e0_star)
+        )
+
     @abstractmethod
     def source_implementation(
         self,
@@ -134,10 +162,75 @@ class RightHandSide:
     ) -> Array:
         """Concrete implementation of the source term calculation."""
 
+    def postcompute(self, state_array: Array, state: FluidState) -> Array:
+        """Undo any transforms to the state array during precompute steps."""
+        _ = state
+        return np.ravel(state_array)
+
+
+FastSlowMode: TypeAlias = Literal["fast", "slow"]
+
+
+class FastSlowSource(RightHandSide):
+    _mode: FastSlowMode
+    idx_implicit: Index
+    idx_explicit: Index
+
+    def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
+        """Split RHS into fast and slow source terms accessed by setting the mode."""
+        super().__init__(**precompute_steps)
+        self.idx_implicit = np.array([], dtype=np.int64)
+        self.idx_explicit = self.geometry.idx_cells
+        self._mode = "slow"
+
+    @property
+    def mode(self) -> FastSlowMode:
+        return self._mode
+
+    @mode.setter
+    def mode(self, mode: FastSlowMode) -> None:
+        self._mode = mode
+        if mode == "fast":
+            self.idx_domain = self.idx_implicit
+            self.source_implementation = self.source_fast
+        elif mode == "slow":
+            self.idx_domain = self.idx_explicit
+            self.source_implementation = self.source_slow
+
+    @abstractmethod
+    def source_slow(
+        self,
+        time: float,
+        state_array: Array | None,
+        state: FluidState | None,
+        face_states: FluidState | None,
+        avg_face_states: FluidState | None,
+        face_gradients: FluidState | None,
+    ) -> Array:
+        """Slow source terms to be integrated explicitly."""
+
+    @abstractmethod
+    def source_fast(
+        self,
+        time: float,
+        state_array: Array | None,
+        state: FluidState | None,
+        face_states: FluidState | None,
+        avg_face_states: FluidState | None,
+        face_gradients: FluidState | None,
+    ) -> Array:
+        """Fast source terms to be integrated implicitly."""
+
 
 class CombinedSource(RightHandSide):
     def __init__(self, sources: list[RightHandSide]) -> None:
         self.sources = sources
+
+        # Dynamically determine the set of unique precompute steps required
+        required_steps: set[PrecomputeStepName] = {
+            x for source in self.sources for x in source.REQUIRED_PRECOMPUTE_STEPS
+        }
+        self.REQUIRED_PRECOMPUTE_STEPS = tuple(required_steps)
 
     def source(
         self,
@@ -146,14 +239,21 @@ class CombinedSource(RightHandSide):
         gamma_star: Array | None = None,
         e0_star: Array | None = None,
     ) -> Array:
-        rhs = np.zeros_like(state_array)
+        rhs: Array = np.zeros_like(state_array)
+
+        state_array, state, face_states, avg_face_states, face_gradients = (
+            self.precompute(time, state_array, gamma_star, e0_star)
+        )
 
         for source in self.sources:
-            rhs[source.idx_domain, source.idx_source] += source.source(
+            dydt = source.source_implementation(
                 time=time,
                 state_array=state_array,
-                gamma_star=gamma_star,
-                e0_star=e0_star,
+                state=state,
+                face_states=face_states,
+                avg_face_states=avg_face_states,
+                face_gradients=face_gradients,
             )
+            rhs = source.add_source(rhs, dydt)
 
         return rhs

--- a/src/stanshock/system/base.py
+++ b/src/stanshock/system/base.py
@@ -11,7 +11,7 @@ from stanshock.numerics.face_average import FaceAverage
 from stanshock.numerics.face_extrapolation import FaceExtrapolator
 from stanshock.numerics.gradient import Gradient
 from stanshock.physics.fluid_base import FluidPhysics, FluidState
-from stanshock.system.backend import Array, Index, NotRequired, TypeAlias, Unpack
+from stanshock.system.backend import Array, Index, TypeAlias, Unpack
 from stanshock.system.geometry import Geometry
 
 # Define the optional precomputation steps to be called before a given source term
@@ -25,54 +25,68 @@ PrecomputeStepName: TypeAlias = Literal[
 ]
 
 
-class PrecomputeSteps(TypedDict):
+class PrecomputeSteps(TypedDict, total=False):
     geometry: Geometry
     physics: FluidPhysics
-    boundary_conditions: NotRequired[BoundaryConditions]
-    face_extrapolator: NotRequired[FaceExtrapolator]
-    face_average: NotRequired[FaceAverage]
-    gradient: NotRequired[Gradient]
+    boundary_conditions: BoundaryConditions
+    face_extrapolator: FaceExtrapolator
+    face_average: FaceAverage
+    gradient: Gradient
 
 
 class RightHandSide:
     REQUIRED_PRECOMPUTE_STEPS: tuple[PrecomputeStepName, ...] = ("geometry", "physics")
     jac: Callable[[float, Array, Array | None, Array | None], Array] | None = None
 
+    # Index into (2D) global state array to be accessed by this source term
+    idx_domain: Index
+    # Index into (2D) local state array of cells to which the source term applies
+    idx_update: Index
+    # Index into (2D) local state array of transport equations to update
+    idx_source: Index
+
     def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
         # Any precompute steps not provided will default to None
-        self.geometry: Geometry = precompute_steps.get("geometry")
-        self.physics: FluidPhysics = precompute_steps.get("physics")
-        self.boundary_conditions = precompute_steps.get("boundary_conditions")
-        self.face_extrapolator = precompute_steps.get("face_extrapolator")
-        self.face_average = precompute_steps.get("face_average")
-        self.gradient = precompute_steps.get("gradient")
+        self.geometry: Geometry | None = precompute_steps.get("geometry")
+        self.physics: FluidPhysics | None = precompute_steps.get("physics")
+        self.boundary_conditions: BoundaryConditions | None = precompute_steps.get(
+            "boundary_conditions"
+        )
+        self.face_extrapolator: FaceExtrapolator | None = precompute_steps.get(
+            "face_extrapolator"
+        )
+        self.face_average: FaceAverage | None = precompute_steps.get("face_average")
+        self.gradient: Gradient | None = precompute_steps.get("gradient")
 
-        n_vars = self.physics.n_scalars + 2
+        # Default sizes and shapes
+        n_cells_input: int = -1
+        n_cells_output: int = -1
+        n_vars = self.physics.n_scalars + 2 if self.physics is not None else 1
+
+        # Default to updating everything
+        self.idx_domain = np.s_[:]
+        self.idx_update = np.s_[:]
+        self.idx_source = np.s_[:]
+
+        if self.geometry is not None:
+            if self.face_extrapolator is not None:
+                # Generally we want to include ghost layers when using face extrapolation
+                n_cells_input = self.geometry.n_cells
+                self.idx_domain = np.s_[:]
+                self.idx_update = self.geometry.idx_cells
+            else:
+                # Otherwise we can drop the ghost cells
+                n_cells_input = self.geometry.n_cells_interior
+                self.idx_domain = self.geometry.idx_cells
+                self.idx_update = np.s_[:]
+
+            # Don't update the ghost cells either way
+            n_cells_output = self.geometry.n_cells_interior
 
         # How to reshape the state_array subsets
         self.shape_full: tuple[int, int] = (-1, n_vars)
-        self.shape_domain: tuple[int, int] = (self.geometry.n_cells, n_vars)
-        self.shape_update: tuple[int, int] = (self.geometry.n_cells_interior, n_vars)
-
-        self.idx_domain: Index  # Index into (2D) global state array to be accessed by this source term
-        self.idx_update: Index  # Index into (2D) local state array of cells to which the source term applies
-        self.idx_source: (
-            Index  # Index into (2D) local state array of transport equations to update
-        )
-
-        if self.face_extrapolator is not None:
-            # Generally we want to include ghost layers when using face extrapolation
-            self.idx_domain = np.s_[:]
-            # And only update the interior cells
-            self.idx_update = self.geometry.idx_cells
-        else:
-            # Otherwise we can drop the ghost cells
-            self.idx_domain = self.geometry.idx_cells
-            self.shape_domain = (self.geometry.n_cells_interior, n_vars)
-            self.idx_update = np.s_[:]
-
-        # Default to updating all source terms
-        self.idx_source = np.s_[:]
+        self.shape_domain: tuple[int, int] = (n_cells_input, n_vars)
+        self.shape_update: tuple[int, int] = (n_cells_output, n_vars)
 
         # Ensure required routines were provided
         for step in self.REQUIRED_PRECOMPUTE_STEPS:
@@ -80,7 +94,7 @@ class RightHandSide:
                 msg: str = f"Must provide {step} for {self.__class__.__name__}."
                 raise ValueError(msg)
 
-    def update_indices(self, time: float, state: FluidState) -> None:
+    def update_indices(self, time: float, state: FluidState | None) -> None:
         """Hook to update time-varying indices."""
         _ = time, state
 
@@ -122,21 +136,24 @@ class RightHandSide:
         Can also apply any necessary inverse transforms.
         """
         state_array_local = state_array_local.reshape(self.shape_domain)
-        state = self.physics.conservative_to_primitive(
-            state_array_local, gamma_star_local, e0_star_local
-        )
-        # Update total energy if using double-flux method
-        if gamma_star is not None:
-            state.temperature = self.physics.get_temperature(state)
-            state.internal_energy = None
-            state_array_local = self.physics.primitive_to_conservative(state)
-            gamma_star_local, e0_star_local = self.physics.get_double_flux_variables(
-                state
-            )
 
-            gamma_star[self.idx_domain] = gamma_star_local
-            assert e0_star is not None
-            e0_star[self.idx_domain] = e0_star_local
+        state = None
+        if self.physics is not None:
+            state = self.physics.conservative_to_primitive(
+                state_array_local, gamma_star_local, e0_star_local
+            )
+            # Update total energy if using double-flux method
+            if gamma_star is not None:
+                state.temperature = self.physics.get_temperature(state)
+                state.internal_energy = None
+                state_array_local = self.physics.primitive_to_conservative(state)
+                gamma_star_local, e0_star_local = (
+                    self.physics.get_double_flux_variables(state)
+                )
+
+                gamma_star[self.idx_domain] = gamma_star_local
+                assert e0_star is not None
+                e0_star[self.idx_domain] = e0_star_local
 
         state_array = np.reshape(state_array, self.shape_full)
         state_array[self.idx_domain] = state_array_local
@@ -167,8 +184,7 @@ class RightHandSide:
         FluidState | None,
     ]:
         """Perform all calculations which must occur prior to source term evaluation."""
-        assert self.physics is not None
-        state_array_local = state_array_local.reshape(self.shape_domain)
+        state_array_local = np.reshape(state_array_local, self.shape_domain)
 
         if self.boundary_conditions is not None:
             state_array_local = self.boundary_conditions.update_ghost_layers(
@@ -199,6 +215,7 @@ class RightHandSide:
 
         face_gradients: FluidState | None = None
         if self.gradient is not None:
+            assert self.geometry is not None
             assert self.physics is not None
             assert state is not None
             state.temperature = self.physics.get_temperature(state)
@@ -254,14 +271,16 @@ FastSlowMode: TypeAlias = Literal["fast", "slow"]
 
 class FastSlowSource(RightHandSide):
     _mode: FastSlowMode
-    idx_implicit: Index
-    idx_explicit: Index
+
+    # By default, all locations and sources are set to slow:
+    idx_update_implicit: Index = np.array([], dtype=np.int64)
+    idx_source_implicit: Index = np.s_[:]
+    idx_update_explicit: Index = np.s_[:]
+    idx_source_explicit: Index = np.s_[:]
 
     def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
         """Split RHS into fast and slow source terms accessed by setting the mode."""
         super().__init__(**precompute_steps)
-        self.idx_implicit = np.array([], dtype=np.int64)
-        self.idx_explicit = np.s_[:]
         self.mode = "slow"
 
     @property
@@ -272,10 +291,12 @@ class FastSlowSource(RightHandSide):
     def mode(self, mode: FastSlowMode) -> None:
         self._mode = mode
         if mode == "fast":
-            self.idx_update = self.idx_implicit
+            self.idx_update = self.idx_update_implicit
+            self.idx_source = self.idx_source_implicit
             self.source_implementation = self.source_fast
         elif mode == "slow":
-            self.idx_update = self.idx_explicit
+            self.idx_update = self.idx_update_explicit
+            self.idx_source = self.idx_source_explicit
             self.source_implementation = self.source_slow
 
     @abstractmethod
@@ -304,6 +325,8 @@ class FastSlowSource(RightHandSide):
 
 
 class CombinedSource(RightHandSide):
+    REQUIRED_PRECOMPUTE_STEPS = ()
+
     def __init__(self, sources: list[RightHandSide]) -> None:
         self.sources = sources
 
@@ -312,6 +335,21 @@ class CombinedSource(RightHandSide):
             x for source in self.sources for x in source.REQUIRED_PRECOMPUTE_STEPS
         }
         self.REQUIRED_PRECOMPUTE_STEPS = tuple(required_steps)
+
+        # Pull the needed modules out of the rhs objects
+        precompute_steps: PrecomputeSteps = {}
+        for step in required_steps:
+            for source in self.sources:
+                if step in dir(source):
+                    precompute_steps[step] = getattr(source, step)
+                    break
+
+        super().__init__(**precompute_steps)
+
+        # Don't modify the shapes, as the sources will handle that internally
+        self.shape_full = max(source.shape_full for source in self.sources)
+        self.shape_domain = self.shape_update = self.shape_full
+        self.idx_domain = self.idx_update = np.s_[:]
 
     def source(
         self,

--- a/src/stanshock/system/base.py
+++ b/src/stanshock/system/base.py
@@ -223,7 +223,11 @@ class RightHandSide:
         )
 
     def source_full(
-        self, time: float, state_array_local: Array, gamma_star: Array, e0_star: Array
+        self,
+        time: float,
+        state_array_local: Array,
+        gamma_star: Array | None = None,
+        e0_star: Array | None = None,
     ) -> Array:
         """Reshape the source term to match the state array."""
         dydt = np.zeros_like(state_array_local)

--- a/tests/test_flux.py
+++ b/tests/test_flux.py
@@ -58,17 +58,30 @@ def test_isentropic_flow_relations(isentropic_flow: Combustor) -> None:
     # Get initial state from given solution
     t = isentropic_flow.t
     state = isentropic_flow.state
-    physics = isentropic_flow.physics
-    y = isentropic_flow.physics.primitive_to_conservative(state)
+    state_array = np.ravel(isentropic_flow.physics.primitive_to_conservative(state))
     gamma_star, e0_star = isentropic_flow.physics.get_double_flux_variables(state)
 
     # Get source terms from inviscid flux
+    y, gamma_star_local, e0_star_local = (
+        isentropic_flow.inviscid_flux.before_time_integration(
+            t, state_array, gamma_star, e0_star
+        )
+    )
     source_flux = isentropic_flow.inviscid_flux.source(
-        t, y, physics, gamma_star, e0_star
+        t, y, gamma_star_local, e0_star_local
     )
 
     # Get source terms from area change
-    source_area = isentropic_flow.area_change.source(
-        t, y, physics, gamma_star, e0_star, 1.0
+    assert isentropic_flow.area_change is not None
+    y, gamma_star_local, e0_star_local = (
+        isentropic_flow.area_change.before_time_integration(
+            t, state_array, gamma_star, e0_star
+        )
+    )
+    source_area = isentropic_flow.area_change.source_full(
+        t,
+        y,
+        gamma_star_local,
+        e0_star_local,
     )
     assert source_flux == pytest.approx(-source_area, rel=1e-3)

--- a/tests/test_time_integration.py
+++ b/tests/test_time_integration.py
@@ -41,8 +41,8 @@ class Brusselator(RightHandSide):
     def __init__(self) -> None:
         super().__init__()
         self.shape_full = (-1, 2)
-        self.shape_domain = (-1, 2)
-        self.shape_update = (-1, 2)
+        self.shape_input = (-1, 2)
+        self.shape_output = (-1, 2)
 
         self.abcd: tuple[float, float, float, float] = (1.0, 3.0, 1.0, 1.0)
 
@@ -55,7 +55,7 @@ class Brusselator(RightHandSide):
     ) -> Array:
         _ = time, gamma_star, e0_star
         a, b, c, _ = self.abcd
-        state_array_local = np.reshape(state_array_local, self.shape_domain)
+        state_array_local = np.reshape(state_array_local, self.shape_input)
         rhs = np.zeros_like(state_array_local)
 
         x = state_array_local[:, 0]
@@ -73,8 +73,8 @@ class Circle(RightHandSide):
     def __init__(self) -> None:
         super().__init__()
         self.shape_full = (-1, 2)
-        self.shape_domain = (-1, 2)
-        self.shape_update = (-1, 2)
+        self.shape_input = (-1, 2)
+        self.shape_output = (-1, 2)
 
     def source(
         self,
@@ -84,7 +84,7 @@ class Circle(RightHandSide):
         e0_star: Array | None = None,
     ) -> Array:
         _ = time, gamma_star, e0_star
-        state_array_local = np.reshape(state_array_local, self.shape_domain)
+        state_array_local = np.reshape(state_array_local, self.shape_input)
         rhs = np.zeros_like(state_array_local)
 
         x = state_array_local[:, 0]
@@ -101,8 +101,8 @@ class Circle(RightHandSide):
 
 class LotkaVolterra(FastSlowSource):
     REQUIRED_PRECOMPUTE_STEPS = ()
-    idx_update_explicit = np.s_[:]
-    idx_update_implicit = np.s_[:]
+    idx_output_explicit = np.s_[:]
+    idx_output_implicit = np.s_[:]
     idx_source_explicit = np.array([0])
     idx_source_implicit = np.array([1])
 
@@ -113,8 +113,8 @@ class LotkaVolterra(FastSlowSource):
     ) -> None:
         """Split RHS into fast and slow source terms accessed by setting the mode."""
         super().__init__(mode, **precompute_steps)
-        self.shape_full = self.shape_domain = (-1, 2)
-        self.shape_update = (-1, 1)
+        self.shape_full = self.shape_input = (-1, 2)
+        self.shape_output = (-1, 1)
 
     def source_slow(
         self,

--- a/tests/test_time_integration.py
+++ b/tests/test_time_integration.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TypedDict
+
+import numpy as np
+import pytest
+from scipy.integrate import solve_ivp
+
+from stanshock.numerics.time_integration import (
+    RK4,
+    SSPRK3,
+    ForwardEuler,
+    HeunsMethod,
+    MidpointMethod,
+    TimeIntegrator,
+)
+from stanshock.system.backend import Array
+from stanshock.system.base import RightHandSide
+
+from .conftest import FixtureRequest
+
+
+# Set up some analytic test problems
+class Brusselator(RightHandSide):
+    REQUIRED_PRECOMPUTE_STEPS = ()
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.shape_full = (-1, 2)
+        self.shape_domain = (-1, 2)
+        self.shape_update = (-1, 2)
+
+        self.abcd: tuple[float, float, float, float] = (1.0, 3.0, 1.0, 1.0)
+
+    def source(
+        self,
+        time: float,
+        state_array_local: Array,
+        gamma_star: Array | None = None,
+        e0_star: Array | None = None,
+    ) -> Array:
+        _ = time, gamma_star, e0_star
+        a, b, c, _ = self.abcd
+        state_array_local = np.reshape(state_array_local, self.shape_domain)
+        rhs = np.zeros_like(state_array_local)
+
+        x = state_array_local[:, 0]
+        y = state_array_local[:, 1]
+
+        rhs[:, 0] = a - (b + 1.0) * x + c * x**2 * y
+        rhs[:, 1] = b * x - c * x**2 * y
+
+        return np.ravel(rhs)
+
+
+class Circle(RightHandSide):
+    REQUIRED_PRECOMPUTE_STEPS = ()
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.shape_full = (-1, 2)
+        self.shape_domain = (-1, 2)
+        self.shape_update = (-1, 2)
+
+    def source(
+        self,
+        time: float,
+        state_array_local: Array,
+        gamma_star: Array | None = None,
+        e0_star: Array | None = None,
+    ) -> Array:
+        _ = time, gamma_star, e0_star
+        state_array_local = np.reshape(state_array_local, self.shape_domain)
+        rhs = np.zeros_like(state_array_local)
+
+        x = state_array_local[:, 0]
+        y = state_array_local[:, 1]
+
+        theta = np.arctan2(y, x)
+        r = np.sqrt(x**2 + y**2)
+
+        rhs[:, 0] = -r * np.sin(theta)
+        rhs[:, 1] = r * np.cos(theta)
+
+        return np.ravel(rhs)
+
+
+# Set up test cases for typical source terms and integrators
+@dataclass
+class TimeIntegrationCase:
+    rhs: RightHandSide
+    t_span: tuple[float, float]
+    y_init: Array
+    analytical_function: Callable[[Array], Array] | None = None
+    reference_solution: Array = field(init=False)
+
+    def __post_init__(self) -> None:
+        n = 5 * 7 * 8 * 9 * 11 + 1
+        t_eval = np.linspace(*self.t_span, n)
+
+        if self.analytical_function is None:
+            ode_result = solve_ivp(
+                fun=self.rhs.source,
+                t_span=self.t_span,
+                y0=self.y_init,
+                t_eval=t_eval,
+                method="DOP853",
+                atol=1e-15,
+                rtol=3e-14,
+                # dense_output=True,
+            )
+            self.reference_solution = ode_result.y
+        else:
+            self.reference_solution = self.analytical_function(t_eval)
+
+
+class IntegratorInfo(TypedDict):
+    integrator: type[TimeIntegrator]
+    order: int
+
+
+test_problems: dict[str, TimeIntegrationCase] = {
+    "brusselator": TimeIntegrationCase(
+        rhs=Brusselator(),
+        t_span=(0.0, 20.0),
+        y_init=np.array((1.0, 0.0)),
+    ),
+    "circle": TimeIntegrationCase(
+        rhs=Circle(),
+        t_span=(0.0, 6.0 * np.pi),
+        y_init=np.array((1.0, 0.0)),
+        analytical_function=lambda t: np.array((np.cos(t), np.sin(t))),
+    ),
+}
+
+test_integrators: dict[str, IntegratorInfo] = {
+    "FE": {"integrator": ForwardEuler, "order": 1},
+    "heun": {"integrator": HeunsMethod, "order": 2},
+    "midpnt": {"integrator": MidpointMethod, "order": 2},
+    "ssprk3": {"integrator": SSPRK3, "order": 3},
+    "rk4": {"integrator": RK4, "order": 4},
+}
+
+
+def get_convergence_order(x: Array, y: Array, n_discard: int = 4) -> float:
+    resid = 1.0
+    slope = -5.0
+    for i in range(n_discard + 1):
+        # Estimate the order of convergence
+        poly, (resid, _, _, _) = np.polynomial.Polynomial.fit(
+            x[i:], y[i:], 1, full=True
+        )
+        slope = poly.convert().coef[1]
+
+        if resid < 0.01:
+            # If the fit is poor, optionally discard up to n_discard of the
+            # smallest values, in case truncation error is dominating.
+            break
+
+    return slope
+
+
+@pytest.fixture(
+    params=list(test_problems.values()), ids=list(test_problems.keys()), scope="module"
+)
+def test_case(request: FixtureRequest[TimeIntegrationCase]) -> TimeIntegrationCase:
+    return request.param
+
+
+@pytest.fixture(
+    params=list(test_integrators.values()),
+    ids=list(test_integrators.keys()),
+    scope="module",
+)
+def integrator_info(request: FixtureRequest[IntegratorInfo]) -> IntegratorInfo:
+    return request.param
+
+
+@pytest.fixture
+def integrator(
+    integrator_info: IntegratorInfo, test_case: TimeIntegrationCase
+) -> TimeIntegrator:
+    return integrator_info["integrator"](test_case.rhs)
+
+
+def test_local_truncation_error_convergence(
+    test_case: TimeIntegrationCase, integrator_info: IntegratorInfo
+) -> None:
+    """Verify that error from a single step converges with the expected order."""
+    integrator = integrator_info["integrator"](test_case.rhs)
+
+    # Preallocate different time step sizes
+    t0, tf = test_case.t_span
+    n = np.shape(test_case.reference_solution)[1] - 1
+    dt0 = (tf - t0) / n
+    t_ref = np.linspace(t0, tf, n + 1)
+
+    N = 12
+    dt = np.arange(1, N + 1) * dt0
+
+    # Get reference solution
+    y_ref = test_case.reference_solution
+
+    # Take single time step with different step sizes
+    y_err_local = np.zeros((N,))
+    for i in range(N):
+        assert dt[i] == pytest.approx(t_ref[i + 1] - t_ref[0])
+        _, y, _, _ = integrator.advance(dt[i], t0, test_case.y_init.copy(), None, None)
+        y_err_local[i] = np.linalg.norm(y_ref[:, i + 1] - y)
+
+    err_slope = get_convergence_order(np.log(dt), np.log(y_err_local))
+
+    assert err_slope == pytest.approx(integrator_info["order"] + 1, abs=0.03)
+
+
+def test_global_truncation_error_convergence(
+    test_case: TimeIntegrationCase, integrator_info: IntegratorInfo
+) -> None:
+    """Verify that error over a fixed interval converges with time step size."""
+    integrator = integrator_info["integrator"](test_case.rhs)
+
+    # Preallocate different time step sizes
+    t0, tf = test_case.t_span
+    n = 5 * 7 * 8 * 9 * 11
+    dt0 = (tf - t0) / n
+
+    N = 12
+    dt = np.arange(1, N + 1) * dt0
+
+    # Get reference solution
+    y_init = test_case.y_init
+    y_ref = test_case.reference_solution[:, -1]
+
+    # Integrate over t_span with different step sizes
+    y_err_global = np.zeros((N,))
+    for i in range(N):
+        t = t0 + 0
+        y = y_init.copy()
+        for _j in range(n // (i + 1)):
+            t, y, _, _ = integrator.advance(dt[i], t, y, None, None)
+        assert t == pytest.approx(tf)
+        y_err_global[i] = np.linalg.norm(y_ref - y)
+
+    err_slope = get_convergence_order(np.log(dt), np.log(y_err_global))
+
+    assert err_slope == pytest.approx(integrator_info["order"], abs=0.02)

--- a/tests/test_time_integration.py
+++ b/tests/test_time_integration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 import numpy as np
 import pytest
@@ -11,18 +11,30 @@ from scipy.integrate import solve_ivp
 from stanshock.numerics.time_integration import (
     RK4,
     SSPRK3,
+    FastSlowIntegrator,
     ForwardEuler,
     HeunsMethod,
+    LieSplitting,
     MidpointMethod,
+    OperatorSplitting,
+    StrangSplitting,
+    SymmetricallyWeightedSequentialSplitting,
+    ThirdOrderSplitting,
     TimeIntegrator,
 )
-from stanshock.system.backend import Array
-from stanshock.system.base import RightHandSide
+from stanshock.physics.fluid_base import FluidState
+from stanshock.system.backend import Array, Unpack
+from stanshock.system.base import (
+    CombinedSource,
+    FastSlowSource,
+    PrecomputeSteps,
+    RightHandSide,
+)
 
 from .conftest import FixtureRequest
 
 
-# Set up some analytic test problems
+# Set up some simple test problems
 class Brusselator(RightHandSide):
     REQUIRED_PRECOMPUTE_STEPS = ()
 
@@ -87,22 +99,81 @@ class Circle(RightHandSide):
         return np.ravel(rhs)
 
 
+class LotkaVolterra(FastSlowSource):
+    REQUIRED_PRECOMPUTE_STEPS = ()
+    idx_update_explicit = np.s_[:]
+    idx_update_implicit = np.s_[:]
+    idx_source_explicit = np.array([0])
+    idx_source_implicit = np.array([1])
+
+    def __init__(
+        self,
+        mode: Literal["slow", "fast"] = "slow",
+        **precompute_steps: Unpack[PrecomputeSteps],
+    ) -> None:
+        """Split RHS into fast and slow source terms accessed by setting the mode."""
+        super().__init__(mode, **precompute_steps)
+        self.shape_full = self.shape_domain = (-1, 2)
+        self.shape_update = (-1, 1)
+
+    def source_slow(
+        self,
+        time: float,
+        state_array_local: Array | None,
+        state: FluidState | None,
+        face_states: FluidState | None,
+        avg_face_states: FluidState | None,
+        face_gradients: FluidState | None,
+    ) -> Array:
+        """Slow source term is constant."""
+        _ = time, state, face_states, avg_face_states, face_gradients
+        assert state_array_local is not None
+        # print(f"Slow source: {state_array_local.shape = }")
+        u = state_array_local[:, 0]
+        v = state_array_local[:, 1]
+        return u * (v - 1.0)
+
+    def source_fast(
+        self,
+        time: float,
+        state_array_local: Array | None,
+        state: FluidState | None,
+        face_states: FluidState | None,
+        avg_face_states: FluidState | None,
+        face_gradients: FluidState | None,
+    ) -> Array:
+        """Fast source term is exponential."""
+        _ = time, state, face_states, avg_face_states, face_gradients
+        assert state_array_local is not None
+        # print(f"Fast source: {state_array_local.shape = }")
+        u = state_array_local[:, 0]
+        v = state_array_local[:, 1]
+        return v * (1.0 - u)
+
+
 # Set up test cases for typical source terms and integrators
 @dataclass
 class TimeIntegrationCase:
-    rhs: RightHandSide
+    rhs: type[RightHandSide] | list[type[RightHandSide]]
     t_span: tuple[float, float]
     y_init: Array
     analytical_function: Callable[[Array], Array] | None = None
     reference_solution: Array = field(init=False)
 
     def __post_init__(self) -> None:
+        if isinstance(self.rhs, list):
+            rhs: RightHandSide = CombinedSource([rhs() for rhs in self.rhs])
+        elif issubclass(self.rhs, FastSlowSource):
+            rhs = CombinedSource([self.rhs("slow"), self.rhs("fast")])
+        else:
+            rhs = self.rhs()
+
         n = 5 * 7 * 8 * 9 * 11 + 1
         t_eval = np.linspace(*self.t_span, n)
 
         if self.analytical_function is None:
             ode_result = solve_ivp(
-                fun=self.rhs.source,
+                fun=rhs.source,
                 t_span=self.t_span,
                 y0=self.y_init,
                 t_eval=t_eval,
@@ -116,6 +187,7 @@ class TimeIntegrationCase:
             self.reference_solution = self.analytical_function(t_eval)
 
 
+# Setup for standard time integration tests
 class IntegratorInfo(TypedDict):
     integrator: type[TimeIntegrator]
     order: int
@@ -123,28 +195,46 @@ class IntegratorInfo(TypedDict):
 
 test_problems: dict[str, TimeIntegrationCase] = {
     "brusselator": TimeIntegrationCase(
-        rhs=Brusselator(),
+        rhs=Brusselator,
         t_span=(0.0, 20.0),
         y_init=np.array((1.0, 0.0)),
     ),
     "circle": TimeIntegrationCase(
-        rhs=Circle(),
+        rhs=Circle,
         t_span=(0.0, 6.0 * np.pi),
         y_init=np.array((1.0, 0.0)),
         analytical_function=lambda t: np.array((np.cos(t), np.sin(t))),
     ),
+    "lotkavolterra": TimeIntegrationCase(
+        rhs=LotkaVolterra,
+        t_span=(0.0, 2.5),
+        y_init=np.array((10.0, 6.0)),
+    ),
 }
 
 test_integrators: dict[str, IntegratorInfo] = {
+    # Standard integrators
     "FE": {"integrator": ForwardEuler, "order": 1},
     "heun": {"integrator": HeunsMethod, "order": 2},
     "midpnt": {"integrator": MidpointMethod, "order": 2},
     "ssprk3": {"integrator": SSPRK3, "order": 3},
     "rk4": {"integrator": RK4, "order": 4},
+    # Operator-split integrators
+    "lie": {"integrator": LieSplitting, "order": 1},
+    "fastslow": {"integrator": FastSlowIntegrator, "order": 1},
+    "strang": {"integrator": StrangSplitting, "order": 2},
+    "swss": {"integrator": SymmetricallyWeightedSequentialSplitting, "order": 2},
+    # Haven't observed third-order convergence with this:
+    "o3split": {"integrator": ThirdOrderSplitting, "order": 2},
 }
 
 
 def get_convergence_order(x: Array, y: Array, n_discard: int = 4) -> float:
+    # Remove points very close to machine epsilon
+    idx = np.where(y >= 1e-15)[0]
+    x = np.log(x[idx])
+    y = np.log(y[idx])
+
     resid = 1.0
     slope = -5.0
     for i in range(n_discard + 1):
@@ -182,15 +272,50 @@ def integrator_info(request: FixtureRequest[IntegratorInfo]) -> IntegratorInfo:
 def integrator(
     integrator_info: IntegratorInfo, test_case: TimeIntegrationCase
 ) -> TimeIntegrator:
-    return integrator_info["integrator"](test_case.rhs)
+    integrator = integrator_info["integrator"]
+
+    if integrator is FastSlowIntegrator:
+        # Requires FastSlowSource
+        if isinstance(test_case.rhs, list) or not issubclass(
+            test_case.rhs, FastSlowSource
+        ):
+            pytest.skip("FastSlowIntegrator requires a FastSlowSource.")
+        return integrator(test_case.rhs())
+
+    rhs: RightHandSide | None = None
+    rhs_list: list[RightHandSide] | None = None
+
+    if isinstance(test_case.rhs, list):
+        rhs_list = [rhs() for rhs in test_case.rhs]
+    elif issubclass(test_case.rhs, FastSlowSource):
+        # Split a fast/slow source into two RHS objects
+        rhs_list = [test_case.rhs("slow"), test_case.rhs("fast")]
+    else:
+        rhs = test_case.rhs()
+
+    if issubclass(integrator, OperatorSplitting):
+        if rhs_list is None:
+            pytest.skip("Can't apply operator splitting to single source term.")
+        else:
+            operators: tuple[TimeIntegrator, ...] = tuple(
+                [MidpointMethod(rhs) for rhs in rhs_list]
+            )
+
+        return integrator(operators=operators)
+
+    if rhs_list is not None:
+        rhs = CombinedSource(rhs_list)
+
+    assert rhs is not None
+    return integrator(rhs)
 
 
 def test_local_truncation_error_convergence(
-    test_case: TimeIntegrationCase, integrator_info: IntegratorInfo
+    test_case: TimeIntegrationCase,
+    integrator_info: IntegratorInfo,
+    integrator: TimeIntegrator,
 ) -> None:
     """Verify that error from a single step converges with the expected order."""
-    integrator = integrator_info["integrator"](test_case.rhs)
-
     # Preallocate different time step sizes
     t0, tf = test_case.t_span
     n = np.shape(test_case.reference_solution)[1] - 1
@@ -198,7 +323,7 @@ def test_local_truncation_error_convergence(
     t_ref = np.linspace(t0, tf, n + 1)
 
     N = 12
-    dt = np.arange(1, N + 1) * dt0
+    dt = np.arange(1, N + 1, dtype=np.float64) * dt0
 
     # Get reference solution
     y_ref = test_case.reference_solution
@@ -210,24 +335,24 @@ def test_local_truncation_error_convergence(
         _, y, _, _ = integrator.advance(dt[i], t0, test_case.y_init.copy(), None, None)
         y_err_local[i] = np.linalg.norm(y_ref[:, i + 1] - y)
 
-    err_slope = get_convergence_order(np.log(dt), np.log(y_err_local))
+    err_slope = get_convergence_order(dt, y_err_local)
 
     assert err_slope == pytest.approx(integrator_info["order"] + 1, abs=0.03)
 
 
 def test_global_truncation_error_convergence(
-    test_case: TimeIntegrationCase, integrator_info: IntegratorInfo
+    test_case: TimeIntegrationCase,
+    integrator_info: IntegratorInfo,
+    integrator: TimeIntegrator,
 ) -> None:
     """Verify that error over a fixed interval converges with time step size."""
-    integrator = integrator_info["integrator"](test_case.rhs)
-
     # Preallocate different time step sizes
     t0, tf = test_case.t_span
-    n = 5 * 7 * 8 * 9 * 11
+    n = np.shape(test_case.reference_solution)[1] - 1
     dt0 = (tf - t0) / n
 
     N = 12
-    dt = np.arange(1, N + 1) * dt0
+    dt = np.arange(1, N + 1, dtype=np.float64) * dt0
 
     # Get reference solution
     y_init = test_case.y_init
@@ -243,6 +368,6 @@ def test_global_truncation_error_convergence(
         assert t == pytest.approx(tf)
         y_err_global[i] = np.linalg.norm(y_ref - y)
 
-    err_slope = get_convergence_order(np.log(dt), np.log(y_err_global))
+    err_slope = get_convergence_order(dt, y_err_global)
 
-    assert err_slope == pytest.approx(integrator_info["order"], abs=0.02)
+    assert err_slope == pytest.approx(integrator_info["order"], abs=0.05)


### PR DESCRIPTION
Closes #21 

This is a complete overhaul of the time integration which includes the following changes:

- Updated `RightHandSide` with substantial new functionality:
    - Fine-grained shape controls:
        - `shape_full`: 2D shape of the full `state_array`, typically `(n_cells, n_variables)`
        - `idx_input`: Indices into full `state_array` of cells required to compute a source term, producing a `state_array_local` of shape `shape_input`. Typically:
            - Everything (i.e. `np.s_[:]` -> `(geometry.n_cells, n_variables)`) when ghost cells are required.
            - Internal cells (i.e. `geometry.idx_cells` -> `(geometry.n_cells_interior, n_variables)`) otherwise.
        - `shape_output`: Shape of resulting source term, which can be a subset of the `shape_input` given:
            - `idx_output`: Indices into first dimension of `state_array_local` -> cells to which the source term applies.
            - `idx_source`: Indices into second dimension of `state_array_local` -> equations to apply source terms.
        - Overridable `update_indices` function which enables dynamic modification of the above based on the `time` and `state`. By default this is executed at the end of the time step inside the `after_time_integration` call in anticipation of the next time step.
    - New `before_time_integration` and `after_time_integration` functions which are called at the start and end of the `TimeIntegrator.advance` method.
        - By default these handle extracting the `shape_input` subset of the `state_array` and then inserting the updated state back into the full array.
        - Also gets subset of double flux variables, then computes updated values to reinsert into the full arrays.
        - This default behavior should be sufficient for most source terms, but it is possible to do more advanced transformations with `before_` as long as everything is converted back to the standard form by `after_`. For example, the `ConstantVolumeChemistry` source term extracts the mass fractions and temperature, integrates them forward in time, then transforms those back into the conservative variables at the end.
    - Internally, the `source` evaluation is split into a precompute and implementation step:
        - Calculations which may be repeated across multiple source terms, such as `physics.conservative_to_primitive`, have been pulled into a separate `precompute_for_source` method which produces a set of common values (e.g. the `FluidState` at cell faces). The required set of precompute steps are specified at the class level as a tuple of strings.
        - These values are then passed to the `source_implementation` method, which is where the logic for computing the source term typically exists. Most source terms will only need to fill this in.
        - The primary purpose of this step is to avoid repeating calculations for cases where multiple source terms are evaluated together (see next bullet).
    - Convenience subclasses for specialized `RightHandSide`s:
        - `FastSlowSource` represents sources which distinguish between "slow", or non-stiff, source terms which can be integrated using an explicit solver, and "fast", or stiff, source terms which require implicit time integration.
            - Requires defining `source_fast` and `source_slow` methods which take the place of `source_implementation`.
            - It is recommended to provide a Jacobian for the fast source, if possible.
            - This generalizes the approach employed by the `AreaChange` source terms.
            - It allows for each source term to be applied over its own range of cells.
            - The two modes can be switched by setting the "mode" property to either "fast" or "slow."
        - `CombinedSource` takes in a list of `RightHandSide` objects and sums their source terms together.
            - The unique set of precompute steps across all RHS objects are assembled and computed only once prior to calling each individual `source_implementation`.
            - Currently, this approach will only work for source terms for the conservative variables. In the future, other forms could potentially be accommodated, e.g. by multiplying by a primitive-to-conservative transform matrix, but in the mean time we should consider detecting non-standard source terms and raising an error.

- The `state_array` should now always be 1D for consistency with `solve_ivp`, but is reshaped internally as-needed.

- Chemistry-related source terms have been extracted into `physics/chemistry_source.py`.

- Added `FaceAverage` base class in `numerics/face_average.py` to compute an effective face state from the left and right extrapolated states.
    - Implemented simple average ((left + right) / 2) and Roe-average implementations.
    - Currently used by the viscous flux calculations.

- Created a `TimeIntegrator` base class which defines a common interface for integrating any source term (`RightHandSide` objects).
    - Centers around the `advance` method, which takes one time step of specified size `dt`.
    - Takes in the current `time` and `state_array`, and optionally the double flux variables, and returns the same at the end of the time step.
    - Implemented some common approaches:
        - Interface to SciPy's `solve_ivp`.
        - Generic explicit Runge-Kutta class with implementations of common first, second, and third-order methods.
    - Implemented some convenient meta-approaches:
        - `StrangSplitting` which alternates integrating a transport and a reaction operator.
        - `LieSplitting` which integrates a list of `TimeIntegrator` objects in series.
        - `FastSlowIntegrator` which handles integrating the fast and slow terms of a `FastSlowSource` in series.

- Added unit tests which assess time integrators using canonical ODE problems, fully independent of other components of StanShock.
  - Verifies the convergence order of both local and global truncation errors with respect to the time step size.

Planned future work includes:

- Add an `examples/customization` folder for examples showcasing how to modify and extend `StanShock`, starting with a `source_terms.py` with examples of custom source terms.
- Add tests for `ScipyIVP` (needs to be tested in a different way due to its internal error control).
- Add IMEX integrator approaches for fast/slow problems.
- Make `FastSlowIntegrator` into an `OperatorSplitting` subclass, or somehow unifying them another way as there is a lot of overlap in their underlying approaches.
- Add some more test problems, including ones which use the physics.
    - For example, the unsteady partially-stirred reactor (PSR) test problem which has been used previously for testing operator splitting approaches, e.g. https://doi.org/10.1016/j.jcp.2014.01.016