### PR TITLE
Partial cleanup of Combustor signature.

### DIFF
--- a/examples/hyshot_ii.py
+++ b/examples/hyshot_ii.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from stanshock.components.combustor import Combustor
-from stanshock.numerics.boundary_conditions import SpecifiedFace
+from stanshock.numerics.boundary_conditions import BCInput, SpecifiedFace
 from stanshock.physics.fluid_base import FluidState
 from stanshock.physics.thermotable import ThermoTable
 from stanshock.system.backend import Array
@@ -99,7 +99,7 @@ BC_inlet = SpecifiedFace(
     reference_state=(gas_init.density, U_in, gas_init.P, gas_init.Y)
 )
 BC_outlet = "outflow"
-BCs = {"left": BC_inlet, "right": BC_outlet}
+BCs: BCInput = {"left": BC_inlet, "right": BC_outlet}
 
 
 # Define the fuel inflow
@@ -176,7 +176,6 @@ class HydrogenInjection(RightHandSide):
 # Initialize and run the simulation
 physics = ThermoTable(gas)
 ss = Combustor(
-    xf=xf,
     geometry=geometry,
     initialization=("constant", gas_init, U_in),
     boundary_conditions=BCs,

--- a/examples/hyshot_ii_jic/hyshot_ii_jic.py
+++ b/examples/hyshot_ii_jic/hyshot_ii_jic.py
@@ -10,7 +10,7 @@ from scipy import optimize
 
 from stanshock.components.combustor import Combustor
 from stanshock.models.jicf import JICModel
-from stanshock.numerics.boundary_conditions import SpecifiedFace
+from stanshock.numerics.boundary_conditions import BCInput, SpecifiedFace
 from stanshock.physics.flamelet import FPVTable
 from stanshock.processing.plot import XTDiagram
 from stanshock.system.geometry import Box
@@ -242,7 +242,7 @@ BC_inlet = SpecifiedFace(
     reference_state=(gas_init.density, U_in, gas_init.P, (1.0, 0.0, 0.0))
 )
 BC_outlet = "outflow"
-BCs = (BC_inlet, BC_outlet)
+BCs: BCInput = {"left": BC_inlet, "right": BC_outlet}
 
 # Load the FPV table
 fpv_table = FPVTable(
@@ -405,7 +405,6 @@ jic = JICModel(
 
 # Initialize and run the simulation
 ss = Combustor(
-    xf=xf,
     geometry=geometry,
     wall_temperature=300.0,
     include_boundary_layer=True,

--- a/examples/laminar_flame.py
+++ b/examples/laminar_flame.py
@@ -9,9 +9,10 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from stanshock.components.combustor import Combustor
-from stanshock.numerics.boundary_conditions import FreezeCells
+from stanshock.numerics.boundary_conditions import BCInput, FreezeCells
 from stanshock.physics.cantera_interface import CanteraInterface
 from stanshock.physics.thermotable import ThermoTable
+from stanshock.system.geometry import initialize_geometry
 
 
 def main(
@@ -55,7 +56,10 @@ def main(
     flame_center = flame.grid[np.argmax(np.gradient(flame.T, flame.grid))]
     L = flame.grid[-1] - flame.grid[0]
     xUpper, xLower = flame_center + L * f, flame_center - L * f
-    boundary_conditions = {
+    xf = np.linspace(xLower, xUpper, nX + 1)
+    geometry = initialize_geometry(xf)
+
+    boundary_conditions: BCInput = {
         "left": FreezeCells(
             "left"
         ),  # (gasUnburned.density, uUnburned, None, gasUnburned.Y),
@@ -67,7 +71,7 @@ def main(
         physics = CanteraInterface(gas)
 
     ss = Combustor(
-        xf=np.linspace(xLower, xUpper, nX + 1),
+        geometry=geometry,
         initialization=("Riemann", unburnedState, burnedState, flame_center),
         physics=physics,
         boundary_conditions=boundary_conditions,

--- a/examples/optimization.py
+++ b/examples/optimization.py
@@ -10,6 +10,7 @@ from matplotlib import pyplot as plt
 from scipy.optimize import newton
 
 from stanshock.components.shocktube import ShockTube
+from stanshock.numerics.boundary_conditions import BCInput
 from stanshock.physics.thermotable import ThermoTable
 from stanshock.processing.initialize import (
     smoothing_function,
@@ -80,6 +81,8 @@ def main(
     def dlnA_dx(time: float, x: Array) -> Array:
         return dA_dx(time, x) / A(time, x)
 
+    geometry = Cylinder(xf=xf, d_outer=d_outer, dlnA_dx=dlnA_dx)
+
     # compute the gas dynamics
     def res(Ms1):
         return p5 / p1 - ((2.0 * g1 * Ms1**2.0 - (g1 - 1.0)) / (g1 + 1.0)) * (
@@ -111,13 +114,13 @@ def main(
     gas4.TPX = T4, p4, "HE:1"
 
     # set up solver parameters
-    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
+    boundary_conditions: BCInput = {"left": "reflecting", "right": "reflecting"}
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
 
     ss = ShockTube(
-        xf=xf,
+        geometry=geometry,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -125,8 +128,6 @@ def main(
         output_every=100,
         include_boundary_layer=True,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
-        d_outer=d_outer,
-        dlnA_dx=dlnA_dx,
     )
     ss.state.gamma = ss.physics.get_gamma(ss.state)
     assert isinstance(ss.geometry, Cylinder)
@@ -144,10 +145,13 @@ def main(
 
     # recalculate at higher resolution with the insert
     xf = np.linspace(xLower, xUpper, nXFine + 1)
+    geometry = Cylinder(
+        xf=xf, d_inner=ss.geometry.d_inner, d_outer=d_outer, dlnA_dx=ss.geometry.dlnA_dx
+    )
     gas1.TPX = T1, p1, "AR:1"
     gas4.TPX = T4, p4, "HE:1"
     ss = ShockTube(
-        xf=xf,
+        geometry=geometry,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -155,9 +159,6 @@ def main(
         output_every=100,
         include_boundary_layer=True,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
-        d_outer=d_outer,
-        d_inner=ss.geometry.d_inner,
-        dlnA_dx=ss.geometry.dlnA_dx,
     )
 
     diagram_settings = [
@@ -186,10 +187,11 @@ def main(
     d_inner_insert = ss.geometry.d_inner(0.0, ss.geometry.xc)
 
     # recalculate at higher resolution without the insert
+    geometry = Cylinder(xf=xf, d_outer=d_outer, dlnA_dx=dlnA_dx)
     gas1.TPX = T1, p1, "AR:1"
     gas4.TPX = T4, p4, "HE:1"
     ss = ShockTube(
-        xf=xf,
+        geometry=geometry,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -197,8 +199,6 @@ def main(
         output_every=100,
         include_boundary_layer=True,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
-        d_outer=d_outer,
-        dlnA_dx=dlnA_dx,
     )
     if plot_results:
         ss.xt_diagrams += [

--- a/examples/validation/case1.py
+++ b/examples/validation/case1.py
@@ -9,9 +9,11 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from stanshock.components.shocktube import ShockTube
+from stanshock.numerics.boundary_conditions import BCInput
 from stanshock.physics.thermotable import ThermoTable
 from stanshock.processing.probe import Probe
 from stanshock.system.backend import Array
+from stanshock.system.geometry import initialize_geometry
 from stanshock.utils.csv_loader import get_pressure_data
 
 
@@ -92,25 +94,24 @@ def main(
     def dlnA_dx(time: float, x: Array) -> Array:
         return dA_dx(time, x) / A(time, x)
 
+    geometry = initialize_geometry(xf, d_outer=D, dlnA_dx=dlnA_dx)
+
     # set up solver parameters
     print("Solving with boundary layer terms")
-    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
+    boundary_conditions: BCInput = {"left": "reflecting", "right": "reflecting"}
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
 
     ssbl = ShockTube(
-        n_cells=nX,
-        xf=xf,
+        geometry=geometry,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
         cfl=0.9,
         output_every=100,
         include_boundary_layer=True,
-        d_outer=D,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
-        dlnA_dx=dlnA_dx,
     )
     ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xf)))  # end wall probe
 
@@ -126,16 +127,13 @@ def main(
     gas1.TP = T1, p1
     gas4.TP = T4, p4
     ssnbl = ShockTube(
-        n_cells=nX,
-        xf=xf,
+        geometry=geometry,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
         cfl=0.9,
         output_every=100,
         include_boundary_layer=False,
-        d_outer=D,
-        dlnA_dx=dlnA_dx,
     )
     ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xf)))  # end wall probe
 

--- a/examples/validation/case2.py
+++ b/examples/validation/case2.py
@@ -9,9 +9,11 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from stanshock.components.shocktube import ShockTube
+from stanshock.numerics.boundary_conditions import BCInput
 from stanshock.physics.thermotable import ThermoTable
 from stanshock.processing.probe import Probe
 from stanshock.system.backend import Array
+from stanshock.system.geometry import initialize_geometry
 from stanshock.utils.csv_loader import get_pressure_data
 
 
@@ -93,16 +95,17 @@ def main(
     def dlnA_dx(time: float, x: Array) -> Array:
         return dA_dx(time, x) / A(time, x)
 
+    geometry = initialize_geometry(xf, d_outer=D, dlnA_dx=dlnA_dx)
+
     # set up solver parameters
     print("Solving with boundary layer terms")
-    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
+    boundary_conditions: BCInput = {"left": "reflecting", "right": "reflecting"}
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
 
     ssbl = ShockTube(
-        n_cells=nX,
-        xf=xf,
+        geometry=geometry,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -110,8 +113,6 @@ def main(
         output_every=100,
         include_boundary_layer=True,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
-        d_outer=D,
-        dlnA_dx=dlnA_dx,
     )
     ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xf)))  # end wall probe
 
@@ -127,16 +128,13 @@ def main(
     gas1.TP = T1, p1
     gas4.TP = T4, p4
     ssnbl = ShockTube(
-        n_cells=nX,
-        xf=xf,
+        geometry=geometry,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
         cfl=0.9,
         output_every=100,
         include_boundary_layer=False,
-        d_outer=D,
-        dlnA_dx=dlnA_dx,
     )
     ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xf)))  # end wall probe
 

--- a/examples/validation/case3.py
+++ b/examples/validation/case3.py
@@ -9,6 +9,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from stanshock.components.shocktube import ShockTube
+from stanshock.numerics.boundary_conditions import BCInput
 from stanshock.physics.thermotable import ThermoTable
 from stanshock.processing.initialize import (
     smoothing_function,
@@ -16,6 +17,7 @@ from stanshock.processing.initialize import (
 )
 from stanshock.processing.probe import Probe
 from stanshock.system.backend import Array
+from stanshock.system.geometry import initialize_geometry
 from stanshock.utils.csv_loader import get_pressure_data
 
 
@@ -142,16 +144,19 @@ def main(
     def dlnA_dx(time: float, x: Array) -> Array:
         return dA_dx(time, x) / A(time, x)
 
+    geometry = initialize_geometry(
+        xf, d_inner=d_inner, d_outer=d_outer, dlnA_dx=dlnA_dx
+    )
+
     # set up solver parameters
     print("Solving with boundary layer terms")
-    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
+    boundary_conditions: BCInput = {"left": "reflecting", "right": "reflecting"}
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
 
     ssbl = ShockTube(
-        n_cells=nX,
-        xf=xf,
+        geometry=geometry,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -159,9 +164,6 @@ def main(
         output_every=100,
         include_boundary_layer=True,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
-        d_inner=d_inner,
-        d_outer=d_outer,
-        dlnA_dx=dlnA_dx,
     )
     ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xf)))  # end wall probe
 
@@ -177,17 +179,13 @@ def main(
     gas1.TP = T1, p1
     gas4.TP = T4, p4
     ssnbl = ShockTube(
-        n_cells=nX,
-        xf=xf,
+        geometry=geometry,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
         cfl=0.9,
         output_every=100,
         include_boundary_layer=False,
-        d_inner=d_inner,
-        d_outer=d_outer,
-        dlnA_dx=dlnA_dx,
     )
     ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xf)))  # end wall probe
 

--- a/examples/validation/case4.py
+++ b/examples/validation/case4.py
@@ -10,10 +10,12 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from stanshock.components.shocktube import ShockTube
+from stanshock.numerics.boundary_conditions import BCInput
 from stanshock.physics.thermotable import ThermoTable
 from stanshock.processing.plot import XTDiagram
 from stanshock.processing.probe import Probe
 from stanshock.system.backend import Array
+from stanshock.system.geometry import initialize_geometry
 
 
 # =============================================================================
@@ -144,15 +146,18 @@ def main(
     def dlnA_dx(time: float, x: Array) -> Array:
         return dA_dx(time, x) / A(time, x)
 
+    geometry = initialize_geometry(
+        xf, d_inner=d_inner, d_outer=d_outer, dlnA_dx=dlnA_dx
+    )
+
     # solve with boundary layer model
-    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
+    boundary_conditions: BCInput = {"left": "reflecting", "right": "reflecting"}
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
 
     ssbl = ShockTube(
-        n_cells=nX,
-        xf=xf,
+        geometry=geometry,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -160,9 +165,6 @@ def main(
         output_every=100,
         include_boundary_layer=True,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
-        d_inner=d_inner,
-        d_outer=d_outer,
-        dlnA_dx=dlnA_dx,
     )
     ssbl.state.gamma = ssbl.physics.get_gamma(ssbl.state)
     ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xf)))  # end wall probe
@@ -215,8 +217,7 @@ def main(
     gas1.TP = T1, p1
     gas4.TP = T4, p4
     ssnbl = ShockTube(
-        n_cells=nX,
-        xf=xf,
+        geometry=geometry,
         physics=physics_model,
         initialization=("riemann", state4, state1, xShock),
         boundary_conditions=boundary_conditions,
@@ -224,9 +225,6 @@ def main(
         output_every=100,
         include_boundary_layer=False,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
-        d_inner=d_inner,
-        d_outer=d_outer,
-        dlnA_dx=dlnA_dx,
     )
     ssnbl.state.gamma = ssnbl.physics.get_gamma(ssnbl.state)
     ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xf)))  # end wall probe

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+from typing import Any
+
 import numpy as np
 
 from stanshock.models.area_change import AreaChange
-from stanshock.models.boundary_layer import BoundaryLayer
+from stanshock.models.boundary_layer import BoundaryLayer, SkinFriction
 from stanshock.numerics.boundary_conditions import (
     BCInput,
     BoundaryConditions,
@@ -16,7 +19,11 @@ from stanshock.numerics.face_extrapolation import (
     FirstOrder,
 )
 from stanshock.numerics.gradient import CentralDifference
-from stanshock.numerics.inviscid_flux import InviscidFlux, RiemannSolver, hllc_flux
+from stanshock.numerics.inviscid_flux import (
+    InviscidFlux,
+    RiemannSolver,
+    hllc_flux_vectorized,
+)
 from stanshock.numerics.time_integration import (
     SSPRK3,
     FastSlowIntegrator,
@@ -40,7 +47,7 @@ from stanshock.processing.plot import XTDiagram, plot_state
 from stanshock.processing.probe import Probe
 from stanshock.system.backend import Array
 from stanshock.system.base import RightHandSide
-from stanshock.system.geometry import Geometry, initialize_geometry
+from stanshock.system.geometry import Geometry
 
 
 class Combustor:
@@ -49,81 +56,66 @@ class Combustor:
     1D gasdynamics solver.
     """
 
-    def __init__(  # type: ignore[no-untyped-def]
+    def __init__(
         self,
-        physics: FluidPhysics,
-        n_cells: int = 10,
-        geometry: Geometry | None = None,
-        **kwargs,
+        physics: FluidPhysics,  # Model handling all fluid property evaluations
+        geometry: Geometry,
+        boundary_conditions: BoundaryConditions | BCInput,
+        initialization: Sequence[str | Any],  # initialization options
+        cfl: float = 1.0,  # stability condition
+        t: float = 0.0,  # time
+        verbose: bool = True,  # console output switch
+        output_every: int = 1,  # number of iterations of simulation advancement between logging updates
+        include_boundary_layer: bool = False,  # flag to include boundary layer terms
+        wall_temperature: float | None = None,  # wall temperature (needed for BL)
+        skin_friction_coefficient: SkinFriction | None = None,  # skin friction functor
+        source_terms: RightHandSide
+        | list[RightHandSide]
+        | None = None,  # Catch-all source term(s)
+        injector: RightHandSide | None = None,  # injector model
+        flux_function: RiemannSolver = hllc_flux_vectorized,
+        inviscid_face_extrapolator: type[FaceExtrapolator] = FifthOrderWeno,
+        viscous_face_extrapolator: type[FaceExtrapolator] = FirstOrder,
+        probes: list[Probe] | None = None,  # list of probe objects
+        xt_diagrams: list[XTDiagram] | None = None,  # list of XT diagram objects
+        optimization_iteration: int = 0,  # counter to keep track of optimization
+        reacting: bool = False,  # flag to solver about whether to solve source terms
+        include_diffusion: bool = False,  # exclude diffusion
+        thickening: None = None,  # thickening function
+        plot_state_interval: int = -1,  # plot the state every n iterations
     ) -> None:
         """
         initialization of the object with default values. The keyword arguments
         allow the user to initialize the state
         """
         # initialize the class
-        self.cfl = 1.0  # stability condition
-        self.dx = 1.0  # grid spacing
-        self.n_cells = n_cells  # grid size
-        self.boundary_conditions: BoundaryConditions | BCInput = {
-            "left": "outflow",
-            "right": "outflow",
-        }
-        self.xf: Array = np.linspace(
-            0.0, self.dx * self.n_cells, self.n_cells + 1, dtype=np.float64
-        )
-        self.t = 0.0  # time
-        self.verbose = True  # console output switch
-        self.output_every = (
-            1  # number of iterations of simulation advancement between logging updates
-        )
-        self.area_change: RightHandSide | None = None
-        self.include_boundary_layer = False  # flag to include boundary layer terms
-        self.wall_temperature = None  # wall temperature (needed for BL)
-        self.source_terms: RightHandSide | None = None  # source term function
-        self.injector = None  # injector model
-        self.flux_function: RiemannSolver = hllc_flux
-        self.inviscid_face_extrapolator: type[FaceExtrapolator] = FifthOrderWeno
-        self.viscous_face_extrapolator: type[FaceExtrapolator] = FirstOrder
-        self.initialization = None  # initialization options
-        self.probes: list[Probe] = []  # list of probe objects
-        self.xt_diagrams: list[XTDiagram] = []  # list of XT diagram objects
-        self.skin_friction_coefficient = None  # skin friction functor
-        self.optimization_iteration = 0  # counter to keep track of optimization
-        self.physics = physics  # Model handling all fluid property evaluations
-        self.reacting = False  # flag to solver about whether to solve source terms
-        self.in_reacting_region = lambda _t, x: np.ones_like(
-            x, dtype=bool
-        )  # the reacting region of the shock tube.
-        self.include_diffusion = False  # exclude diffusion
-        self.thickening = None  # thickening function
-        self.plot_state_interval = -1  # plot the state every n iterations
-        # overwrite the default data
-        for key, item in kwargs.items():
-            if key in self.__dict__:
-                self.__dict__[key] = item
+        self.cfl = cfl
+        self.t = t
+        self.verbose = verbose
+        self.output_every = output_every
+        self.injector = injector
+        self.optimization_iteration = optimization_iteration
+        self.physics: FluidPhysics = physics
+        self.include_diffusion = include_diffusion
+        self.thickening = thickening
+        self.plot_state_interval = plot_state_interval
+
+        # Initialize values which are passed in as None
+        self.probes: list[Probe] = [] if probes is None else probes
+        self.xt_diagrams: list[XTDiagram] = [] if xt_diagrams is None else xt_diagrams
 
         # Determine the number of ghost layers required by the spatial scheme
-        n_ghost_layers: int = self.inviscid_face_extrapolator.minimum_ghost_layers
+        n_ghost_layers: int = inviscid_face_extrapolator.minimum_ghost_layers
         if self.include_diffusion:
             n_ghost_layers = max(
-                n_ghost_layers, self.viscous_face_extrapolator.minimum_ghost_layers
+                n_ghost_layers, viscous_face_extrapolator.minimum_ghost_layers
             )
 
         # Initialize the geometry of the domain
-        if geometry is None:
-            kwargs.pop("xf")
-            self.geometry: Geometry = initialize_geometry(
-                xf=self.xf, n_ghost_layers=n_ghost_layers, **kwargs
-            )
-        else:
-            self.geometry = geometry
-            self.geometry.setup_ghost_layers(n_ghost_layers=n_ghost_layers)
+        self.geometry = geometry
+        self.geometry.setup_ghost_layers(n_ghost_layers=n_ghost_layers)
 
-        # Add area-change related source terms
-        if self.geometry.dlnA_dt is not None or self.geometry.dlnA_dx is not None:
-            self.area_change = AreaChange(geometry=self.geometry, physics=self.physics)
-
-        # set the number of scalars
+        # Set the number of scalars
         self.n_scalars = self.physics.n_scalars
         if not self.physics.is_flamelet and self.injector is not None:
             msg = "JIC injector model requires FPVTable physics."
@@ -131,38 +123,35 @@ class Combustor:
 
         # Set up boundary conditions
         self.boundary_conditions = set_boundary_conditions(
-            self.boundary_conditions, self.geometry.n_ghost_layers
+            boundary_conditions, self.geometry.n_ghost_layers
         )
 
         # initialize the state
-        if self.initialization is None:
-            msg = "No initialization method selected"
-            raise Exception(msg)
-        if self.initialization[0].lower() == "constant":
+        if initialization[0].lower() == "constant":
             self.state = initialize_constant(
-                self.geometry, self.physics, *self.initialization[1:]
+                self.geometry, self.physics, *initialization[1:]
             )
-        elif self.initialization[0].lower() == "riemann":
+        elif initialization[0].lower() == "riemann":
             self.state = initialize_riemann_problem(
-                self.geometry, self.physics, *self.initialization[1:]
+                self.geometry, self.physics, *initialization[1:]
             )
-        elif self.initialization[0].lower() == "diffuse_interface":
+        elif initialization[0].lower() == "diffuse_interface":
             self.state = initialize_diffuse_interface(
-                self.geometry, self.physics, *self.initialization[1:]
+                self.geometry, self.physics, *initialization[1:]
             )
-        elif self.initialization[0].lower() == "isentropic":
+        elif initialization[0].lower() == "isentropic":
             self.state = initialize_isentropic(
-                self.geometry, self.physics, *self.initialization[1:]
+                self.geometry, self.physics, *initialization[1:]
             )
 
         # Initialize the key physics
         self.inviscid_flux = InviscidFlux(
-            face_extrapolator=self.inviscid_face_extrapolator(
+            face_extrapolator=inviscid_face_extrapolator(
                 n_scalars_rho_sum=self.physics.n_scalars_rho_sum,
                 n_ghost_layers=self.geometry.n_ghost_layers,
             ),
             boundary_conditions=self.boundary_conditions,
-            riemann_solver=self.flux_function,
+            riemann_solver=flux_function,
             geometry=self.geometry,
             physics=self.physics,
         )
@@ -170,14 +159,14 @@ class Combustor:
         # Set up time integrators
         integrators: list[TimeIntegrator] = []
         advection = SSPRK3(self.inviscid_flux)
-        if self.physics.is_flamelet:
+        if reacting and self.physics.is_flamelet:
             integrators += [
                 HeunsMethod(
                     ChemistrySource(geometry=self.geometry, physics=self.physics)
                 ),
                 advection,
             ]
-        elif self.physics.gas.n_reactions > 0:
+        elif reacting and self.physics.gas.n_reactions > 0:
             chemistry = ScipyIVP(
                 ConstantVolumeChemistry(geometry=self.geometry, physics=self.physics)
             )
@@ -190,7 +179,7 @@ class Combustor:
                 geometry=self.geometry,
                 physics=self.physics,
                 boundary_conditions=self.boundary_conditions,
-                face_extrapolator=self.viscous_face_extrapolator(
+                face_extrapolator=viscous_face_extrapolator(
                     n_scalars_rho_sum=self.physics.n_scalars_rho_sum,
                     n_ghost_layers=self.geometry.n_ghost_layers,
                 ),
@@ -199,22 +188,26 @@ class Combustor:
             )
             integrators += [HeunsMethod(self.viscous_flux)]
 
-        if self.area_change is not None:
-            # integrators += [ForwardEuler(self.area_change)]
+        # Add area-change related source terms
+        if self.geometry.dlnA_dt is not None or self.geometry.dlnA_dx is not None:
+            self.area_change = AreaChange(geometry=self.geometry, physics=self.physics)
             integrators += [FastSlowIntegrator(self.area_change)]
 
-        if self.include_boundary_layer:
+        if include_boundary_layer:
             # Initialize the boundary layer source terms
             self.boundary_layer = BoundaryLayer(
-                wall_temperature=self.wall_temperature,
-                skin_friction_coefficient=self.skin_friction_coefficient,
+                wall_temperature=wall_temperature,
+                skin_friction_coefficient=skin_friction_coefficient,
                 geometry=self.geometry,
                 physics=self.physics,
             )
             integrators += [ForwardEuler(self.boundary_layer)]
 
-        if self.source_terms is not None:
-            integrators += [HeunsMethod(self.source_terms)]
+        if source_terms is not None:
+            if isinstance(source_terms, list):
+                integrators += [HeunsMethod(rhs) for rhs in source_terms]
+            else:
+                integrators += [HeunsMethod(source_terms)]
 
         if self.injector is not None:
             integrators += [HeunsMethod(self.injector)]
@@ -224,15 +217,16 @@ class Combustor:
 
         self.F = np.ones(self.geometry.n_cells)  # thickening
 
-    def get_wave_speed(self):
+    def get_wave_speed(self) -> Array:
         """
         This method determines the absolute maximum of the wave speed
             outputs:
                 speed of acoustic wave
         """
+        assert self.state.velocity is not None
         return abs(self.state.velocity) + self.physics.get_sound_speed(self.state)
 
-    def get_time_step(self):
+    def get_time_step(self) -> float:
         """
         This method determines the maximal timestep in accord with the CFL
         condition
@@ -241,21 +235,22 @@ class Combustor:
         """
         local_timescale = self.geometry.dx / self.get_wave_speed()
         if self.include_diffusion:
+            assert self.state.density is not None
             mu = self.physics.get_mu(self.state)
             nu = mu / self.state.density
             alpha = self.physics.get_thermal_diffusivity(self.state) * self.F
-            diff = (
+            diff: Array = (
                 np.max(self.physics.get_mass_diffusivity(self.state), axis=1) * self.F
             )
-            viscous_timescale = (
+            viscous_timescale: Array = (
                 0.5
                 * self.geometry.dx**2.0
                 / np.maximum(4.0 / 3.0 * nu, np.maximum(alpha, diff))
             )
             local_timescale = np.minimum(local_timescale, viscous_timescale)
-        return self.cfl * min(local_timescale)
+        return self.cfl * np.min(local_timescale)
 
-    def update_probes(self, iters):
+    def update_probes(self, iters: int) -> None:
         """
         This method updates all the probes to the current value
         """
@@ -265,7 +260,7 @@ class Combustor:
             if iters % (probe.skipSteps + 1) == 0:
                 probe.update(self)
 
-    def update_XT_diagrams(self, iters):
+    def update_XT_diagrams(self, iters: int) -> None:
         """
         This method updates all the XT Diagrams to the current value.
         """
@@ -274,7 +269,7 @@ class Combustor:
             if iters % (diagram.skipSteps + 1) == 0:
                 diagram.update(self)
 
-    def advance_simulation(self, tFinal, res_p_target=-1.0):
+    def advance_simulation(self, tFinal: float, res_p_target: float = -1.0) -> None:
         """
         This method advances the simulation until the prescribed time, tFinal
             inputs
@@ -282,9 +277,11 @@ class Combustor:
         """
         iters = 0
         res_p = np.inf
+        gamma_star: Array | None
+        e0_star: Array | None
         gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
         state_array = self.physics.primitive_to_conservative(self.state)
-        self.shape_full: tuple[int, int] = state_array.shape
+        self.shape_full: tuple[int, ...] = state_array.shape
         state_array = np.ravel(state_array)
         p_new = self.physics.get_pressure(self.state)
         while self.t < tFinal and res_p > res_p_target:
@@ -309,7 +306,7 @@ class Combustor:
             self.update_probes(iters)
             self.update_XT_diagrams(iters)
             iters += 1
-            res_p = np.linalg.norm(p_new - p_old)
+            res_p = float(np.linalg.norm(p_new - p_old))
             if self.verbose and iters % self.output_every == 0:
                 print(
                     f"Iteration: {iters}. Current time: {self.t}. Time step: {dt:e}. "

--- a/src/stanshock/components/shocktube.py
+++ b/src/stanshock/components/shocktube.py
@@ -75,10 +75,9 @@ class ShockTube(Combustor):
         )  # RBF is the gaussian correlation
 
         # Check for boundary layer terms
-        if not self.include_boundary_layer:
-            self.include_boundary_layer = True
-            if self.verbose:
-                print("WARNING: Boundary Layer Terms Included")
+        if not hasattr(self, "boundary_layer"):
+            msg = "Boundary layer terms have not been set."
+            raise AttributeError(msg)
 
         assert isinstance(self.geometry, Cylinder)
         geometry: Cylinder = self.geometry


### PR DESCRIPTION
Removed `kwargs` from `Combustor` and moved all keyword arguments with their default values into the signature along with the comments describing them. Boundary conditions must now be specified (no default value, but can be a `BCInput` dictionary), and geometry must be passed in as an initialized `Geometry` object.

This also enabled the removal of several attributes which are not used outside of `__init__`, such as `inviscid_face_extrapolator` and `include_boundary_layer`.

Closes #70