### PR TITLE
Standardize the flow initialization

### DIFF
--- a/examples/hyshot_ii.py
+++ b/examples/hyshot_ii.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import code
 from typing import Unpack
 
 import cantera as ct
@@ -11,6 +10,7 @@ from stanshock.components.combustor import Combustor
 from stanshock.numerics.boundary_conditions import BCInput, SpecifiedFace
 from stanshock.physics.fluid_base import FluidState
 from stanshock.physics.thermotable import ThermoTable
+from stanshock.processing.initialize import InitializeConstant
 from stanshock.system.backend import Array
 from stanshock.system.base import PrecomputeSteps, RightHandSide
 from stanshock.system.geometry import Box
@@ -106,6 +106,8 @@ BCs: BCInput = {"left": BC_inlet, "right": BC_outlet}
 class HydrogenInjection(RightHandSide):
     def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
         super().__init__(**precompute_steps)
+        assert self.geometry is not None
+        assert self.physics is not None
         gas = self.physics.gas
         n_variables = self.physics.n_scalars + 2
 
@@ -127,25 +129,26 @@ class HydrogenInjection(RightHandSide):
         U_f = M_f * a_f
         rho_f = mdot_f / (U_f * A_f_tot)
         gas.TDX = T_f, rho_f, "H2:1"
-        P_f = gas.P
-        # W_f = gas.mean_molecular_weight
 
-        rhoE_f = P_f / (gamma_f - 1) + 0.5 * rho_f * U_f**2
+        # rhoE_f = P_f / (gamma_f - 1) + 0.5 * rho_f * U_f**2
+        rhoE_f = rho_f * (gas.int_energy_mass + 0.5 * U_f**2)
         rhoYH2_f = rho_f * gas.Y[gas.species_index("H2")]
         A_f = A_f_tot
 
         # Define the source terms
         L_src = 30.0e-3
-        scale_factor = 3.960715337483353
+        scale_factor = 1.0  # 3.960715337483353
 
         # Get geometry information
         xf = self.geometry.xf
-        self.idx_input = (
-            np.where(np.logical_and(xf >= x_inj, xf < x_inj + L_src))[0]
-            + self.geometry.n_ghost_layers
-        )
+        idx_faces = np.where(np.logical_and(xf >= x_inj, xf < x_inj + L_src))[0]
+        self.idx_input = idx_faces + self.geometry.n_ghost_layers
         self.xc = self.geometry.xc[self.idx_input]
         n_cells = len(self.xc)
+
+        idx_faces = np.concatenate((idx_faces, [idx_faces[-1] + 1]))
+        self.xf = self.geometry.xf[idx_faces]
+
         self.shape_input = (n_cells, n_variables)
         self.shape_output = (n_cells, 3)
         self.idx_source = np.array([0, 1, 2 + gas.species_index("H2")])
@@ -154,7 +157,18 @@ class HydrogenInjection(RightHandSide):
         self.rhs[:, 0] = rho_f * U_f
         self.rhs[:, 1] = rhoE_f
         self.rhs[:, 2] = rhoYH2_f
-        self.rhs *= U_f * A_f / L_src * scale_factor
+
+        dx = self.geometry.dx
+        if isinstance(dx, np.ndarray):
+            dx = dx[self.idx_input, None]
+        self.rhs *= U_f * A_f * (dx / L_src) * scale_factor
+
+        # If the volume is constant with time, go ahead and precompute it:
+        self.compute_volume: bool = True
+        if self.geometry.dlnA_dt is None:
+            self.compute_volume = False
+            vol = self.geometry.volume(0.0, self.xf)[:, None]
+            self.rhs = np.ravel(self.rhs / vol)
 
     def source_implementation(
         self,
@@ -165,19 +179,19 @@ class HydrogenInjection(RightHandSide):
         avg_face_states: FluidState | None,
         face_gradients: FluidState | None,
     ) -> Array:
-        _ = state_array_local, state, face_states, avg_face_states, face_gradients
-        area = self.geometry.area(time, self.xc)
-        if isinstance(area, np.ndarray):
-            area = area[:, None]
-
-        return np.ravel(self.rhs / area)
+        assert self.geometry is not None
+        _ = time, state_array_local, state, face_states, avg_face_states, face_gradients
+        if self.compute_volume:
+            vol = self.geometry.volume(time, self.xf)[:, None]
+            return np.ravel(self.rhs / vol)
+        return self.rhs
 
 
 # Initialize and run the simulation
 physics = ThermoTable(gas)
 ss = Combustor(
     geometry=geometry,
-    initialization=("constant", gas_init, U_in),
+    initialization=InitializeConstant(geometry, physics, gas_init, U_in),
     boundary_conditions=BCs,
     source_terms=HydrogenInjection(geometry=geometry, physics=physics),
     cfl=0.5,
@@ -191,8 +205,13 @@ ss.advance_simulation(t_end)
 
 # Plot the results
 def plot_sim(ss: Combustor) -> None:
+    assert ss.state.density is not None
+    assert ss.state.velocity is not None
+    assert ss.state.pressure is not None
+    assert ss.state.composition is not None
     idx = ss.geometry.idx_cells
     xc = ss.geometry.xc[idx] * scale
+    area = ss.geometry.area(ss.t, ss.geometry.xc[idx])
     rho = ss.state.density[idx]
     u = ss.state.velocity[idx]
     p = ss.state.pressure[idx]
@@ -200,11 +219,21 @@ def plot_sim(ss: Combustor) -> None:
     T = ss.physics.get_temperature(ss.state)[idx]
     c = ss.physics.get_sound_speed(ss.state)[idx]
     M = u / c
+    mdot = rho * u * area
+    mdot_f = 4.4e-3  # kg/s
+    Y_f = mdot_f / (mdot_f + mdot_a)
 
     fig, ax = plt.subplots(7, 1, sharex=True, figsize=(6, 8))
-    ax[0].plot(xc, rho)
+    # ax[0].plot(xc, rho)
+    # ax[0].set_ymargin(0.1)
+    # ax[0].set_ylabel(r"$\rho$ [kg/m$^3$]")
+    # add_h_plot(ax[0])
+
+    ax[0].plot(xc[[0, -1]], mdot[[0, 0]], "g:")
+    ax[0].plot(xc[[0, -1]], mdot[[0, 0]] + mdot_f, "g:")
+    ax[0].plot(xc, mdot)
     ax[0].set_ymargin(0.1)
-    ax[0].set_ylabel(r"$\rho$ [kg/m$^3$]")
+    ax[0].set_ylabel(r"$\dot{m}$ [kg/s]")
     add_h_plot(ax[0])
 
     ax[1].plot(xc, u)
@@ -227,6 +256,8 @@ def plot_sim(ss: Combustor) -> None:
     ax[4].set_ylabel(r"$M$ [-]")
     add_h_plot(ax[4])
 
+    ax[5].plot(xc[[0, -1]], [0.0, 0.0], "g:")
+    ax[5].plot(xc[[0, -1]], [Y_f, Y_f], "g:")
     ax[5].plot(xc, Y[:, gas.species_index("H2")])
     ax[5].set_ymargin(0.1)
     ax[5].set_ylabel(r"$Y_{\mathrm{H}_2}$ [-]")
@@ -244,5 +275,3 @@ def plot_sim(ss: Combustor) -> None:
 
 
 plot_sim(ss)
-
-code.interact(local=locals())

--- a/examples/laminar_flame.py
+++ b/examples/laminar_flame.py
@@ -12,7 +12,7 @@ from stanshock.components.combustor import Combustor
 from stanshock.numerics.boundary_conditions import BCInput, FreezeCells
 from stanshock.physics.cantera_interface import CanteraInterface
 from stanshock.physics.thermotable import ThermoTable
-from stanshock.processing.initialize import InitializeRiemannProblem
+from stanshock.processing.initialize import InitializeCanteraArray
 from stanshock.system.geometry import initialize_geometry
 
 
@@ -21,7 +21,7 @@ def main(
     mech_filename: str = "ohn.yaml",
     plot_results: bool = True,
     show_results: bool = False,
-    results_location: str | None = ".",
+    results_location: Path | str | None = ".",
     physics_model: str = "ThermoTable",
 ) -> dict[str, np.ndarray]:
     # user parameters
@@ -34,8 +34,7 @@ def main(
 
     # find the initial state of the fluids
     gas = ct.Solution(mech_filename)
-    unburnedState = TU, p, "H2:2,O2:1,N2:3.76"
-    gas.TPX = unburnedState
+    gas.TPX = TU, p, {"H2": 2, "O2": 1, "N2": 3.76}
 
     # get the flame thickness
     _, flame = flameSpeed(gas, estFlameThickness, returnFlame=True)
@@ -43,14 +42,8 @@ def main(
     flameThickness = (TB - TU) / max(np.gradient(flame.T, flame.grid))
 
     # get flame parameters
-    gasUnburned = ct.Solution(mech_filename)
-    gasUnburned.TPY = flame.T[0], flame.P, flame.Y[:, 0]
     uUnburned = flame.velocity[0]
-    unburnedState = gasUnburned, uUnburned
-    gasBurned = ct.Solution(mech_filename)
-    gasBurned.TPY = flame.T[-1], flame.P, flame.Y[:, -1]
     uBurned = flame.velocity[-1]
-    burnedState = gasBurned, uBurned
 
     # set up grid
     nX = flame.grid.shape[0]
@@ -70,9 +63,8 @@ def main(
         physics = ThermoTable(gas)
     else:
         physics = CanteraInterface(gas)
-    initialization = InitializeRiemannProblem(
-        geometry, physics, unburnedState, burnedState, flame_center
-    )
+
+    initialization = InitializeCanteraArray(geometry, flame.to_array())
 
     ss = Combustor(
         geometry=geometry,
@@ -84,24 +76,11 @@ def main(
         include_diffusion=True,
         output_every=10,
     )
-    print(ss.boundary_conditions._boundary_conditions)
-
-    # interpolate flame solution
-    Y = ss.state.composition
-    for iSp in range(gas.n_species):
-        Y[:, iSp] = np.interp(ss.geometry.xc, flame.grid, flame.Y[iSp, :])
-
-    ss.state.density = np.interp(ss.geometry.xc, flame.grid, flame.density)
-    ss.state.velocity = np.interp(ss.geometry.xc, flame.grid, flame.velocity)
-    ss.state.pressure = flame.P * np.ones(ss.geometry.n_cells)
-    ss.state.composition = Y
-
-    T = ss.state.temperature = ss.physics.get_temperature(ss.state)
-    ss.state.gamma = ss.physics.get_gamma(ss.state)
 
     # calculate the final time if not specified
     if sim_time is None:
         sim_time = ntFlowThrough * (xUpper - xLower) / (uUnburned + uBurned) * 2.0
+    assert isinstance(sim_time, float)
 
     # Solve
     t0 = time.perf_counter()
@@ -110,13 +89,14 @@ def main(
     print("The process took ", t1 - t0)
 
     # plot setup
+    # idx = ss.geometry.idx_cells
+    idx = np.s_[:]
+    T = ss.physics.get_temperature(ss.state)[idx]
     if plot_results:
-        # idx = ss.geometry.idx_cells
-        idx = np.s_[:]
         x = (ss.geometry.xc[idx] - flame_center) / flameThickness
         x_ct = (flame.grid - flame_center) / flameThickness
-        T = ss.physics.get_temperature(ss.state)[idx]
         state = ss.physics.set_state(ss.state)
+        assert state.mass_fractions is not None
 
         plt.close("all")
         font = {"family": "serif", "serif": ["computer modern roman"]}

--- a/examples/laminar_flame.py
+++ b/examples/laminar_flame.py
@@ -12,6 +12,7 @@ from stanshock.components.combustor import Combustor
 from stanshock.numerics.boundary_conditions import BCInput, FreezeCells
 from stanshock.physics.cantera_interface import CanteraInterface
 from stanshock.physics.thermotable import ThermoTable
+from stanshock.processing.initialize import InitializeRiemannProblem
 from stanshock.system.geometry import initialize_geometry
 
 
@@ -69,10 +70,13 @@ def main(
         physics = ThermoTable(gas)
     else:
         physics = CanteraInterface(gas)
+    initialization = InitializeRiemannProblem(
+        geometry, physics, unburnedState, burnedState, flame_center
+    )
 
     ss = Combustor(
         geometry=geometry,
-        initialization=("Riemann", unburnedState, burnedState, flame_center),
+        initialization=initialization,
         physics=physics,
         boundary_conditions=boundary_conditions,
         cfl=0.9,

--- a/examples/optimization.py
+++ b/examples/optimization.py
@@ -13,6 +13,7 @@ from stanshock.components.shocktube import ShockTube
 from stanshock.numerics.boundary_conditions import BCInput
 from stanshock.physics.thermotable import ThermoTable
 from stanshock.processing.initialize import (
+    InitializeRiemannProblem,
     smoothing_function,
     smoothing_function_gradient,
 )
@@ -118,11 +119,14 @@ def main(
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
+    initialization = InitializeRiemannProblem(
+        geometry, physics_model, state4, state1, xShock
+    )
 
     ss = ShockTube(
         geometry=geometry,
         physics=physics_model,
-        initialization=("riemann", state4, state1, xShock),
+        initialization=initialization,
         boundary_conditions=boundary_conditions,
         cfl=0.9,
         output_every=100,
@@ -148,12 +152,13 @@ def main(
     geometry = Cylinder(
         xf=xf, d_inner=ss.geometry.d_inner, d_outer=d_outer, dlnA_dx=ss.geometry.dlnA_dx
     )
+    initialization.geometry = geometry
     gas1.TPX = T1, p1, "AR:1"
     gas4.TPX = T4, p4, "HE:1"
     ss = ShockTube(
         geometry=geometry,
         physics=physics_model,
-        initialization=("riemann", state4, state1, xShock),
+        initialization=initialization,
         boundary_conditions=boundary_conditions,
         cfl=0.9,
         output_every=100,
@@ -188,12 +193,13 @@ def main(
 
     # recalculate at higher resolution without the insert
     geometry = Cylinder(xf=xf, d_outer=d_outer, dlnA_dx=dlnA_dx)
+    initialization.geometry = geometry
     gas1.TPX = T1, p1, "AR:1"
     gas4.TPX = T4, p4, "HE:1"
     ss = ShockTube(
         geometry=geometry,
         physics=physics_model,
-        initialization=("riemann", state4, state1, xShock),
+        initialization=initialization,
         boundary_conditions=boundary_conditions,
         cfl=0.9,
         output_every=100,

--- a/examples/optimization.py
+++ b/examples/optimization.py
@@ -133,7 +133,6 @@ def main(
         include_boundary_layer=True,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
     )
-    ss.state.gamma = ss.physics.get_gamma(ss.state)
     assert isinstance(ss.geometry, Cylinder)
 
     # Solve

--- a/examples/validation/case1.py
+++ b/examples/validation/case1.py
@@ -11,6 +11,7 @@ from matplotlib import pyplot as plt
 from stanshock.components.shocktube import ShockTube
 from stanshock.numerics.boundary_conditions import BCInput
 from stanshock.physics.thermotable import ThermoTable
+from stanshock.processing.initialize import InitializeRiemannProblem
 from stanshock.processing.probe import Probe
 from stanshock.system.backend import Array
 from stanshock.system.geometry import initialize_geometry
@@ -102,11 +103,14 @@ def main(
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
+    initialization = InitializeRiemannProblem(
+        geometry, physics_model, state4, state1, xShock
+    )
 
     ssbl = ShockTube(
         geometry=geometry,
         physics=physics_model,
-        initialization=("riemann", state4, state1, xShock),
+        initialization=initialization,
         boundary_conditions=boundary_conditions,
         cfl=0.9,
         output_every=100,
@@ -129,7 +133,7 @@ def main(
     ssnbl = ShockTube(
         geometry=geometry,
         physics=physics_model,
-        initialization=("riemann", state4, state1, xShock),
+        initialization=initialization,
         boundary_conditions=boundary_conditions,
         cfl=0.9,
         output_every=100,

--- a/examples/validation/case2.py
+++ b/examples/validation/case2.py
@@ -11,6 +11,7 @@ from matplotlib import pyplot as plt
 from stanshock.components.shocktube import ShockTube
 from stanshock.numerics.boundary_conditions import BCInput
 from stanshock.physics.thermotable import ThermoTable
+from stanshock.processing.initialize import InitializeRiemannProblem
 from stanshock.processing.probe import Probe
 from stanshock.system.backend import Array
 from stanshock.system.geometry import initialize_geometry
@@ -103,11 +104,14 @@ def main(
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
+    initialization = InitializeRiemannProblem(
+        geometry, physics_model, state4, state1, xShock
+    )
 
     ssbl = ShockTube(
         geometry=geometry,
         physics=physics_model,
-        initialization=("riemann", state4, state1, xShock),
+        initialization=initialization,
         boundary_conditions=boundary_conditions,
         cfl=0.9,
         output_every=100,
@@ -130,7 +134,7 @@ def main(
     ssnbl = ShockTube(
         geometry=geometry,
         physics=physics_model,
-        initialization=("riemann", state4, state1, xShock),
+        initialization=initialization,
         boundary_conditions=boundary_conditions,
         cfl=0.9,
         output_every=100,

--- a/examples/validation/case3.py
+++ b/examples/validation/case3.py
@@ -12,6 +12,7 @@ from stanshock.components.shocktube import ShockTube
 from stanshock.numerics.boundary_conditions import BCInput
 from stanshock.physics.thermotable import ThermoTable
 from stanshock.processing.initialize import (
+    InitializeRiemannProblem,
     smoothing_function,
     smoothing_function_gradient,
 )
@@ -154,11 +155,14 @@ def main(
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
+    initialization = InitializeRiemannProblem(
+        geometry, physics_model, state4, state1, xShock
+    )
 
     ssbl = ShockTube(
         geometry=geometry,
         physics=physics_model,
-        initialization=("riemann", state4, state1, xShock),
+        initialization=initialization,
         boundary_conditions=boundary_conditions,
         cfl=0.9,
         output_every=100,
@@ -181,7 +185,7 @@ def main(
     ssnbl = ShockTube(
         geometry=geometry,
         physics=physics_model,
-        initialization=("riemann", state4, state1, xShock),
+        initialization=initialization,
         boundary_conditions=boundary_conditions,
         cfl=0.9,
         output_every=100,

--- a/examples/validation/case4.py
+++ b/examples/validation/case4.py
@@ -11,15 +11,63 @@ from matplotlib import pyplot as plt
 
 from stanshock.components.shocktube import ShockTube
 from stanshock.numerics.boundary_conditions import BCInput
+from stanshock.physics.fluid_base import FluidPhysics, FluidState
 from stanshock.physics.thermotable import ThermoTable
 from stanshock.processing.initialize import InitializeRiemannProblem
 from stanshock.processing.plot import XTDiagram
 from stanshock.processing.probe import Probe
 from stanshock.system.backend import Array
-from stanshock.system.geometry import initialize_geometry
+from stanshock.system.geometry import Geometry, initialize_geometry
 
 
-# =============================================================================
+class InitializePartialFill(InitializeRiemannProblem):
+    def __init__(
+        self,
+        geometry: Geometry,
+        physics: FluidPhysics,
+        left_state: tuple[ct.Solution, float],
+        right_state: tuple[ct.Solution, float],
+        shock_location: float,
+    ) -> None:
+        """Custom initialization routine for partial filling strategy."""
+        super().__init__(geometry, physics, left_state, right_state, shock_location)
+        self.T, self.P = left_state[0].TP
+        self.XN2Lower = 0.80  # assume smearing during fill
+        self.XN2Upper = 1.5 - self.XN2Lower
+        idx = self.geometry.idx_cells
+        xc = self.geometry.xc[idx]
+        dV = self.geometry.volume(0.0, self.geometry.xf)
+        VDriver = np.sum(dV[xc < shock_location])
+        V = np.cumsum(dV)
+        V -= V[0] / 2.0  # center
+        self.VNorms = V / VDriver
+
+    def __call__(self) -> FluidState:
+        state = super().__call__()
+        assert state.density is not None
+        assert state.composition is not None
+        state.gamma = self.physics.get_gamma(state)
+
+        # get gas properties
+        gas = self.physics.gas
+        iHE, iN2 = gas.species_index("HE"), gas.species_index("N2")
+        mt = self.geometry.n_ghost_layers
+
+        for iX, VNorm in enumerate(self.VNorms):
+            if VNorm <= 1.0:
+                # nitrogen and helium
+                X = np.zeros(gas.n_species)
+                XN2 = self.XN2Lower + (self.XN2Upper - self.XN2Lower) * VNorm
+                XHE = 1.0 - XN2
+                X[[iHE, iN2]] = XHE, XN2
+                gas.TPX = self.T, self.P, X
+                state.density[iX + mt] = gas.density
+                state.composition[iX + mt, :] = gas.Y
+                state.gamma[iX + mt] = gas.cp / gas.cv
+
+        return state
+
+
 def get_pressure_data_from_image(fileName):
     """
     function getPressureData
@@ -156,7 +204,7 @@ def main(
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
-    initialization = InitializeRiemannProblem(
+    initialization = InitializePartialFill(
         geometry, physics_model, state4, state1, xShock
     )
 
@@ -170,7 +218,6 @@ def main(
         include_boundary_layer=True,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
     )
-    ssbl.state.gamma = ssbl.physics.get_gamma(ssbl.state)
     ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xf)))  # end wall probe
     diagram_settings = [
         ("pressure", (p1 / 101325, p4 / 101325)),
@@ -180,31 +227,6 @@ def main(
         XTDiagram(ssbl, variable=variable, limits=limits)
         for variable, limits in diagram_settings
     ]
-
-    # adjust for partial filling strategy
-    XN2Lower = 0.80  # assume smearing during fill
-    XN2Upper = 1.5 - XN2Lower
-    idx = ssbl.geometry.idx_cells
-    xc = ssbl.geometry.xc[idx]
-    dV = ssbl.geometry.volume(0.0, ssbl.geometry.xf)
-    VDriver = np.sum(dV[xc < xShock])
-    V = np.cumsum(dV)
-    V -= V[0] / 2.0  # center
-    VNorms = V / VDriver
-    # get gas properties
-    iHE, iN2 = gas4.species_index("HE"), gas4.species_index("N2")
-    mt = ssbl.geometry.n_ghost_layers
-    for iX, VNorm in enumerate(VNorms):
-        if VNorm <= 1.0:
-            # nitrogen and helium
-            X = np.zeros(gas4.n_species)
-            XN2 = XN2Lower + (XN2Upper - XN2Lower) * VNorm
-            XHE = 1.0 - XN2
-            X[[iHE, iN2]] = XHE, XN2
-            gas4.TPX = T4, p4, X
-            ssbl.state.density[iX + mt] = gas4.density
-            ssbl.state.composition[iX + mt, :] = gas4.Y
-            ssbl.state.gamma[iX + mt] = gas4.cp / gas4.cv
 
     # Solve
     t0 = time.perf_counter()
@@ -230,37 +252,11 @@ def main(
         include_boundary_layer=False,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
     )
-    ssnbl.state.gamma = ssnbl.physics.get_gamma(ssnbl.state)
     ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xf)))  # end wall probe
     ssnbl.xt_diagrams += [
         XTDiagram(ssnbl, variable=variable, limits=limits)
         for variable, limits in diagram_settings
     ]
-
-    # adjust for partial filling strategy
-    XN2Lower = 0.80  # assume smearing during fill
-    XN2Upper = 1.5 - XN2Lower
-    idx = ssnbl.geometry.idx_cells
-    xc = ssnbl.geometry.xc[idx]
-    dV = ssnbl.geometry.volume(0.0, ssnbl.geometry.xf)
-    VDriver = np.sum(dV[xc < xShock])
-    V = np.cumsum(dV)
-    V -= V[0] / 2.0  # center
-    VNorms = V / VDriver
-    # get gas properties
-    iHE, iN2 = gas4.species_index("HE"), gas4.species_index("N2")
-    mt = ssnbl.geometry.n_ghost_layers
-    for iX, VNorm in enumerate(VNorms):
-        if VNorm <= 1.0:
-            # nitrogen and helium
-            X = np.zeros(gas4.n_species)
-            XN2 = XN2Lower + (XN2Upper - XN2Lower) * VNorm
-            XHE = 1.0 - XN2
-            X[[iHE, iN2]] = XHE, XN2
-            gas4.TPX = T4, p4, X
-            ssnbl.state.density[iX + mt] = gas4.density
-            ssnbl.state.composition[iX + mt, :] = gas4.Y
-            ssnbl.state.gamma[iX + mt] = gas4.cp / gas4.cv
 
     # Solve
     t0 = time.perf_counter()

--- a/examples/validation/case4.py
+++ b/examples/validation/case4.py
@@ -12,6 +12,7 @@ from matplotlib import pyplot as plt
 from stanshock.components.shocktube import ShockTube
 from stanshock.numerics.boundary_conditions import BCInput
 from stanshock.physics.thermotable import ThermoTable
+from stanshock.processing.initialize import InitializeRiemannProblem
 from stanshock.processing.plot import XTDiagram
 from stanshock.processing.probe import Probe
 from stanshock.system.backend import Array
@@ -155,11 +156,14 @@ def main(
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
+    initialization = InitializeRiemannProblem(
+        geometry, physics_model, state4, state1, xShock
+    )
 
     ssbl = ShockTube(
         geometry=geometry,
         physics=physics_model,
-        initialization=("riemann", state4, state1, xShock),
+        initialization=initialization,
         boundary_conditions=boundary_conditions,
         cfl=0.9,
         output_every=100,
@@ -219,7 +223,7 @@ def main(
     ssnbl = ShockTube(
         geometry=geometry,
         physics=physics_model,
-        initialization=("riemann", state4, state1, xShock),
+        initialization=initialization,
         boundary_conditions=boundary_conditions,
         cfl=0.9,
         output_every=100,

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from stanshock.models.area_change import AreaChange
 from stanshock.models.boundary_layer import BoundaryLayer, SkinFriction
+from stanshock.models.jicf import JICModel
 from stanshock.numerics.boundary_conditions import (
     BCInput,
     BoundaryConditions,
@@ -34,7 +35,7 @@ from stanshock.numerics.time_integration import (
 from stanshock.numerics.viscous_flux import ViscousFlux
 from stanshock.physics.chemistry_source import ChemistrySource, ConstantVolumeChemistry
 from stanshock.physics.fluid_base import FluidPhysics
-from stanshock.processing.initialize import Initialization
+from stanshock.processing.initialize import Initialization, InitializeRestart
 from stanshock.processing.plot import XTDiagram, plot_state
 from stanshock.processing.probe import Probe
 from stanshock.system.backend import Array
@@ -64,7 +65,7 @@ class Combustor:
         source_terms: RightHandSide
         | list[RightHandSide]
         | None = None,  # Catch-all source term(s)
-        injector: RightHandSide | None = None,  # injector model
+        injector: JICModel | None = None,  # injector model
         flux_function: RiemannSolver = hllc_flux_vectorized,
         inviscid_face_extrapolator: type[FaceExtrapolator] = FifthOrderWeno,
         viscous_face_extrapolator: type[FaceExtrapolator] = FirstOrder,
@@ -75,6 +76,8 @@ class Combustor:
         include_diffusion: bool = False,  # exclude diffusion
         thickening: None = None,  # thickening function
         plot_state_interval: int = -1,  # plot the state every n iterations
+        iteration: int = 0,  # Iteration to start from
+        n_restart_interval: int = -1,  # If >0, saves the fluid state to a file every n_restart_interval iterations
     ) -> None:
         """
         initialization of the object with default values. The keyword arguments
@@ -92,6 +95,8 @@ class Combustor:
         self.include_diffusion = include_diffusion
         self.thickening = thickening
         self.plot_state_interval = plot_state_interval
+        self.iteration = iteration
+        self.n_restart_interval = n_restart_interval
 
         # Initialize values which are passed in as None
         self.probes: list[Probe] = [] if probes is None else probes
@@ -108,19 +113,10 @@ class Combustor:
         self.geometry = geometry
         self.geometry.setup_ghost_layers(n_ghost_layers=n_ghost_layers)
 
-        # Set the number of scalars
-        self.n_scalars = self.physics.n_scalars
-        if not self.physics.is_flamelet and self.injector is not None:
-            msg = "JIC injector model requires FPVTable physics."
-            raise Exception(msg)
-
         # Set up boundary conditions
         self.boundary_conditions = set_boundary_conditions(
             boundary_conditions, self.geometry.n_ghost_layers
         )
-
-        # initialize the state
-        self.state = self.initialization()
 
         # Initialize the key physics
         self.inviscid_flux = InviscidFlux(
@@ -137,6 +133,7 @@ class Combustor:
         # Set up time integrators
         integrators: list[TimeIntegrator] = []
         advection = SSPRK3(self.inviscid_flux)
+        chemistry: TimeIntegrator
         if reacting and self.physics.is_flamelet:
             integrators += [
                 HeunsMethod(
@@ -188,10 +185,13 @@ class Combustor:
                 integrators += [HeunsMethod(source_terms)]
 
         if self.injector is not None:
+            if not self.physics.is_flamelet:
+                msg = "JIC injector model requires FPVTable physics."
+                raise Exception(msg)
             integrators += [HeunsMethod(self.injector)]
 
         # Apply Lie splitting approach
-        self.time_integrator = LieSplitting(tuple(integrators))
+        self.time_integrator = LieSplitting(tuple(integrators), update_double_flux=True)
 
         self.F = np.ones(self.geometry.n_cells)  # thickening
 
@@ -253,7 +253,18 @@ class Combustor:
             inputs
                     tFinal=final time
         """
-        iters = 0
+        iters = self.iteration
+
+        # Initialize the fluid state
+        if not hasattr(self, "state"):
+            self.state = self.initialization()
+
+            if isinstance(self.initialization, InitializeRestart):
+                iters = int(self.initialization.groupname)
+            elif self.n_restart_interval > 0:
+                # Save the initial conditions to a file
+                self.state.save(groupname=str(iters))
+
         res_p = np.inf
         gamma_star: Array | None
         e0_star: Array | None
@@ -298,3 +309,12 @@ class Combustor:
                     self,
                     f"figures/anim/test_{iters // self.plot_state_interval:05d}.png",
                 )
+
+            # Periodically save the fluid state
+            if (self.n_restart_interval > 0) and (iters % self.n_restart_interval == 0):
+                self.state.save(groupname=str(iters))
+
+        # Save the final state
+        self.iteration = iters
+        if self.n_restart_interval > 0:
+            self.state.save(groupname="stop")

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any
-
 import numpy as np
 
 from stanshock.models.area_change import AreaChange
@@ -37,12 +34,7 @@ from stanshock.numerics.time_integration import (
 from stanshock.numerics.viscous_flux import ViscousFlux
 from stanshock.physics.chemistry_source import ChemistrySource, ConstantVolumeChemistry
 from stanshock.physics.fluid_base import FluidPhysics
-from stanshock.processing.initialize import (
-    initialize_constant,
-    initialize_diffuse_interface,
-    initialize_isentropic,
-    initialize_riemann_problem,
-)
+from stanshock.processing.initialize import Initialization
 from stanshock.processing.plot import XTDiagram, plot_state
 from stanshock.processing.probe import Probe
 from stanshock.system.backend import Array
@@ -61,7 +53,7 @@ class Combustor:
         physics: FluidPhysics,  # Model handling all fluid property evaluations
         geometry: Geometry,
         boundary_conditions: BoundaryConditions | BCInput,
-        initialization: Sequence[str | Any],  # initialization options
+        initialization: Initialization,  # initialization options
         cfl: float = 1.0,  # stability condition
         t: float = 0.0,  # time
         verbose: bool = True,  # console output switch
@@ -96,6 +88,7 @@ class Combustor:
         self.injector = injector
         self.optimization_iteration = optimization_iteration
         self.physics: FluidPhysics = physics
+        self.initialization: Initialization = initialization
         self.include_diffusion = include_diffusion
         self.thickening = thickening
         self.plot_state_interval = plot_state_interval
@@ -127,22 +120,7 @@ class Combustor:
         )
 
         # initialize the state
-        if initialization[0].lower() == "constant":
-            self.state = initialize_constant(
-                self.geometry, self.physics, *initialization[1:]
-            )
-        elif initialization[0].lower() == "riemann":
-            self.state = initialize_riemann_problem(
-                self.geometry, self.physics, *initialization[1:]
-            )
-        elif initialization[0].lower() == "diffuse_interface":
-            self.state = initialize_diffuse_interface(
-                self.geometry, self.physics, *initialization[1:]
-            )
-        elif initialization[0].lower() == "isentropic":
-            self.state = initialize_isentropic(
-                self.geometry, self.physics, *initialization[1:]
-            )
+        self.state = self.initialization()
 
         # Initialize the key physics
         self.inviscid_flux = InviscidFlux(

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -265,6 +265,10 @@ class Combustor:
                 # Save the initial conditions to a file
                 self.state.save(groupname=str(iters))
 
+            # Update plots at initial condition
+            self.update_probes(iters)
+            self.update_XT_diagrams(iters)
+
         res_p = np.inf
         gamma_star: Array | None
         e0_star: Array | None

--- a/src/stanshock/components/shocktube.py
+++ b/src/stanshock/components/shocktube.py
@@ -79,6 +79,10 @@ class ShockTube(Combustor):
             msg = "Boundary layer terms have not been set."
             raise AttributeError(msg)
 
+        # Initialize the state
+        self.state = self.initialization()
+        self.state.gamma = self.physics.get_gamma(self.state)
+
         assert isinstance(self.geometry, Cylinder)
         geometry: Cylinder = self.geometry
         msg = None

--- a/src/stanshock/models/area_change.py
+++ b/src/stanshock/models/area_change.py
@@ -129,7 +129,13 @@ class AreaChange(FastSlowSource):
             gamma_star=gamma_star,
             e0_star=e0_star,
         )
-        state.pressure = self.physics.get_pressure(state)
+        if gamma_star is not None:
+            # Compute pressure using double-flux method
+            assert e0_star is not None
+            state.pressure = (gamma_star - 1.0) * r * (e_int - e0_star)
+        else:
+            state.pressure = self.physics.get_pressure(state)
+
         state.temperature = self.physics.get_temperature(state)
 
         return np.ravel(state_array_local), state, None, None, None

--- a/src/stanshock/physics/fluid_base.py
+++ b/src/stanshock/physics/fluid_base.py
@@ -5,8 +5,9 @@ from dataclasses import dataclass
 
 import cantera as ct
 import numpy as np
+from h5py import File, Group
 
-from stanshock.system.backend import Array, Composition
+from stanshock.system.backend import Array, Composition, Index
 
 
 @dataclass
@@ -36,6 +37,53 @@ class FluidState:
     e0_star: Array | None = None
 
     _cache_valid: bool = False
+
+    def __getitem__(self, index: Index) -> FluidState:
+        # Enable slicing into a FluidState object like an array
+        if isinstance(index, int):
+            index = np.array([index])
+
+        sliced_data: dict[str, Array] = {
+            k: v[index] for k, v in self.__dict__.items() if isinstance(v, np.ndarray)
+        }
+        shape = (next(iter(sliced_data.values())).shape[0],)
+        return FluidState(shape=shape, _cache_valid=False, **sliced_data)
+
+    def save(
+        self, groupname: str | None = None, filename: str = "fluid_state.hdf5"
+    ) -> None:
+        """Dump the current fluid state to an HDF5-format file.
+
+        Data resides with a group with the given `groupname` or, if not
+        provided, in an incrementally-numbered group.
+        """
+        filehandle: File = File(name=filename, mode="a")
+        if groupname is None:
+            groupname = str(len(filehandle.keys()))
+
+        if groupname in filehandle:
+            # Overwrite any existing groupname
+            del filehandle[groupname]
+
+        group: Group = filehandle.create_group(name=groupname)
+        for key, val in self.__dict__.items():
+            if isinstance(val, np.ndarray):
+                group.create_dataset(name=key, data=val)
+
+    @classmethod
+    def restore(
+        cls, groupname: str | None = None, filename: str = "fluid_state.hdf5"
+    ) -> FluidState:
+        """Initiates a FluidState object from an HDF5-format file."""
+        filehandle: File = File(name=filename, mode="r")
+
+        if groupname is None:
+            groupname = next(iter(filehandle.keys()))
+        group: Group = filehandle.require_group(groupname)
+        loaded_data: dict[str, Array] = {k: v[:] for k, v in group.items()}
+
+        shape = (next(iter(loaded_data.values())).shape[0],)
+        return FluidState(shape=shape, _cache_valid=False, **loaded_data)
 
 
 class FluidPhysics(ABC):

--- a/src/stanshock/processing/initialize.py
+++ b/src/stanshock/processing/initialize.py
@@ -492,3 +492,16 @@ class InitializeIsentropicTotal(Initialization):
         state.velocity = mach * self.physics.get_sound_speed(state)
 
         return state
+
+
+class InitializeRestart(Initialization):
+    def __init__(
+        self,
+        groupname: str = "0",
+        filename: str = "fluid_state.hdf5",
+    ) -> None:
+        self.groupname = groupname
+        self.filename = filename
+
+    def __call__(self) -> FluidState:
+        return FluidState.restore(self.groupname, self.filename)

--- a/src/stanshock/processing/initialize.py
+++ b/src/stanshock/processing/initialize.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from abc import abstractmethod
+
 import cantera as ct
 import numpy as np
 
@@ -10,20 +12,15 @@ from stanshock.utils.isentropic import mach_from_area_ratio, property_ratios
 
 
 def smoothing_function(
-    x: Array,
-    xShock: float,
-    Delta: float,
-    phiLeft: float,
-    phiRight: float,
+    x: Array, xShock: float, Delta: float, phiLeft: float, phiRight: float
 ) -> Array:
-    """
-    This helper function returns the function of the variable smoothed
-    over the interface
-        inputs:
-            x = numpy array of cell centers
-            phiLeft = the value of the variable on the left side
-            phiRight = the value of the variable on the right side
-            xShock = the mean of the shock location
+    """Returns the variable smoothed over the interface.
+
+    inputs:
+        x = numpy array of cell centers
+        phiLeft = the value of the variable on the left side
+        phiRight = the value of the variable on the right side
+        xShock = the mean of the shock location
     """
     dphidx = (phiRight - phiLeft) / Delta
     phi = (phiLeft + phiRight) / 2.0 + dphidx * (x - xShock)
@@ -33,380 +30,465 @@ def smoothing_function(
 
 
 def smoothing_function_gradient(
-    x: Array,
-    xShock: float,
-    Delta: float,
-    phiLeft: float,
-    phiRight: float,
+    x: Array, xShock: float, Delta: float, phiLeft: float, phiRight: float
 ) -> Array:
+    """Returns the derivative of the smoothing function.
+
+    inputs:
+        x = numpy array of cell centers
+        phiLeft = the value of the variable on the left side
+        phiRight = the value of the variable on the right side
+        xShock = the mean of the shock location
     """
-    This helper function returns the derivative of the smoothing function
-        inputs:
-            x = numpy array of cell centers
-            phiLeft = the value of the variable on the left side
-            phiRight = the value of the variable on the right side
-            xShock = the mean of the shock location
-    """
-    dphidx = (phiRight - phiLeft) / Delta
-    dphidx = np.ones(len(x)) * dphidx
+    dphidx = np.full_like(x, (phiRight - phiLeft) / Delta)
     dphidx[x < (xShock - Delta / 2.0)] = 0.0
     dphidx[x > (xShock + Delta / 2.0)] = 0.0
     return dphidx
 
 
-def initialize_constant(
-    geometry: Geometry,
-    physics: FluidPhysics,
-    gas: ct.Solution,
-    u: float,
-) -> FluidState:
-    """
-    This helper function initializes a constant state
+class Initialization:
+    def __init__(self, geometry: Geometry, physics: FluidPhysics) -> None:
+        self.geometry = geometry
+        self.physics = physics
+
+    @property
+    def geometry(self) -> Geometry:
+        return self._geometry
+
+    @geometry.setter
+    def geometry(self, geometry: Geometry) -> None:
+        self._geometry = geometry
+
+    @abstractmethod
+    def __call__(self) -> FluidState:
+        """Compute an initial state for the fluid."""
+
+
+class InitializeConstant(Initialization):
+    def __init__(
+        self,
+        geometry: Geometry,
+        physics: FluidPhysics,
+        gas: ct.Solution,
+        u: float,
+    ) -> None:
+        """Initializes a constant state.
+
         inputs:
             gas = Cantera solution object at the desired thermodynamic state
             u = velocity
-    """
-    n = geometry.n_cells
-    ones = np.ones(n)
+        """
+        super().__init__(geometry, physics)
 
-    # Initialize state
-    composition = physics.get_composition(gas.Y[None, :])
+        # Initialize state
+        self.density: float = gas.density_mass
+        self.pressure: float = gas.P
+        self.gamma: float = gas.cp / gas.cv
+        self.composition = self.physics.get_composition(gas.Y[None, :])
+        self.u: float = u
 
-    return FluidState(
-        shape=(n,),
-        density=ones * gas.density,
-        velocity=ones * u,
-        pressure=ones * gas.P,
-        gamma=ones * (gas.cp / gas.cv),
-        composition=np.tile(composition, (n, 1)),
-    )
+    def __call__(self) -> FluidState:
+        n = self.geometry.n_cells
+        ones = np.ones(n)
+
+        return FluidState(
+            shape=(n,),
+            density=ones * self.density,
+            velocity=ones * self.u,
+            pressure=ones * self.pressure,
+            gamma=ones * self.gamma,
+            composition=np.tile(self.composition, (n, 1)),
+        )
 
 
-def initialize_riemann_problem(
-    geometry: Geometry,
-    physics: FluidPhysics,
-    left_state: tuple[ct.Solution, float],
-    right_state: tuple[ct.Solution, float],
-    shock_location: float,
-) -> FluidState:
-    """
-    This helper function initializes a Riemann Problem
+class InitializeRiemannProblem(Initialization):
+    def __init__(
+        self,
+        geometry: Geometry,
+        physics: FluidPhysics,
+        left_state: tuple[ct.Solution, float],
+        right_state: tuple[ct.Solution, float],
+        shock_location: float,
+    ) -> None:
+        """Initialize a Riemann Problem.
+
         inputs:
             left_state = a tuple containing the Cantera solution object at the
-                         the desired thermodynamic state and the velocity:
-                         (canteraSolution,u)
+                            the desired thermodynamic state and the velocity:
+                            (canteraSolution,u)
             right_state = a tuple containing the Cantera solution object at the
-                          the desired thermodynamic state and the velocity:
-                          (canteraSolution,u)
+                            the desired thermodynamic state and the velocity:
+                            (canteraSolution,u)
             shock_location = x-location of the shock within the domain
-    """
-    gas = physics.gas
-    left_gas, u_left = left_state
-    right_gas, u_right = right_state
-    if (
-        left_gas.species_names != gas.species_names
-        or right_gas.species_names != gas.species_names
-    ):
-        msg = "Input gasses must be the same as the initialized gas."
-        raise Exception(msg)
+        """
+        gas = physics.gas
+        left_gas, u_left = left_state
+        right_gas, u_right = right_state
+        if (
+            left_gas.species_names != gas.species_names
+            or right_gas.species_names != gas.species_names
+        ):
+            msg = "Input gasses must be the same as the initialized gas."
+            raise Exception(msg)
 
-    # Initialize with left state
-    state = initialize_constant(geometry, physics, left_gas, u_left)
+        self.shock_location = shock_location
+        self.left = InitializeConstant(geometry, physics, left_gas, u_left)
+        self.right = InitializeConstant(geometry, physics, right_gas, u_right)
+        super().__init__(geometry, physics)
 
-    # Override with right state
-    state_right = initialize_constant(geometry, physics, right_gas, u_right)
+    @property
+    def geometry(self) -> Geometry:
+        return self._geometry
 
-    index = np.where(geometry.xc >= shock_location)[0]
-    state.density[index] = state_right.density[index]
-    state.velocity[index] = state_right.velocity[index]
-    state.pressure[index] = state_right.pressure[index]
-    state.composition[index, :] = state_right.composition[index, :]
-    state.gamma[index] = state_right.gamma[index]
+    @geometry.setter
+    def geometry(self, geometry: Geometry) -> None:
+        self._geometry = geometry
+        self.left.geometry = geometry
+        self.right.geometry = geometry
 
-    return state
+    def __call__(self) -> FluidState:
+        # Initialize with left state
+        state = self.left()
+        assert state.density is not None
+        assert state.velocity is not None
+        assert state.pressure is not None
+        assert state.composition is not None
+        assert state.gamma is not None
+
+        # Override with right state
+        state_right = self.right()
+        assert state_right.density is not None
+        assert state_right.velocity is not None
+        assert state_right.pressure is not None
+        assert state_right.composition is not None
+        assert state_right.gamma is not None
+
+        index = np.where(self.geometry.xc >= self.shock_location)[0]
+        state.density[index] = state_right.density[index]
+        state.velocity[index] = state_right.velocity[index]
+        state.pressure[index] = state_right.pressure[index]
+        state.composition[index, :] = state_right.composition[index, :]
+        state.gamma[index] = state_right.gamma[index]
+
+        return state
 
 
-def initialize_diffuse_interface(
-    geometry: Geometry,
-    physics: FluidPhysics,
-    left_state: tuple[ct.Solution, float],
-    right_state: tuple[ct.Solution, float],
-    shock_location: float,
-    delta_smoothing: float,
-) -> FluidState:
-    """
-    This helper function initializes an interface smoothed over a distance
+class InitializeDiffuseInterface(Initialization):
+    def __init__(
+        self,
+        geometry: Geometry,
+        physics: FluidPhysics,
+        left_state: tuple[ct.Solution, float],
+        right_state: tuple[ct.Solution, float],
+        shock_location: float,
+        delta_smoothing: float,
+    ) -> None:
+        """Initialize an interface smoothed over a distance.
+
         inputs:
             left_state = a tuple containing the Cantera solution object at the
-                         the desired thermodynamic state and the velocity:
-                         (canteraSolution,u)
+                        the desired thermodynamic state and the velocity:
+                        (canteraSolution,u)
             right_state = a tuple containing the Cantera solution object at the
-                          the desired thermodynamic state and the velocity:
-                          (canteraSolution,u)
+                        the desired thermodynamic state and the velocity:
+                        (canteraSolution,u)
             shock_location = x-location of the shock within the domain
             delta_smoothing = distance over which the interface is smoothed linearly
-    """
-    gas = physics.gas
-    left_gas, u_left = left_state
-    right_gas, u_right = right_state
-    if (
-        left_gas.species_names != gas.species_names
-        or right_gas.species_names != gas.species_names
-    ):
-        msg = "Input gasses must be the same as the initialized gas."
-        raise Exception(msg)
+        """
+        super().__init__(geometry, physics)
+        gas = physics.gas
+        left_gas, u_left = left_state
+        right_gas, u_right = right_state
+        if (
+            left_gas.species_names != gas.species_names
+            or right_gas.species_names != gas.species_names
+        ):
+            msg = "Input gasses must be the same as the initialized gas."
+            raise Exception(msg)
 
-    gamma_left = left_gas.cp / left_gas.cv
-    gamma_right = right_gas.cp / right_gas.cv
-    composition_left = physics.get_composition(left_gas.Y)
-    composition_right = physics.get_composition(right_gas.Y)
-
-    # Smooth transition between left and right states
-    r = smoothing_function(
-        geometry.xc,
-        shock_location,
-        delta_smoothing,
-        left_gas.density,
-        right_gas.density,
-    )
-    geometry.u = smoothing_function(
-        geometry.xc, shock_location, delta_smoothing, u_left, u_right
-    )
-    p = smoothing_function(
-        geometry.xc, shock_location, delta_smoothing, left_gas.P, right_gas.P
-    )
-    gamma = smoothing_function(
-        geometry.xc, shock_location, delta_smoothing, gamma_left, gamma_right
-    )
-
-    composition = np.zeros((geometry.n_cells, geometry.n_scalars))
-    for kSp in range(geometry.n_scalars):
-        composition[:, kSp] = smoothing_function(
-            geometry.xc,
-            shock_location,
-            delta_smoothing,
-            composition_left[:, kSp],
-            composition_right[:, kSp],
+        self.shock_location = shock_location
+        self.delta_smoothing = delta_smoothing
+        self.left = (
+            left_gas.density_mass,
+            u_left,
+            left_gas.P,
+            left_gas.cp / left_gas.cv,
+            physics.get_composition(left_gas.Y),
+        )
+        self.right = (
+            right_gas.density_mass,
+            u_right,
+            right_gas.P,
+            right_gas.cp / right_gas.cv,
+            physics.get_composition(right_gas.Y),
         )
 
-    return FluidState(
-        shape=(geometry.n_cells,),
-        density=r,
-        pressure=p,
-        gamma=gamma,
-        composition=composition,
-    )
+    def __call__(self) -> FluidState:
+        # Smooth transition between left and right states
+        xc = self.geometry.xc
+        n_cells = self.geometry.n_cells
+        n_scalars = self.physics.n_scalars
 
+        rl, ul, pl, gl, Yl = self.left
+        rr, ur, pr, gr, Yr = self.right
+        r = smoothing_function(xc, self.shock_location, self.delta_smoothing, rl, rr)
+        u = smoothing_function(xc, self.shock_location, self.delta_smoothing, ul, ur)
+        p = smoothing_function(xc, self.shock_location, self.delta_smoothing, pl, pr)
+        g = smoothing_function(xc, self.shock_location, self.delta_smoothing, gl, gr)
 
-def initialize_isentropic(
-    geometry: Geometry,
-    physics: FluidPhysics,
-    inflow_state: ct.Solution,
-    throat_area: float | None = None,
-    subsonic_inflow: bool = True,
-    subsonic_outflow: bool = False,
-) -> FluidState:
-    """
-    Applies isentropic flow relations to set initial conditions.
+        composition = np.zeros((n_cells, n_scalars))
+        for kSp in range(n_scalars):
+            composition[:, kSp] = smoothing_function(
+                xc, self.shock_location, self.delta_smoothing, Yl[kSp], Yr[kSp]
+            )
 
-    Note that this formulation is only valid for a flow with constant specific
-    heat ratio. It could be extended for non-ideal gas equations of state
-    """
-    # Get inflow properties for the gas
-    g = inflow_state.cp / inflow_state.cv
-    P_in = inflow_state.P
-    rho_in = inflow_state.density_mass
-    composition = physics.get_composition(inflow_state.Y)
-
-    # Get cross-sectional area from the geometry
-    area = geometry.area(0.0, geometry.xf)
-    assert isinstance(area, np.ndarray)
-
-    # If throat area is not given, assume choked flow
-    min_area: float = area.min()
-    throat_area = min_area if throat_area is None else min(min_area, throat_area)
-    area_ratio = area / throat_area
-    inflow_area_ratio = area_ratio[0]
-    area_ratio_min = area_ratio.min()
-    choked_flow = area_ratio_min < 1.0
-    if choked_flow:
-        # Adjust throat area based on choked flow - will affect requested boundary conditions
-        inflow_area_ratio /= area_ratio_min
-        area_ratio /= area_ratio_min
-        throat_area /= area_ratio_min
-    elif subsonic_inflow != subsonic_outflow:
-        print(
-            "Warning: Subsonic/supersonic transition requested, but flow may not be choked.\n"
-            + f"Minimum area ratio = {area_ratio_min}."
+        return FluidState(
+            shape=(n_cells,),
+            density=r,
+            pressure=p,
+            velocity=u,
+            gamma=g,
+            composition=composition,
         )
 
-    # Get area ratios at cell centers
-    area = geometry.area(0.0, geometry.xc)
-    area_ratio = area / throat_area
 
-    # Solve for allowable Mach numbers corresponding to given area ratio
-    subsonic_mach: Array = mach_from_area_ratio(area_ratio, g, subsonic=True)
-    supersonic_mach: Array = mach_from_area_ratio(area_ratio, g, subsonic=False)
+class InitializeIsentropic(Initialization):
+    def __init__(
+        self,
+        geometry: Geometry,
+        physics: FluidPhysics,
+        inflow_state: ct.Solution,
+        throat_area: float | None = None,
+        subsonic_inflow: bool = True,
+        subsonic_outflow: bool = False,
+    ) -> None:
+        """Applies isentropic flow relations to set initial conditions.
 
-    # Combine into one mach profile
-    mach = subsonic_mach
-    if subsonic_inflow != subsonic_outflow:
-        idx = np.argmin(area_ratio)
+        Note that this formulation is only valid for a flow with constant specific
+        heat ratio. It could be extended for non-ideal gas equations of state.
+        """
+        super().__init__(geometry, physics)
+        self.throat_area = throat_area
+        self.subsonic_inflow = subsonic_inflow
+        self.subsonic_outflow = subsonic_outflow
 
-        if subsonic_inflow:
-            mach[idx + 1 :] = supersonic_mach[idx + 1 :]
-        else:
-            mach[:idx] = supersonic_mach[:idx]
-    elif not subsonic_inflow and not subsonic_outflow:
-        mach = supersonic_mach
+        # Get inflow properties for the gas
+        self.g = inflow_state.cp / inflow_state.cv
+        self.P_in = inflow_state.P
+        self.rho_in = inflow_state.density_mass
+        self.composition = physics.get_composition(inflow_state.Y)
 
-    # Get stagnation properties based on inflow
-    inflow_mach: float = mach_from_area_ratio(
-        inflow_area_ratio, g, subsonic=subsonic_inflow
-    )[0]
-    _, inflow_Pratio, inflow_rhoratio = property_ratios(inflow_mach, g)
+    def __call__(self) -> FluidState:
+        # Get cross-sectional area from the geometry
+        area = self.geometry.area(0.0, self.geometry.xf)
+        assert isinstance(area, np.ndarray)
 
-    # Get properties throughout
-    _, Pratio_profile, rhoratio_profile = property_ratios(mach, g)
-
-    n = geometry.n_cells
-    state = FluidState(
-        shape=(n,),
-        pressure=P_in / inflow_Pratio * Pratio_profile,
-        density=rho_in / inflow_rhoratio * rhoratio_profile,
-        gamma=g * np.ones((n,)),
-        composition=np.broadcast_to(composition, (n, composition.shape[0])).copy(),
-    )
-    state.velocity = mach * physics.get_sound_speed(state)
-    state.temperature = physics.get_temperature(state)
-
-    return state
-
-
-def initialize_isentropic_total(
-    geometry: Geometry,
-    physics: FluidPhysics,
-    total_state: ct.Solution,
-    inflow_mach: float | None = None,
-    inflow_pressure: float | None = None,
-    outflow_pressure: float | None = None,
-    throat_area: float | None = None,
-    subsonic_inflow: bool = True,
-    subsonic_outflow: bool = True,
-) -> FluidState:
-    """
-    Applies isentropic flow relations to set initial conditions.
-
-    Note that this formulation is only valid for a flow with constant specific
-    heat ratio. It could be extended for non-ideal gas equations of state
-    """
-    # Get cross-sectional area from the geometry
-    x = geometry.x
-    area = geometry.area(0.0, x)
-    assert isinstance(area, np.ndarray)
-
-    # Get stagnation properties for the gas
-    g = total_state.cp / total_state.cv
-    Pt = total_state.P
-    Tt = total_state.T
-    rhot = total_state.density_mass
-    composition = physics.get_composition(total_state.Y)
-
-    # Determine throat area from given inputs
-    inputs_done = False
-    too_many_inputs_prefix = "Too many inputs specified. "
-    error_msg = "Must specify one of inflow_velocity, inflow_pressure, outflow_pressure, or throat area."
-
-    if throat_area is not None:
-        inputs_done = True
-
-    if inflow_mach is not None:
-        Tratio, _, _ = property_ratios(inflow_mach, g)
-        inflow_area = area[0]
-        throat_area = (
-            inflow_area
-            * inflow_mach
-            * (2.0 * Tratio / (g + 1)) ** (0.5 * (g + 1) / (g - 1))
+        # If throat area is not given, assume choked flow
+        min_area: float = area.min()
+        self.throat_area = (
+            min_area if self.throat_area is None else min(min_area, self.throat_area)
         )
-        if inputs_done:
-            raise ValueError(too_many_inputs_prefix + error_msg)
-        inputs_done = True
+        area_ratio = area / self.throat_area
+        inflow_area_ratio = area_ratio[0]
+        area_ratio_min = area_ratio.min()
+        choked_flow = area_ratio_min < 1.0
+        if choked_flow:
+            # Adjust throat area based on choked flow - will affect requested boundary conditions
+            inflow_area_ratio /= area_ratio_min
+            area_ratio /= area_ratio_min
+            self.throat_area /= area_ratio_min
+        elif self.subsonic_inflow != self.subsonic_outflow:
+            print(
+                "Warning: Subsonic/supersonic transition requested, but flow may not be choked.\n"
+                + f"Minimum area ratio = {area_ratio_min}."
+            )
 
-    if inflow_pressure is not None:
-        Pratio = inflow_pressure / Pt
-        Tratio = Pratio ** ((g - 1.0) / g)
-        inflow_mach = np.sqrt(2.0 * (1.0 / Tratio - 1.0) / (g - 1.0))
-        inflow_area = area[0]
-        throat_area = (
-            inflow_area
-            * inflow_mach
-            * (2.0 * Tratio / (g + 1)) ** (0.5 * (g + 1) / (g - 1))
+        # Get area ratios at cell centers
+        area = self.geometry.area(0.0, self.geometry.xc)
+        assert isinstance(area, np.ndarray)
+        area_ratio = area / self.throat_area
+
+        # Solve for allowable Mach numbers corresponding to given area ratio
+        subsonic_mach: Array = mach_from_area_ratio(area_ratio, self.g, subsonic=True)
+        supersonic_mach: Array = mach_from_area_ratio(
+            area_ratio, self.g, subsonic=False
         )
-        if inputs_done:
-            raise ValueError(too_many_inputs_prefix + error_msg)
-        inputs_done = True
 
-    if outflow_pressure is not None:
-        Pratio = outflow_pressure / Pt
-        Tratio = Pratio ** ((g - 1.0) / g)
-        outflow_mach = np.sqrt(2.0 * (1.0 / Tratio - 1.0) / (g - 1.0))
-        outflow_area = area[-1]
-        throat_area = (
-            outflow_area
-            * outflow_mach
-            * (2.0 * Tratio / (g + 1)) ** (0.5 * (g + 1) / (g - 1))
+        # Combine into one mach profile
+        mach = subsonic_mach
+        if self.subsonic_inflow != self.subsonic_outflow:
+            idx = np.argmin(area_ratio)
+
+            if self.subsonic_inflow:
+                mach[idx + 1 :] = supersonic_mach[idx + 1 :]
+            else:
+                mach[:idx] = supersonic_mach[:idx]
+        elif not self.subsonic_inflow and not self.subsonic_outflow:
+            mach = supersonic_mach
+
+        # Get stagnation properties based on inflow
+        inflow_mach: float = mach_from_area_ratio(
+            inflow_area_ratio, self.g, subsonic=self.subsonic_inflow
+        )[0]
+        _, inflow_Pratio, inflow_rhoratio = property_ratios(inflow_mach, self.g)
+
+        # Get properties throughout
+        _, Pratio_profile, rhoratio_profile = property_ratios(mach, self.g)
+
+        n = self.geometry.n_cells
+        state = FluidState(
+            shape=(n,),
+            pressure=self.P_in / inflow_Pratio * Pratio_profile,
+            density=self.rho_in / inflow_rhoratio * rhoratio_profile,
+            gamma=self.g * np.ones((n,)),
+            composition=np.broadcast_to(
+                self.composition, (n, self.composition.shape[0])
+            ).copy(),
         )
-        if inputs_done:
-            raise ValueError(too_many_inputs_prefix + error_msg)
-        inputs_done = True
+        state.velocity = mach * self.physics.get_sound_speed(state)
+        state.temperature = self.physics.get_temperature(state)
 
-    if not inputs_done:
-        raise ValueError(error_msg)
+        return state
 
-    # Get the permissible subsonic and supersonic Mach numbers throughout
-    # the domain from the area ratio
-    assert isinstance(throat_area, float)
-    area_ratio = area / throat_area
 
-    # Check if flow is choked
-    area_ratio_min = area_ratio.min()
-    choked_flow = area_ratio_min <= 1.0
-    if choked_flow:
-        # Adjust throat area based on choked flow - will affect requested boundary conditions
-        area_ratio /= area_ratio_min
-        throat_area /= area_ratio_min
+class InitializeIsentropicTotal(Initialization):
+    def __init__(
+        self,
+        geometry: Geometry,
+        physics: FluidPhysics,
+        total_state: ct.Solution,
+        inflow_mach: float | None = None,
+        inflow_pressure: float | None = None,
+        outflow_pressure: float | None = None,
+        throat_area: float | None = None,
+        subsonic_inflow: bool = True,
+        subsonic_outflow: bool = True,
+    ) -> None:
+        """Applies isentropic flow relations to set initial conditions.
 
-    # Solve for allowable Mach numbers corresponding to given area ratio
-    subsonic_mach: Array = mach_from_area_ratio(area_ratio, g, subsonic=True)
-    supersonic_mach: Array = mach_from_area_ratio(area_ratio, g, subsonic=False)
+        Note that this formulation is only valid for a flow with constant specific
+        heat ratio. It could be extended for non-ideal gas equations of state
+        """
+        super().__init__(geometry, physics)
+        self.inflow_mach = inflow_mach
+        self.inflow_pressure = inflow_pressure
+        self.outflow_pressure = outflow_pressure
+        self.throat_area = throat_area
+        self.subsonic_inflow = subsonic_inflow
+        self.subsonic_outflow = subsonic_outflow
 
-    # Combine into one mach profile
-    mach = subsonic_mach
-    if subsonic_inflow != subsonic_outflow:
-        if not choked_flow:
-            msg = f"Subsonic-supersonic transition requested, but flow is not choked. {area_ratio_min = }"
-            raise ValueError(msg)
-        idx = np.argmin(area_ratio)
+        # Get stagnation properties for the gas
+        self.g = total_state.cp / total_state.cv
+        self.Pt = total_state.P
+        self.Tt = total_state.T
+        self.rhot = total_state.density_mass
+        self.composition = physics.get_composition(total_state.Y)
 
-        if subsonic_inflow:
-            mach[idx:] = supersonic_mach[idx:]
-        else:
-            mach[:idx] = supersonic_mach[:idx]
-    elif not subsonic_inflow and not subsonic_outflow:
-        mach = supersonic_mach
+    def __call__(self) -> FluidState:
+        # Get cross-sectional area from the geometry
+        x = self.geometry.xc
+        area = self.geometry.area(0.0, x)
+        assert isinstance(area, np.ndarray)
 
-    # Get properties throughout
-    Tratio_profile, Pratio_profile, rhoratio_profile = property_ratios(mach, g)
+        # Determine throat area from given inputs
+        inputs_done = False
+        too_many_inputs_prefix = "Too many inputs specified. "
+        error_msg = "Must specify one of inflow_velocity, inflow_pressure, outflow_pressure, or throat area."
 
-    n = geometry.n
-    state = FluidState(
-        shape=(n,),
-        temperature=Tt * Tratio_profile,
-        pressure=Pt * Pratio_profile,
-        density=rhot * rhoratio_profile,
-        gamma=g * np.ones((n,)),
-        composition=np.broadcast_to(composition, (n, composition.shape[0])).copy(),
-    )
-    state.velocity = mach * physics.get_sound_speed(state)
+        if self.throat_area is not None:
+            inputs_done = True
 
-    return state
+        if self.inflow_mach is not None:
+            Tratio, _, _ = property_ratios(self.inflow_mach, self.g)
+            inflow_area = area[0]
+            self.throat_area = (
+                inflow_area
+                * self.inflow_mach
+                * (2.0 * Tratio / (self.g + 1)) ** (0.5 * (self.g + 1) / (self.g - 1))
+            )
+            if inputs_done:
+                raise ValueError(too_many_inputs_prefix + error_msg)
+            inputs_done = True
+
+        if self.inflow_pressure is not None:
+            Pratio = self.inflow_pressure / self.Pt
+            Tratio = Pratio ** ((self.g - 1.0) / self.g)
+            inflow_mach = np.sqrt(2.0 * (1.0 / Tratio - 1.0) / (self.g - 1.0))
+            inflow_area = area[0]
+            self.throat_area = (
+                inflow_area
+                * inflow_mach
+                * (2.0 * Tratio / (self.g + 1)) ** (0.5 * (self.g + 1) / (self.g - 1))
+            )
+            if inputs_done:
+                raise ValueError(too_many_inputs_prefix + error_msg)
+            inputs_done = True
+
+        if self.outflow_pressure is not None:
+            Pratio = self.outflow_pressure / self.Pt
+            Tratio = Pratio ** ((self.g - 1.0) / self.g)
+            outflow_mach = np.sqrt(2.0 * (1.0 / Tratio - 1.0) / (self.g - 1.0))
+            outflow_area = area[-1]
+            self.throat_area = (
+                outflow_area
+                * outflow_mach
+                * (2.0 * Tratio / (self.g + 1)) ** (0.5 * (self.g + 1) / (self.g - 1))
+            )
+            if inputs_done:
+                raise ValueError(too_many_inputs_prefix + error_msg)
+            inputs_done = True
+
+        if not inputs_done:
+            raise ValueError(error_msg)
+
+        # Get the permissible subsonic and supersonic Mach numbers throughout
+        # the domain from the area ratio
+        assert isinstance(self.throat_area, float)
+        area_ratio = area / self.throat_area
+
+        # Check if flow is choked
+        area_ratio_min = area_ratio.min()
+        choked_flow = area_ratio_min <= 1.0
+        if choked_flow:
+            # Adjust throat area based on choked flow - will affect requested boundary conditions
+            area_ratio /= area_ratio_min
+            self.throat_area /= area_ratio_min
+
+        # Solve for allowable Mach numbers corresponding to given area ratio
+        subsonic_mach: Array = mach_from_area_ratio(area_ratio, self.g, subsonic=True)
+        supersonic_mach: Array = mach_from_area_ratio(
+            area_ratio, self.g, subsonic=False
+        )
+
+        # Combine into one mach profile
+        mach = subsonic_mach
+        if self.subsonic_inflow != self.subsonic_outflow:
+            if not choked_flow:
+                msg = f"Subsonic-supersonic transition requested, but flow is not choked. {area_ratio_min = }"
+                raise ValueError(msg)
+            idx = np.argmin(area_ratio)
+
+            if self.subsonic_inflow:
+                mach[idx:] = supersonic_mach[idx:]
+            else:
+                mach[:idx] = supersonic_mach[:idx]
+        elif not self.subsonic_inflow and not self.subsonic_outflow:
+            mach = supersonic_mach
+
+        # Get properties throughout
+        Tratio_profile, Pratio_profile, rhoratio_profile = property_ratios(mach, self.g)
+
+        n = self.geometry.n_cells
+        state = FluidState(
+            shape=(n,),
+            temperature=self.Tt * Tratio_profile,
+            pressure=self.Pt * Pratio_profile,
+            density=self.rhot * rhoratio_profile,
+            gamma=self.g * np.ones((n,)),
+            composition=np.broadcast_to(
+                self.composition, (n, self.composition.shape[0])
+            ).copy(),
+        )
+        state.velocity = mach * self.physics.get_sound_speed(state)
+
+        return state

--- a/src/stanshock/processing/initialize.py
+++ b/src/stanshock/processing/initialize.py
@@ -494,6 +494,61 @@ class InitializeIsentropicTotal(Initialization):
         return state
 
 
+class InitializeInterpolate(Initialization):
+    def __init__(
+        self,
+        geometry: Geometry,
+        x_init: Array,
+        state_init: FluidState,
+    ) -> None:
+        """Interpolate properties onto a new mesh."""
+        self.geometry = geometry
+        self.x_init = x_init
+        self.state_init = state_init
+
+    def __call__(self) -> FluidState:
+        x_new = self.geometry.xc
+        shape = (len(x_new),)
+
+        # Straightforward to interpolate 1D data
+        interpolated_data = {
+            key: np.interp(x_new, self.x_init, val)
+            for key, val in self.state_init.__dict__.items()
+            if isinstance(val, np.ndarray) and val.ndim == 1
+        }
+
+        # Special treatment for 2D data
+        comp_init = self.state_init.composition
+        if comp_init is not None:
+            nsp = comp_init.shape[1]
+            composition = np.zeros((*shape, nsp))
+            for isp in range(nsp):
+                composition[:, isp] = np.interp(x_new, self.x_init, comp_init[:, isp])
+            interpolated_data["composition"] = composition
+
+        return FluidState(shape=shape, _cache_valid=False, **interpolated_data)
+
+
+class InitializeCanteraArray(InitializeInterpolate):
+    def __init__(
+        self,
+        geometry: Geometry,
+        sol: ct.SolutionArray,
+    ) -> None:
+        """Interpolate properties from a Cantera SolutionArray."""
+        self.geometry = geometry
+
+        self.x_init = sol.grid
+        self.state_init = FluidState(
+            shape=(len(self.x_init),),
+            density=sol.density_mass,
+            pressure=sol.P,
+            temperature=sol.T,
+            composition=sol.Y,
+            velocity=sol.velocity,
+        )
+
+
 class InitializeRestart(Initialization):
     def __init__(
         self,

--- a/src/stanshock/processing/plot.py
+++ b/src/stanshock/processing/plot.py
@@ -52,8 +52,6 @@ class XTDiagram:
         self.t: list[float] = []  # list of times
         self.mdot: list[float] = []  # list of mass flow rates
 
-        self.update(domain)
-
     def update(self, domain: Combustor) -> None:
         """
         This method updates the XT diagram.

--- a/src/stanshock/processing/probe.py
+++ b/src/stanshock/processing/probe.py
@@ -55,7 +55,7 @@ class Probe:
                         self.probeLocation,
                     )
                 )
-                for kSp in range(domain.n_scalars)
+                for kSp in range(domain.physics.n_scalars)
             ]
         )
         self.Y.append(YProbe)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,11 @@ import pytest
 from cantera import Solution
 
 from stanshock.components.combustor import Combustor
-from stanshock.numerics.boundary_conditions import FreezeCells, SpecifiedFace
+from stanshock.numerics.boundary_conditions import BCInput, FreezeCells, SpecifiedFace
 from stanshock.physics.cantera_interface import CanteraInterface
 from stanshock.physics.fluid_base import FluidPhysics
 from stanshock.physics.thermotable import ThermoTable
+from stanshock.processing.initialize import InitializeIsentropic
 from stanshock.system.backend import Array
 from stanshock.system.geometry import (
     Geometry,
@@ -178,7 +179,7 @@ def isentropic_flow(
     # Reinitialize Solution object to inflow conditions
     nsp = gas.n_species
     gas.TPY = 3000.0, 30e6, np.ones((nsp,)) / nsp
-    bcs = {
+    bcs: BCInput = {
         "left": FreezeCells(location="left"),
         "right": FreezeCells(location="right"),
     }
@@ -187,11 +188,19 @@ def isentropic_flow(
     area = geometry.area(0.0, geometry.xf)
     throat_area: float = area[0] / choking_area_ratio
     subsonic_outflow = area.min() - throat_area > 1e-3
+    initialization = InitializeIsentropic(
+        geometry=geometry,
+        physics=fluid_physics,
+        inflow_state=gas,
+        throat_area=throat_area,
+        subsonic_inflow=True,
+        subsonic_outflow=subsonic_outflow,
+    )
 
     # Set up simulation object
     return Combustor(
         boundary_conditions=bcs,
         geometry=geometry,
-        initialization=("isentropic", gas, throat_area, True, subsonic_outflow),
+        initialization=initialization,
         physics=fluid_physics,
     )

--- a/tests/processing/test_initialization.py
+++ b/tests/processing/test_initialization.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from cantera import Solution
+
+from stanshock.physics.cantera_interface import CanteraInterface
+from stanshock.processing.initialize import (
+    InitializeConstant,
+    InitializeDiffuseInterface,
+    InitializeIsentropic,
+    InitializeRiemannProblem,
+)
+from stanshock.system.geometry import Geometry, initialize_geometry
+from stanshock.utils.isentropic import area_ratio_from_mach
+
+
+@pytest.fixture
+def const_geometry() -> Geometry:
+    xf = np.linspace(0.0, 10.0, 51, dtype=np.float64)
+
+    return initialize_geometry(xf=xf, area=5.0)
+
+
+@pytest.fixture
+def left_state(mechanism: Path) -> tuple[Solution, float]:
+    gas = Solution(mechanism)
+    gas.TP = 300.0, 10132.50
+    return (gas, 10.0)
+
+
+@pytest.fixture
+def right_state(mechanism: Path) -> tuple[Solution, float]:
+    gas = Solution(mechanism)
+    gas.TP = 1000.0, 101325.0
+    return (gas, 1.0)
+
+
+@pytest.fixture
+def physics(left_state: tuple[Solution, float]) -> CanteraInterface:
+    return CanteraInterface(left_state[0])
+
+
+def test_constant_init(
+    gas: Solution, const_geometry: Geometry, physics: CanteraInterface
+) -> None:
+    state = InitializeConstant(const_geometry, physics, gas, 10.0)()
+
+    assert state.density is not None
+    assert np.all(state.density == gas.density_mass)
+
+
+def test_riemann_init(
+    left_state: tuple[Solution, float],
+    right_state: tuple[Solution, float],
+    const_geometry: Geometry,
+    physics: CanteraInterface,
+) -> None:
+    x_midpoint = 0.5 * (const_geometry.xf[0] + const_geometry.xf[-1])
+    state = InitializeRiemannProblem(
+        const_geometry, physics, left_state, right_state, x_midpoint
+    )()
+
+    assert state.density is not None
+    idx_left = np.where(const_geometry.xc < x_midpoint)[0]
+    assert np.all(state.density[idx_left] == left_state[0].density_mass)
+    idx_right = np.where(const_geometry.xc > x_midpoint)[0]
+    assert np.all(state.density[idx_right] == right_state[0].density_mass)
+
+
+def test_diffuse_interface_init(
+    left_state: tuple[Solution, float],
+    right_state: tuple[Solution, float],
+    const_geometry: Geometry,
+    physics: CanteraInterface,
+) -> None:
+    x_midpoint = 0.5 * (const_geometry.xf[0] + const_geometry.xf[-1])
+    dx_smooth = 0.05 * (const_geometry.xf[-1] - const_geometry.xf[0])
+    state = InitializeDiffuseInterface(
+        const_geometry, physics, left_state, right_state, x_midpoint, dx_smooth
+    )()
+
+    assert state.density is not None
+
+    x_left = x_midpoint - 0.5 * dx_smooth
+    rho_left = left_state[0].density_mass
+    idx_left = np.where(const_geometry.xc < x_left)[0]
+    assert np.all(state.density[idx_left] == rho_left)
+
+    x_right = x_midpoint + 0.5 * dx_smooth
+    rho_right = right_state[0].density_mass
+    idx_right = np.where(const_geometry.xc > x_right)[0]
+    assert np.all(state.density[idx_right] == rho_right)
+
+    idx_interpolate = np.where(
+        np.logical_and(const_geometry.xc > x_left, const_geometry.xc < x_right)
+    )[0]
+    dphidx = (rho_right - rho_left) / dx_smooth
+    dx = const_geometry.dx
+    if isinstance(dx, np.ndarray):
+        dx = np.diff(const_geometry.xc[idx_interpolate])
+    assert np.diff(state.density[idx_interpolate]) / dx == pytest.approx(dphidx)
+
+
+def test_isentropic_init(
+    left_state: tuple[Solution, float], physics: CanteraInterface, geometry: Geometry
+) -> None:
+    choking_area_ratio = 10.0
+    gas = left_state[0]
+    area = geometry.area(0.0, geometry.xf)
+    throat_area: float = area[0] / choking_area_ratio
+    subsonic_outflow = area.min() - throat_area > 1e-3
+    state = InitializeIsentropic(
+        geometry=geometry,
+        physics=physics,
+        inflow_state=gas,
+        throat_area=throat_area,
+        subsonic_inflow=True,
+        subsonic_outflow=subsonic_outflow,
+    )()
+
+    # Verify that the Mach numbers match the area ratio
+    assert state.velocity is not None
+    g = gas.cp / gas.cv
+    area_ratio = geometry.area(0.0, geometry.xc) / throat_area
+    mach = state.velocity / physics.get_sound_speed(state)
+    area_ratio_target = area_ratio_from_mach(mach, g)
+
+    assert area_ratio_target == pytest.approx(area_ratio)
+
+    # Verify the inflow and outflow Mach numbers are correct
+    assert mach[-1] < 1.0 if subsonic_outflow else mach[-1] > 1.0

--- a/tests/test_flux.py
+++ b/tests/test_flux.py
@@ -57,7 +57,7 @@ def test_hllc_predicts_constant_flux():
 def test_isentropic_flow_relations(isentropic_flow: Combustor) -> None:
     # Get initial state from given solution
     t = isentropic_flow.t
-    state = isentropic_flow.state
+    state = isentropic_flow.initialization()
     state_array = np.ravel(isentropic_flow.physics.primitive_to_conservative(state))
     gamma_star, e0_star = isentropic_flow.physics.get_double_flux_variables(state)
 


### PR DESCRIPTION
This pull request abstracts the initialization away from the `Combustor` class by creating a common `Initialization` base class and having each available option inherit from that.

Additionally, new functionality has been added to `FluidState`:
- It is now possible to slice into the state, similar to how one would slice into a NumPy array, in order to return a subset of the properties.
- New `save` and `restore` methods dump the current values in a `FluidState` to an HDF5 format file and recreates it from a given group, respectively. These are now used to optionally save the data during a simulation and initialize a simulation from a restart file.

Closes #71 