### PR TITLE
Support Python 3.14 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.14"]
         runs-on: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dependencies = [
   # "types-tqdm",
   "h5py",
   "imageio",
+  # Conditional:
+  "cantera>=3.2.0; python_version>='3.14'",
+  "numba>=0.63.0rc1; python_version>='3.14'",
 ]
 
 [project.urls]


### PR DESCRIPTION
Now that Numba and Cantera support Python 3.14, we can go ahead and pin their minimum versions and start using them in the CI jobs.