### PR TITLE
Correct precompute steps class variable name.

### DIFF
--- a/src/stanshock/models/area_change.py
+++ b/src/stanshock/models/area_change.py
@@ -8,7 +8,7 @@ from stanshock.system.base import FastSlowSource, PrecomputeSteps
 
 
 class AreaChange(FastSlowSource):
-    PRECOMPUTE_STEPS = ("geometry", "physics")
+    REQUIRED_PRECOMPUTE_STEPS = ("geometry", "physics")
 
     def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
         super().__init__(**precompute_steps)

--- a/src/stanshock/models/boundary_layer.py
+++ b/src/stanshock/models/boundary_layer.py
@@ -57,7 +57,7 @@ class SkinFriction:
 
 
 class BoundaryLayer(RightHandSide):
-    PRECOMPUTE_STEPS: tuple[PrecomputeStepName, ...] = ("geometry", "physics")
+    REQUIRED_PRECOMPUTE_STEPS: tuple[PrecomputeStepName, ...] = ("geometry", "physics")
 
     def __init__(
         self,

--- a/src/stanshock/numerics/inviscid_flux.py
+++ b/src/stanshock/numerics/inviscid_flux.py
@@ -274,7 +274,7 @@ def hllc_flux_vectorized(
 
 
 class InviscidFlux(RightHandSide):
-    PRECOMPUTE_STEPS: tuple[PrecomputeStepName, ...] = (
+    REQUIRED_PRECOMPUTE_STEPS: tuple[PrecomputeStepName, ...] = (
         "boundary_conditions",
         "face_extrapolator",
         "geometry",

--- a/src/stanshock/numerics/viscous_flux.py
+++ b/src/stanshock/numerics/viscous_flux.py
@@ -8,7 +8,7 @@ from stanshock.system.base import PrecomputeStepName, PrecomputeSteps, RightHand
 
 
 class ViscousFlux(RightHandSide):
-    PRECOMPUTE_STEPS: tuple[PrecomputeStepName, ...] = (
+    REQUIRED_PRECOMPUTE_STEPS: tuple[PrecomputeStepName, ...] = (
         "geometry",
         "physics",
         "boundary_conditions",

--- a/src/stanshock/physics/chemistry_source.py
+++ b/src/stanshock/physics/chemistry_source.py
@@ -10,7 +10,7 @@ from stanshock.system.base import PrecomputeSteps, RightHandSide
 
 
 class ChemistrySource(RightHandSide):
-    PRECOMPUTE_STEPS = ("geometry", "physics")
+    REQUIRED_PRECOMPUTE_STEPS = ("geometry", "physics")
 
     def __init__(self, **precompute_steps: Unpack[PrecomputeSteps]) -> None:
         super().__init__(**precompute_steps)


### PR DESCRIPTION
At some point I changed `PRECOMPUTE_STEPS` to `REQUIRED_PRECOMPUTE_STEPS` and failed to update it on all of the `RightHandSide` subclasses.