### PR TITLE
Add option to disable double-flux approach.

### DIFF
--- a/examples/sod_problem.py
+++ b/examples/sod_problem.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import TypedDict
+
+import cantera as ct
+import numpy as np
+from matplotlib import pyplot as plt
+from scipy.optimize import fsolve
+
+from stanshock.components.shocktube import ShockTube
+from stanshock.numerics.boundary_conditions import BCInput
+from stanshock.numerics.face_extrapolation import (
+    FaceExtrapolator,
+    FifthOrderWeno,
+    FirstOrder,
+)
+from stanshock.numerics.inviscid_flux import (
+    RiemannSolver,
+    hllc_flux_vectorized,
+    lax_friedrichs_flux,
+)
+from stanshock.physics.fluid_base import FluidState
+from stanshock.physics.thermotable import ThermoTable
+from stanshock.processing.initialize import InitializeRiemannProblem
+from stanshock.system.backend import Array
+from stanshock.system.geometry import Geometry
+
+
+class ShockTubeOptions(TypedDict, total=False):
+    use_double_flux: bool
+    flux_function: RiemannSolver
+    inviscid_face_extrapolator: type[FaceExtrapolator]
+
+
+cases: dict[str, ShockTubeOptions] = {
+    "WENO5, HLLC": {
+        "use_double_flux": False,
+        "flux_function": hllc_flux_vectorized,
+        "inviscid_face_extrapolator": FifthOrderWeno,
+    },
+    "WENO5, HLLC, +DF": {
+        "use_double_flux": True,
+        "flux_function": hllc_flux_vectorized,
+        "inviscid_face_extrapolator": FifthOrderWeno,
+    },
+    "O1, HLLC": {
+        "use_double_flux": False,
+        "flux_function": hllc_flux_vectorized,
+        "inviscid_face_extrapolator": FirstOrder,
+    },
+    "O1, LF": {
+        "use_double_flux": False,
+        "flux_function": lax_friedrichs_flux,
+        "inviscid_face_extrapolator": FirstOrder,
+    },
+}
+
+sod_case: dict[str, float] = {
+    "t_final": 2.0,
+    "L": 10.0,
+    "rhoL": 1.0,
+    "uL": 0.0,
+    "pL": 1.0,
+    "rhoR": 0.125,
+    "uR": 0.0,
+    "pR": 0.1,
+}
+
+
+def analytical_sod_solution(
+    t: float,
+    x: Array,
+    gamma: float = 1.4,
+) -> tuple[Array, Array, Array]:
+    # Initial location of discontinuity
+    x0 = 0.0
+
+    # Initial properties in regions 1 and 4
+    rho4 = sod_case["rhoL"]
+    p4 = sod_case["pL"]
+    u4 = sod_case["uL"]
+
+    rho1 = sod_case["rhoR"]
+    p1 = sod_case["pR"]
+    u1 = sod_case["uR"]
+
+    # Speeds of sound in regions 1 and 4
+    c4 = np.sqrt(gamma * p4 / rho4)
+    c1 = np.sqrt(gamma * p1 / rho1)
+
+    def resid(y: Array) -> Array:
+        # Nonlinear equation to get y = p2/p1
+        C1 = np.sqrt((gamma + 1.0) / (2.0 * gamma) * (y - 1.0) + 1)
+        C2 = (gamma - 1.0) / (2.0 * c4) * (u4 - u1 - c1 / gamma * (y - 1.0) / C1)
+        exponent: float = -2.0 * gamma / (gamma - 1)
+        return np.array(y * (1.0 + C2) ** exponent - p4 / p1)
+
+    y0 = 0.5 * p4 / p1  # initial guess
+    Y = float(fsolve(resid, y0)[0])
+
+    # Region 2:
+    p2 = Y * p1
+    u2 = u1 + c1 / gamma * (p2 / p1 - 1) / np.sqrt(
+        (gamma + 1) / (2 * gamma) * (p2 / p1 - 1) + 1
+    )
+    num = (gamma + 1) / (gamma - 1) + p2 / p1
+    den = 1 + (gamma + 1) / (gamma - 1) * (p2 / p1)
+    c2 = c1 * np.sqrt(p2 / p1 * num / den)
+    # Shock speed
+    V = u1 + c1 * np.sqrt((gamma + 1) / (2 * gamma) * (p2 / p1 - 1) + 1)
+    rho2 = gamma * p2 / c2**2
+
+    # Region 3:
+    p3 = p2
+    u3 = u2
+    c3 = (gamma - 1) / 2 * (u4 - u3 + 2 / (gamma - 1) * c4)
+    rho3 = gamma * p3 / c3**2
+
+    # Expansion fan
+    xe1 = (u4 - c4) * t + x0  # "start" of expansion fan
+    xe2 = t * ((gamma + 1) / 2 * u3 - (gamma - 1) / 2 * u4 - c4) + x0  # end
+
+    # Location of shock
+    xs = V * t + x0
+    # Location of contact
+    xc = u2 * t + x0
+
+    # Initialize with properties left of expansion fan (region 4)
+    u = np.full_like(x, u4)
+    p = np.full_like(x, p4)
+    rho = np.full_like(x, rho4)
+
+    # Expansion fan
+    idx = np.where(np.logical_and(x > xe1, x <= xe2))[0]
+    u[idx] = 2 / (gamma + 1) * ((x[idx] - x0) / t + (gamma - 1) / 2 * u4 + c4)
+    c = u[idx] - (x[idx] - x0) / t
+    p[idx] = p4 * (c / c4) ** (2 * gamma / (gamma - 1))
+    rho[idx] = gamma * p[idx] / c**2
+
+    # Between expansion fan and and contact discontinuity (region 3)
+    idx = np.where(np.logical_and(x > xe2, x <= xc))[0]
+    u[idx] = u3
+    p[idx] = p3
+    rho[idx] = rho3
+
+    # Between the contact discontinuity and the shock (region 2)
+    idx = np.where(np.logical_and(x > xc, x <= xs))[0]
+    u[idx] = u2
+    p[idx] = p2
+    rho[idx] = rho2
+
+    # Right of the shock (region 1)
+    idx = np.where(x > xs)[0]
+    u[idx] = u1
+    p[idx] = p1
+    rho[idx] = rho1
+
+    return p, rho, u
+
+
+# Get mechanism path relative to this script
+mech_file = Path(__file__).resolve().parent / "../data/mechanisms/Nitrogen.yaml"
+
+# Set up the Cantera Solutions for the left and right states
+gas = ct.Solution(mech_file)
+Tref = 600.0  # K
+Pref = 101325.0  # Pa
+gas.TP = Tref, Pref
+g = gas.cp / gas.cv
+Wm = gas.mean_molecular_weight
+R = ct.gas_constant / Wm
+rhoref = Pref / (R * Tref)
+
+# Dimensionalize the case parameters
+Lref = np.sqrt(g / 1.4 * Pref / rhoref)
+gas_left = ct.Solution(mech_file)
+gas_left.DP = sod_case["rhoL"] * rhoref, sod_case["pL"] * Pref
+left_state = (gas_left, sod_case["uL"])
+
+gas_right = ct.Solution(mech_file)
+gas_right.DP = sod_case["rhoR"] * rhoref, sod_case["pR"] * Pref
+right_state = (gas_right, sod_case["uR"])
+
+# Set up geometry
+L = sod_case["L"]
+n_cells = 200  # mesh resolution
+xf = np.linspace(-0.5 * L * Lref, 0.5 * L * Lref, n_cells + 1)
+geometry = Geometry(xf, area=1.0)
+
+# Get analytical solution on fine mesh
+t_final = sod_case["t_final"]
+x_analytical = np.linspace(-0.5 * L, L, 2001)
+p_analytical, rho_analytical, u_analytical = analytical_sod_solution(
+    t_final, x_analytical, g
+)
+
+# Set up solver parameters
+boundary_conditions: BCInput = {"left": "reflecting", "right": "reflecting"}
+physics = ThermoTable(gas_left)
+initialization = InitializeRiemannProblem(
+    geometry, physics, left_state, right_state, 0.0
+)
+
+final_states: dict[str, tuple[Array, FluidState]] = {}
+for case_name, case_options in cases.items():
+    print(f"Solving Sod shock tube problem {case_name}")
+    case = ShockTube(
+        geometry=geometry,
+        physics=physics,
+        initialization=initialization,
+        boundary_conditions=boundary_conditions,
+        cfl=0.9,
+        output_every=100,
+        **case_options,
+    )
+
+    # Solve
+    t0 = time.perf_counter()
+    case.advance_simulation(t_final)
+    t1 = time.perf_counter()
+    print("The process took ", t1 - t0)
+
+    # Store the state
+    idx = geometry.idx_cells
+    x = geometry.xc[idx] / Lref
+    state = case.state[idx]
+    final_states[case_name] = (x, state)
+
+# Plot the results
+for ylabel in [r"$\rho$", "p", "u"]:
+    ystring = ylabel.replace("\\", "").replace("$", "")
+    y = np.zeros_like(x_analytical)
+
+    fig, ax = plt.subplots(figsize=(8.0, 6.4))
+    ax.tick_params(axis="both", which="major", labelsize="18")
+
+    # Plot analytical solution
+    if ystring == "rho":
+        y = rho_analytical
+    elif ystring == "p":
+        y = p_analytical
+    elif ystring == "u":
+        y = u_analytical
+    ax.plot(x_analytical, y, "k", ls="--", lw=2, label="Analytical")
+
+    # Plot simulation results
+    for case_name, (x, state) in final_states.items():
+        if ystring == "rho":
+            assert state.density is not None
+            y = state.density / rhoref
+        elif ystring == "p":
+            assert state.pressure is not None
+            y = state.pressure / Pref
+        elif ystring == "u":
+            assert state.velocity is not None
+            y = state.velocity / Lref
+
+        ax.plot(x, y, lw=2, label=case_name)
+
+    ax.set_xlabel("x", fontsize=18)
+    ax.set_ylabel(ylabel, fontsize=18)
+    ax.legend(loc="best", fontsize=18)
+
+    fig.tight_layout()
+    fig.savefig(f"sod_{ystring}.png")
+    plt.close()

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -59,6 +59,7 @@ class Combustor:
         t: float = 0.0,  # time
         verbose: bool = True,  # console output switch
         output_every: int = 1,  # number of iterations of simulation advancement between logging updates
+        use_double_flux: bool = True,  # Toggle the double-flux approach on or off
         include_boundary_layer: bool = False,  # flag to include boundary layer terms
         wall_temperature: float | None = None,  # wall temperature (needed for BL)
         skin_friction_coefficient: SkinFriction | None = None,  # skin friction functor
@@ -88,6 +89,7 @@ class Combustor:
         self.t = t
         self.verbose = verbose
         self.output_every = output_every
+        self.use_double_flux = use_double_flux
         self.injector = injector
         self.optimization_iteration = optimization_iteration
         self.physics: FluidPhysics = physics
@@ -270,9 +272,10 @@ class Combustor:
             self.update_XT_diagrams(iters)
 
         res_p = np.inf
-        gamma_star: Array | None
-        e0_star: Array | None
-        gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
+        gamma_star: Array | None = None
+        e0_star: Array | None = None
+        if self.use_double_flux:
+            gamma_star, e0_star = self.physics.get_double_flux_variables(self.state)
         state_array = self.physics.primitive_to_conservative(self.state)
         self.shape_full: tuple[int, ...] = state_array.shape
         state_array = np.ravel(state_array)

--- a/src/stanshock/models/area_change.py
+++ b/src/stanshock/models/area_change.py
@@ -130,13 +130,14 @@ class AreaChange(FastSlowSource):
             e0_star=e0_star,
         )
         if gamma_star is not None:
-            # Compute pressure using double-flux method
+            # Compute pressure using double-flux method, then temperature from pressure
             assert e0_star is not None
             state.pressure = (gamma_star - 1.0) * r * (e_int - e0_star)
+            state.temperature = self.physics.get_temperature(state)
         else:
+            # Temperature from internal energy, pressure from temperature
+            state.temperature = self.physics.get_temperature(state)
             state.pressure = self.physics.get_pressure(state)
-
-        state.temperature = self.physics.get_temperature(state)
 
         return np.ravel(state_array_local), state, None, None, None
 

--- a/src/stanshock/numerics/face_extrapolation.py
+++ b/src/stanshock/numerics/face_extrapolation.py
@@ -449,39 +449,46 @@ class FifthOrderWeno(FaceExtrapolator):
         assert state.velocity is not None
         assert state.pressure is not None
         assert state.composition is not None
-        assert state.gamma_star is not None
-        assert state.e0_star is not None
+
+        gamma_star: Array | None = None
+        e0_star: Array | None = None
+        if state.gamma_star is not None:
+            gamma: Array = state.gamma_star
+            gamma_star = np.stack(
+                (
+                    state.gamma_star[self.index_face_left],
+                    state.gamma_star[self.index_face_right],
+                ),
+                axis=0,
+            )
+            assert state.e0_star is not None
+            e0_star = np.stack(
+                (
+                    state.e0_star[self.index_face_left],
+                    state.e0_star[self.index_face_right],
+                ),
+                axis=0,
+            )
+        else:
+            assert state.gamma is not None
+            gamma = state.gamma
 
         face_states_array: Array = weno5(
             r=state.density,
             u=state.velocity,
             p=state.pressure,
             Y=state.composition,
-            gamma=state.gamma_star,
+            gamma=gamma,
             n_ghost_layers=self.n_ghost_layers,
             n_scalars_rho_sum=self.n_scalars_rho_sum,
         )
 
-        n_faces: int = state.shape[0]
-
         return FluidState(
-            shape=(2, n_faces),
+            shape=face_states_array.shape[:2],
             density=face_states_array[:, :, 0],
             velocity=face_states_array[:, :, 1],
             pressure=face_states_array[:, :, 2],
             composition=face_states_array[:, :, 3:],
-            gamma_star=np.stack(
-                (
-                    state.gamma_star[self.index_face_left],
-                    state.gamma_star[self.index_face_right],
-                ),
-                axis=0,
-            ),
-            e0_star=np.stack(
-                (
-                    state.e0_star[self.index_face_left],
-                    state.e0_star[self.index_face_right],
-                ),
-                axis=0,
-            ),
+            gamma_star=gamma_star,
+            e0_star=e0_star,
         )

--- a/src/stanshock/numerics/inviscid_flux.py
+++ b/src/stanshock/numerics/inviscid_flux.py
@@ -13,7 +13,6 @@ from stanshock.system.base import PrecomputeStepName, PrecomputeSteps, RightHand
 mn = 2  # number of 1D Euler equations
 
 # Type signatures for numba
-double1D = double[:]
 double2D = double[:, :]
 double3D = double[:, :, :]
 
@@ -21,7 +20,7 @@ double3D = double[:, :, :]
 RiemannSolver: TypeAlias = Callable[[Array, Array, Array, Array, Array, Array], Array]
 
 
-@njit(double2D(double2D, double2D, double2D, double3D, double1D, double1D))
+@njit(double2D(double2D, double2D, double2D, double3D, double2D, double2D))
 def lax_friedrichs_flux(
     rLR: Array, uLR: Array, pLR: Array, YLR: Array, gamma: Array, e0: Array
 ) -> Array:
@@ -33,8 +32,8 @@ def lax_friedrichs_flux(
             pLR=array containing left and right pressure states [nLR,nFaces]
             YLR=array containing left and right scalar states
                 [nLR,nFaces,nSc]
-            gamma=array containing the specific heat [nFaces]
-            eo=array containing the reference internal energy [nFaces]
+            gamma=array containing the specific heat [nLR,nFaces]
+            e0=array containing the reference internal energy [nLR,nFaces]
         return:
             F=modeled Euler fluxes [nFaces,mn+nSc]
     """
@@ -45,8 +44,8 @@ def lax_friedrichs_flux(
     lambdaMax = 0.0
     for iFace in range(nFaces):
         a = max(
-            np.sqrt(gamma[iFace] * pLR[0, iFace] / rLR[0, iFace]),
-            np.sqrt(gamma[iFace] * pLR[1, iFace] / rLR[1, iFace]),
+            np.sqrt(gamma[0, iFace] * pLR[0, iFace] / rLR[0, iFace]),
+            np.sqrt(gamma[1, iFace] * pLR[1, iFace] / rLR[1, iFace]),
         )
         u = max(abs(uLR[0, iFace]), abs(uLR[1, iFace]))
         lambdaMax = max(lambdaMax, u + a)
@@ -57,8 +56,8 @@ def lax_friedrichs_flux(
         for iFace in range(nFaces):
             FLR[K, iFace, 0] = rLR[K, iFace] * uLR[K, iFace] ** 2.0 + pLR[K, iFace]
             FLR[K, iFace, 1] = uLR[K, iFace] * (
-                gamma[iFace] / (gamma[iFace] - 1) * pLR[K, iFace]
-                + rLR[K, iFace] * (e0[iFace] + 0.5 * uLR[K, iFace] ** 2.0)
+                gamma[K, iFace] / (gamma[K, iFace] - 1) * pLR[K, iFace]
+                + rLR[K, iFace] * (e0[K, iFace] + 0.5 * uLR[K, iFace] ** 2.0)
             )
             for kSc in range(nSc):
                 FLR[K, iFace, mn + kSc] = (
@@ -71,8 +70,8 @@ def lax_friedrichs_flux(
     for iFace in range(nFaces):
         for K in range(nLR):
             U[K, 0] = rLR[K, iFace] * uLR[K, iFace]
-            U[K, 1] = pLR[K, iFace] / (gamma[iFace] - 1.0) + rLR[K, iFace] * (
-                e0[iFace] + 0.5 * uLR[K, iFace] ** 2.0
+            U[K, 1] = pLR[K, iFace] / (gamma[K, iFace] - 1.0) + rLR[K, iFace] * (
+                e0[K, iFace] + 0.5 * uLR[K, iFace] ** 2.0
             )
             for kSc in range(nSc):
                 U[K, mn + kSc] = rLR[K, iFace] * YLR[K, iFace, kSc]
@@ -82,7 +81,7 @@ def lax_friedrichs_flux(
     return F
 
 
-@njit(double2D(double2D, double2D, double2D, double3D, double1D, double1D))
+@njit(double2D(double2D, double2D, double2D, double3D, double2D, double2D))
 def hllc_flux(
     rLR: Array, uLR: Array, pLR: Array, YLR: Array, gamma: Array, e0: Array
 ) -> Array:
@@ -94,8 +93,8 @@ def hllc_flux(
             pLR=array containing left and right pressure states [nLR,nFaces]
             YLR=array containing left and right scalar states
                 [nLR,nFaces,nSc]
-            gamma=array containing the specific heat [nFaces]
-            eo=array containing the reference internal energy [nFaces]
+            gamma=array containing the specific heat [nLR,nFaces]
+            e0=array containing the reference internal energy [nLR,nFaces]
         return:
             F=modeled Euler fluxes [nFaces,mn+nSc]
     """
@@ -108,8 +107,8 @@ def hllc_flux(
     SLR = np.empty((2, nFaces))
     SStar = np.empty(nFaces)
     for iFace in range(nFaces):
-        aLR[0, iFace] = np.sqrt(gamma[iFace] * pLR[0, iFace] / rLR[0, iFace])
-        aLR[1, iFace] = np.sqrt(gamma[iFace] * pLR[1, iFace] / rLR[1, iFace])
+        aLR[0, iFace] = np.sqrt(gamma[0, iFace] * pLR[0, iFace] / rLR[0, iFace])
+        aLR[1, iFace] = np.sqrt(gamma[1, iFace] * pLR[1, iFace] / rLR[1, iFace])
         aBar = 0.5 * (aLR[0, iFace] + aLR[1, iFace])
         pBar = 0.5 * (pLR[0, iFace] + pLR[1, iFace])
         rBar = 0.5 * (rLR[0, iFace] + rLR[1, iFace])
@@ -118,8 +117,8 @@ def hllc_flux(
         qLR[0, iFace] = (
             np.sqrt(
                 1.0
-                + (gamma[iFace] + 1.0)
-                / (2.0 * gamma[iFace])
+                + (gamma[0, iFace] + 1.0)
+                / (2.0 * gamma[0, iFace])
                 * (pStar / pLR[0, iFace] - 1.0)
             )
             if pStar > pLR[0, iFace]
@@ -128,8 +127,8 @@ def hllc_flux(
         qLR[1, iFace] = (
             np.sqrt(
                 1.0
-                + (gamma[iFace] + 1.0)
-                / (2.0 * gamma[iFace])
+                + (gamma[1, iFace] + 1.0)
+                / (2.0 * gamma[1, iFace])
                 * (pStar / pLR[1, iFace] - 1.0)
             )
             if pStar > pLR[1, iFace]
@@ -151,8 +150,8 @@ def hllc_flux(
         for iFace in range(nFaces):
             FLR[K, iFace, 0] = rLR[K, iFace] * uLR[K, iFace] ** 2.0 + pLR[K, iFace]
             FLR[K, iFace, 1] = uLR[K, iFace] * (
-                gamma[iFace] / (gamma[iFace] - 1) * pLR[K, iFace]
-                + rLR[K, iFace] * (e0[iFace] + 0.5 * uLR[K, iFace] ** 2.0)
+                gamma[K, iFace] / (gamma[K, iFace] - 1) * pLR[K, iFace]
+                + rLR[K, iFace] * (e0[K, iFace] + 0.5 * uLR[K, iFace] ** 2.0)
             )
             for kSc in range(nSc):
                 FLR[K, iFace, mn + kSc] = (
@@ -179,11 +178,11 @@ def hllc_flux(
             pFace = pLR[K, iFace]
             for kSc in range(nSc):
                 YFace[kSc] = YLR[K, iFace, kSc]
-            gammaFace = gamma[iFace]
+            gammaFace = gamma[K, iFace]
             SFace = SLR[K, iFace]
             # conservative variable vector
             U[0] = rFace * uFace
-            U[1] = pFace / (gammaFace - 1.0) + rFace * (e0[iFace] + 0.5 * uFace**2.0)
+            U[1] = pFace / (gammaFace - 1.0) + rFace * (e0[K, iFace] + 0.5 * uFace**2.0)
             for kSc in range(nSc):
                 U[mn + kSc] = rFace * YFace[kSc]
             # star conservative variable vector
@@ -208,8 +207,10 @@ def hllc_flux_vectorized(
     """Vectorized version of HLLC flux based on DoubleFlux-1D implementation."""
     nLR, nFaces = rLR.shape
 
-    aLR = np.sqrt(gamma[None, :] * pLR / rLR)
-    ELR = pLR / (gamma[None, :] - 1.0) + rLR * (e0[None, :] + 0.5 * uLR**2)
+    # aLR = np.sqrt(gamma[None, :] * pLR / rLR)
+    # ELR = pLR / (gamma[None, :] - 1.0) + rLR * (e0[None, :] + 0.5 * uLR**2)
+    aLR = np.sqrt(gamma * pLR / rLR)
+    ELR = pLR / (gamma - 1.0) + rLR * (e0 + 0.5 * uLR**2)
 
     FLR = np.concatenate(
         (
@@ -238,7 +239,9 @@ def hllc_flux_vectorized(
         idx = np.where(pStar > pLR[K])[0]
         qLR[K, idx] = np.sqrt(
             1.0
-            + (gamma[idx] + 1.0) / (2.0 * gamma[idx]) * (pStar[idx] / pLR[K, idx] - 1.0)
+            + (gamma[K, idx] + 1.0)
+            / (2.0 * gamma[K, idx])
+            * (pStar[idx] / pLR[K, idx] - 1.0)
         )
     sLR[0] = uLR[0] - aLR[0] * qLR[0]
     sLR[1] = uLR[1] + aLR[1] * qLR[1]
@@ -306,18 +309,43 @@ class InviscidFlux(RightHandSide):
         assert face_states.velocity is not None
         assert face_states.pressure is not None
         assert face_states.composition is not None
+
+        if face_states.gamma_star is None:
+            # Standard approach: One flux evaluation at each face.
+            assert self.physics is not None
+            gamma = self.physics.get_gamma(face_states)
+            e0 = self.physics.get_internal_energy(face_states)
+            e0_star = e0 - face_states.pressure / (face_states.density * (gamma - 1))
+
+            face_flux: Array = self.riemann_solver(
+                face_states.density,
+                face_states.velocity,
+                face_states.pressure,
+                face_states.composition,
+                gamma,
+                e0_star,
+            )
+
+            # Allow any SpecifiedFlux BCs to directly override face fluxes
+            if self.boundary_conditions is not None:
+                face_flux = self.boundary_conditions.update_face_flux(time, face_flux)
+
+            return np.ravel((face_flux[:-1, :] - face_flux[1:, :]) / self.dx)
+
+        # Double-flux approach: Separate flux evaluation for left and right sides.
         assert face_states.gamma_star is not None
         assert face_states.e0_star is not None
 
         # Flux from face on cell's left side, using double-flux variables
         # from cell on the face's right side
+        pad_width = ((0, 1), (0, 0))
         left_face_flux: Array = self.riemann_solver(
             face_states.density,
             face_states.velocity,
             face_states.pressure,
             face_states.composition,
-            face_states.gamma_star[1, :],
-            face_states.e0_star[1, :],
+            np.pad(face_states.gamma_star[[1], :], pad_width, "edge"),
+            np.pad(face_states.e0_star[[1], :], pad_width, "edge"),
         )
         # Flux from face on cell's right side, using double-flux variables
         # from cell on the face's left side
@@ -326,8 +354,8 @@ class InviscidFlux(RightHandSide):
             face_states.velocity,
             face_states.pressure,
             face_states.composition,
-            face_states.gamma_star[0, :],
-            face_states.e0_star[0, :],
+            np.pad(face_states.gamma_star[[0], :], pad_width, "edge"),
+            np.pad(face_states.e0_star[[0], :], pad_width, "edge"),
         )
 
         # Allow any SpecifiedFlux BCs to directly override face fluxes

--- a/src/stanshock/physics/flamelet.py
+++ b/src/stanshock/physics/flamelet.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import h5py
 import numpy as np
 from cantera import Solution
@@ -38,7 +40,7 @@ class FPVTable(FluidPhysics):
 
     def __init__(
         self,
-        filename: str,
+        filename: Path | str,
         gas: Solution,
         ox_def: Composition | None = None,
         fuel_def: Composition | None = None,
@@ -54,7 +56,7 @@ class FPVTable(FluidPhysics):
         self.n_scalars_rho_sum: int = 1
         self.scalar_names = ["density", "mixture fraction", "progress variable"]
         self.is_flamelet = True
-        self.filename: str = filename
+        self.filename: str = filename.name if isinstance(filename, Path) else filename
         self.p_correction: bool = p_correction
         self.T_correction: bool = T_correction
         with h5py.File(filename, "r") as f:
@@ -114,8 +116,8 @@ class FPVTable(FluidPhysics):
     def set_state(self, state: FluidState) -> FluidState:
         """Get the flamelet table coordinates from the composition."""
         assert state.composition is not None
-        Z = state.mixture_fraction = state.composition[:, 1]
-        C = state.progress_variable = state.composition[:, 2]
+        Z = state.mixture_fraction = state.composition[..., 1]
+        C = state.progress_variable = state.composition[..., 2]
         state.normalized_progress_variable = self.get_normalized_progress_variable(Z, C)
         return state
 

--- a/src/stanshock/physics/fluid_base.py
+++ b/src/stanshock/physics/fluid_base.py
@@ -38,7 +38,7 @@ class FluidState:
 
     _cache_valid: bool = False
 
-    def __getitem__(self, index: Index) -> FluidState:
+    def __getitem__(self, index: Index | int) -> FluidState:
         # Enable slicing into a FluidState object like an array
         if isinstance(index, int):
             index = np.array([index])
@@ -327,6 +327,10 @@ class FluidPhysics(ABC):
             # Compute pressure using double-flux method
             assert e0_star is not None
             state.pressure = (gamma_star - 1.0) * r * (e_int - e0_star)
+        else:
+            # Compute the temperature from the internal energy, then compute pressure
+            state.temperature = self.get_temperature(state)
+            state.pressure = self.get_pressure(state)
 
         return self.set_state(state)
 

--- a/src/stanshock/system/base.py
+++ b/src/stanshock/system/base.py
@@ -196,7 +196,11 @@ class RightHandSide:
         avg_face_states: FluidState | None = None
         if self.face_extrapolator is not None:
             assert state is not None
-            state.gamma_star, state.e0_star = gamma_star, e0_star
+            if gamma_star is not None:
+                state.gamma_star, state.e0_star = gamma_star, e0_star
+            else:
+                assert self.physics is not None
+                state.gamma = self.physics.get_gamma(state)
             face_states = self.face_extrapolator(state)
             if self.boundary_conditions is not None:
                 face_states = self.boundary_conditions.update_face_states(
@@ -342,7 +346,7 @@ class CombinedSource(RightHandSide):
         precompute_steps: PrecomputeSteps = {}
         for step in required_steps:
             for source in self.sources:
-                if step in dir(source):
+                if step in source.REQUIRED_PRECOMPUTE_STEPS:
                     precompute_steps[step] = getattr(source, step)
                     break
 

--- a/tests/test_flux.py
+++ b/tests/test_flux.py
@@ -22,8 +22,8 @@ def test_lax_friedrich_predicts_constant_flux():
         uLR=np.array([[u], [u]]),
         pLR=np.array([[p], [p]]),
         YLR=np.array([[[Y]], [[Y]]]),
-        gamma=np.array([gamma]),
-        e0=np.array([e0]),
+        gamma=np.array([[gamma], [gamma]]),
+        e0=np.array([[e0], [e0]]),
     )[0]
     H = gamma * p / (gamma - 1.0) + r * (e0 + 0.5 * u**2.0)
     expected_flux = np.array([r * u**2 + p, H * u, r * Y * u])
@@ -40,13 +40,14 @@ def test_hllc_predicts_constant_flux():
     num_faces = 10
     num_sides = 2
     num_species = 1
+    shape = (num_sides, num_faces)
     flux = hllc_flux(
-        rLR=r * np.ones((num_sides, num_faces)),
-        uLR=u * np.ones((num_sides, num_faces)),
-        pLR=p * np.ones((num_sides, num_faces)),
-        YLR=Y * np.ones((num_sides, num_faces, num_species)),
-        gamma=gamma * np.ones(num_faces),
-        e0=e0 * np.ones(num_faces),
+        rLR=np.full(shape, r),
+        uLR=np.full(shape, u),
+        pLR=np.full(shape, p),
+        YLR=np.full((num_sides, num_faces, num_species), Y),
+        gamma=np.full(shape, gamma),
+        e0=np.full(shape, e0),
     )
     H = gamma * p / (gamma - 1.0) + r * (e0 + 0.5 * u**2.0)
     expected_flux = np.array([r * u**2 + p, H * u, r * Y * u])[np.newaxis, ...]


### PR DESCRIPTION
Initializing a `Combustor` with `use_double_flux=False` will now skip the double-flux variable calculations. Temperature will be computed from the internal energy instead of having pressure computed from the double-flux variables, and a single inviscid flux is computed at the cell faces.