### PR TITLE
Plotting facilities overhaul

### DIFF
--- a/data/stylelib/publication.mplstyle
+++ b/data/stylelib/publication.mplstyle
@@ -1,0 +1,12 @@
+text.usetex: True
+font.family: serif
+font.serif: Computer Modern Roman
+axes.xmargin: 0
+axes.ymargin: 0
+font.size: 14          # controls default text sizes
+axes.titlesize: 14     # fontsize of the axes title
+axes.labelsize: 16     # fontsize of the x and y labels
+xtick.labelsize: 14    # fontsize of the tick labels
+ytick.labelsize: 14    # fontsize of the tick labels
+legend.fontsize: 12    # legend fontsize
+figure.titlesize: 18   # fontsize of the figure title

--- a/examples/hyshot_ii.py
+++ b/examples/hyshot_ii.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Unpack
 
 import cantera as ct
-import matplotlib.pyplot as plt
 import numpy as np
 
 from stanshock.components.combustor import Combustor
@@ -11,45 +10,10 @@ from stanshock.numerics.boundary_conditions import BCInput, SpecifiedFace
 from stanshock.physics.fluid_base import FluidState
 from stanshock.physics.thermotable import ThermoTable
 from stanshock.processing.initialize import InitializeConstant
+from stanshock.processing.plot import plot_state
 from stanshock.system.backend import Array
 from stanshock.system.base import PrecomputeSteps, RightHandSide
 from stanshock.system.geometry import Box
-
-plt.rcParams.update(
-    {
-        "text.usetex": True,
-        "font.family": "serif",
-        "font.serif": ["Computer Modern Roman"],
-    }
-)
-plt.rcParams["axes.xmargin"] = 0
-plt.rcParams["axes.ymargin"] = 0
-
-XSMALL_SIZE = 12
-SMALL_SIZE = 14
-MEDIUM_SIZE = 16
-BIGGER_SIZE = 18
-
-plt.rc("font", size=SMALL_SIZE)  # controls default text sizes
-plt.rc("axes", titlesize=SMALL_SIZE)  # fontsize of the axes title
-plt.rc("axes", labelsize=MEDIUM_SIZE)  # fontsize of the x and y labels
-plt.rc("xtick", labelsize=SMALL_SIZE)  # fontsize of the tick labels
-plt.rc("ytick", labelsize=SMALL_SIZE)  # fontsize of the tick labels
-plt.rc("legend", fontsize=XSMALL_SIZE)  # legend fontsize
-plt.rc("figure", titlesize=BIGGER_SIZE)  # fontsize of the figure title
-
-# Plotting utilities
-scale = 1e3
-
-
-def add_h_plot(ax):
-    ax1 = ax.twinx()
-    ax1.plot(xf * scale, h * scale, "k", linestyle="--")
-    ax1.axhline(0, color="k", linestyle="--")
-    ax1.set_aspect("equal")
-    ax1.set_ylabel("h [mm]")
-    return ax1
-
 
 # Chemistry
 mech = "../data/mechanisms/h2_boivin_9sp_12r_mod.yaml"
@@ -204,74 +168,4 @@ ss.advance_simulation(t_end)
 
 
 # Plot the results
-def plot_sim(ss: Combustor) -> None:
-    assert ss.state.density is not None
-    assert ss.state.velocity is not None
-    assert ss.state.pressure is not None
-    assert ss.state.composition is not None
-    idx = ss.geometry.idx_cells
-    xc = ss.geometry.xc[idx] * scale
-    area = ss.geometry.area(ss.t, ss.geometry.xc[idx])
-    rho = ss.state.density[idx]
-    u = ss.state.velocity[idx]
-    p = ss.state.pressure[idx]
-    Y = ss.state.composition[idx]
-    T = ss.physics.get_temperature(ss.state)[idx]
-    c = ss.physics.get_sound_speed(ss.state)[idx]
-    M = u / c
-    mdot = rho * u * area
-    mdot_f = 4.4e-3  # kg/s
-    Y_f = mdot_f / (mdot_f + mdot_a)
-
-    fig, ax = plt.subplots(7, 1, sharex=True, figsize=(6, 8))
-    # ax[0].plot(xc, rho)
-    # ax[0].set_ymargin(0.1)
-    # ax[0].set_ylabel(r"$\rho$ [kg/m$^3$]")
-    # add_h_plot(ax[0])
-
-    ax[0].plot(xc[[0, -1]], mdot[[0, 0]], "g:")
-    ax[0].plot(xc[[0, -1]], mdot[[0, 0]] + mdot_f, "g:")
-    ax[0].plot(xc, mdot)
-    ax[0].set_ymargin(0.1)
-    ax[0].set_ylabel(r"$\dot{m}$ [kg/s]")
-    add_h_plot(ax[0])
-
-    ax[1].plot(xc, u)
-    ax[1].set_ymargin(0.1)
-    ax[1].set_ylabel(r"$u$ [m/s]")
-    add_h_plot(ax[1])
-
-    ax[2].plot(xc, p)
-    ax[2].set_ymargin(0.1)
-    ax[2].set_ylabel(r"$p$ [Pa]")
-    add_h_plot(ax[2])
-
-    ax[3].plot(xc, T)
-    ax[3].set_ymargin(0.1)
-    ax[3].set_ylabel(r"$T$ [K]")
-    add_h_plot(ax[3])
-
-    ax[4].plot(xc, M)
-    ax[4].set_ymargin(0.1)
-    ax[4].set_ylabel(r"$M$ [-]")
-    add_h_plot(ax[4])
-
-    ax[5].plot(xc[[0, -1]], [0.0, 0.0], "g:")
-    ax[5].plot(xc[[0, -1]], [Y_f, Y_f], "g:")
-    ax[5].plot(xc, Y[:, gas.species_index("H2")])
-    ax[5].set_ymargin(0.1)
-    ax[5].set_ylabel(r"$Y_{\mathrm{H}_2}$ [-]")
-    add_h_plot(ax[5])
-
-    ax[6].plot(xc, Y[:, gas.species_index("H2O")])
-    ax[6].set_ymargin(0.1)
-    ax[6].set_ylabel(r"$Y_{\mathrm{H}_2\mathrm{O}}$ [-]")
-    add_h_plot(ax[6])
-
-    ax[6].set_xlabel("x [mm]")
-
-    fig.tight_layout()
-    fig.savefig("hyshot_ii.png", bbox_inches="tight", dpi=300)
-
-
-plot_sim(ss)
+plot_state(ss, "hyshot_ii.png")

--- a/examples/hyshot_ii_jic/hyshot_ii_jic.py
+++ b/examples/hyshot_ii_jic/hyshot_ii_jic.py
@@ -396,7 +396,7 @@ plot_variables = [
     "progress variable",
     "mach",
 ]
-ss.xt_diagrams = [XTDiagram(ss, variable, skipSteps=10) for variable in plot_variables]
+ss.xt_diagrams = [XTDiagram(ss, variable, skip_steps=10) for variable in plot_variables]
 ss.advance_simulation(t_f[-1])
 for diagram in ss.xt_diagrams:
     diagram.plot(figdir=figdir)

--- a/examples/hyshot_ii_jic/hyshot_ii_jic.py
+++ b/examples/hyshot_ii_jic/hyshot_ii_jic.py
@@ -4,7 +4,6 @@ import code
 from pathlib import Path
 
 import cantera as ct
-import matplotlib.pyplot as plt
 import numpy as np
 from scipy import optimize
 
@@ -15,41 +14,6 @@ from stanshock.physics.flamelet import FPVTable
 from stanshock.processing.initialize import InitializeConstant
 from stanshock.processing.plot import XTDiagram
 from stanshock.system.geometry import Box
-
-XSMALL_SIZE = 12
-SMALL_SIZE = 14
-MEDIUM_SIZE = 16
-BIGGER_SIZE = 18
-
-plt.rcParams.update(
-    {
-        "text.usetex": False,
-        # "font.family": "serif",
-        # "font.serif": ["Computer Modern Roman"],
-        "axes.xmargin": 0,
-        "axes.ymargin": 0,
-        "font.size": SMALL_SIZE,
-        "axes.titlesize": SMALL_SIZE,
-        "axes.labelsize": MEDIUM_SIZE,
-        "xtick.labelsize": SMALL_SIZE,
-        "ytick.labelsize": SMALL_SIZE,
-        "legend.fontsize": XSMALL_SIZE,
-        "figure.titlesize": BIGGER_SIZE,
-    }
-)
-
-# Plotting utilities
-scale = 1e3
-
-
-def add_h_plot(ax):
-    ax1 = ax.twinx()
-    ax1.plot(xf * scale, h * scale, "k", linestyle="--")
-    ax1.axhline(0, color="k", linestyle="--")
-    ax1.set_aspect("equal")
-    ax1.set_ylabel("h [mm]")
-    return ax1
-
 
 # Data
 datadir = Path("./data")

--- a/examples/laminar_flame.py
+++ b/examples/laminar_flame.py
@@ -4,7 +4,6 @@ import time
 from pathlib import Path
 
 import cantera as ct
-import matplotlib as mpl
 import numpy as np
 from matplotlib import pyplot as plt
 
@@ -29,7 +28,6 @@ def main(
     p = 1e5
     estFlameThickness = 1e-2
     ntFlowThrough = 0.1
-    fontsize = 12
     f = 0.1  # factor to reduce Cantera domain
 
     # find the initial state of the fluids
@@ -99,10 +97,6 @@ def main(
         assert state.mass_fractions is not None
 
         plt.close("all")
-        font = {"family": "serif", "serif": ["computer modern roman"]}
-        plt.rc("font", **font)
-        mpl.rcParams["font.size"] = fontsize
-        plt.rc("text", usetex=True)
         # plot
         plt.plot(x_ct, flame.T / flame.T[-1], "r", label=r"$T/T_\mathrm{F}$")
         plt.plot(x, T / flame.T[-1], "r--s")

--- a/examples/optimization.py
+++ b/examples/optimization.py
@@ -21,9 +21,11 @@ from stanshock.processing.probe import Probe
 from stanshock.system.backend import Array
 from stanshock.system.geometry import Cylinder
 
+data_dir = Path(__file__).resolve().parent / "../data"
+
 
 def main(
-    mech_filename: str = "data/mechanisms/HeliumArgon.yaml",
+    mech_filename: Path | str = data_dir / "mechanisms/HeliumArgon.yaml",
     plot_results: bool = True,
     show_results: bool = False,
     results_location: str | None = ".",
@@ -170,7 +172,7 @@ def main(
             XTDiagram(ss, variable=variable, limits=limits)
             for variable, limits in diagram_settings
         ]
-    ss.probes.append(Probe(ss.geometry, max(ss.geometry.xf)))  # end wall probe
+    ss.probes.append(Probe(geometry, physics_model, max(geometry.xf)))  # end wall probe
     t0 = time.perf_counter()
     ss.advance_simulation(tFinal)
     t1 = time.perf_counter()
@@ -206,7 +208,7 @@ def main(
             XTDiagram(ss, variable=variable, limits=limits)
             for variable, limits in diagram_settings
         ]
-    ss.probes.append(Probe(ss.geometry, max(ss.geometry.xf)))  # end wall probe
+    ss.probes.append(Probe(geometry, physics_model, max(geometry.xf)))  # end wall probe
     t0 = time.perf_counter()
     ss.advance_simulation(tFinal)
     t1 = time.perf_counter()

--- a/examples/optimization.py
+++ b/examples/optimization.py
@@ -4,7 +4,6 @@ import time
 from pathlib import Path
 
 import cantera as ct
-import matplotlib as mpl
 import numpy as np
 from matplotlib import pyplot as plt
 from scipy.optimize import newton
@@ -30,7 +29,6 @@ def main(
     results_location: str | None = ".",
 ) -> dict[str, Array]:
     # parameters
-    fontsize = 12
     tFinal = 7.5e-3
     p5, p1 = 18 * ct.one_atm, 0.48e5
     T5 = 1698.0
@@ -44,8 +42,6 @@ def main(
     plot_results = plot_results or show_results
     if plot_results:
         plt.close("all")
-        mpl.rcParams["font.size"] = fontsize
-        # plt.rc("text", usetex=True)
 
     # set up geometry
     xLower = -LDriver
@@ -174,7 +170,7 @@ def main(
             XTDiagram(ss, variable=variable, limits=limits)
             for variable, limits in diagram_settings
         ]
-    ss.probes.append(Probe(ss, max(ss.geometry.xf)))  # end wall probe
+    ss.probes.append(Probe(ss.geometry, max(ss.geometry.xf)))  # end wall probe
     t0 = time.perf_counter()
     ss.advance_simulation(tFinal)
     t1 = time.perf_counter()
@@ -210,7 +206,7 @@ def main(
             XTDiagram(ss, variable=variable, limits=limits)
             for variable, limits in diagram_settings
         ]
-    ss.probes.append(Probe(ss, max(ss.geometry.xf)))  # end wall probe
+    ss.probes.append(Probe(ss.geometry, max(ss.geometry.xf)))  # end wall probe
     t0 = time.perf_counter()
     ss.advance_simulation(tFinal)
     t1 = time.perf_counter()

--- a/examples/validation/case1.py
+++ b/examples/validation/case1.py
@@ -4,7 +4,6 @@ import time
 from pathlib import Path
 
 import cantera as ct
-import matplotlib as mpl
 import numpy as np
 from matplotlib import pyplot as plt
 
@@ -34,9 +33,7 @@ def main(
     tFinal = 60e-3
     # delta = 0.5  # distance to smear the initial conditions; models incomplete initial formation of shock.
 
-    # plotting parameters
     plot_results = plot_results or show_results
-    fontsize = 12
 
     # provided geometry
     DDriven = 4.5 * 0.0254
@@ -117,7 +114,7 @@ def main(
         include_boundary_layer=True,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
     )
-    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xf)))  # end wall probe
+    ssbl.probes.append(Probe(ssbl.geometry, max(ssbl.geometry.xf)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()
@@ -139,7 +136,7 @@ def main(
         output_every=100,
         include_boundary_layer=False,
     )
-    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xf)))  # end wall probe
+    ssnbl.probes.append(Probe(ssnbl.geometry, max(ssnbl.geometry.xf)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()
@@ -157,8 +154,6 @@ def main(
         # make plots of probe and XT diagrams
         tExp += timeDifference
         plt.close("all")
-        mpl.rcParams["font.size"] = fontsize
-        plt.rc("text", usetex=True)
         plt.figure(figsize=(4, 4))
         plt.plot(
             np.array(ssnbl.probes[0].t) * 1000.0,

--- a/examples/validation/case1.py
+++ b/examples/validation/case1.py
@@ -16,10 +16,12 @@ from stanshock.system.backend import Array
 from stanshock.system.geometry import initialize_geometry
 from stanshock.utils.csv_loader import get_pressure_data
 
+data_dir = Path(__file__).resolve().parent / "../../data"
+
 
 def main(
-    data_filename: str = "data/validation/case1.csv",
-    mech_filename: str = "data/mechanisms/Nitrogen.yaml",
+    data_filename: Path | str = data_dir / "validation/case1.csv",
+    mech_filename: Path | str = data_dir / "mechanisms/Nitrogen.yaml",
     plot_results: bool = True,
     show_results: bool = False,
     results_location: str | None = ".",
@@ -114,7 +116,9 @@ def main(
         include_boundary_layer=True,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
     )
-    ssbl.probes.append(Probe(ssbl.geometry, max(ssbl.geometry.xf)))  # end wall probe
+    ssbl.probes.append(
+        Probe(geometry, physics_model, max(geometry.xf))
+    )  # end wall probe
 
     # Solve
     t0 = time.perf_counter()
@@ -136,7 +140,9 @@ def main(
         output_every=100,
         include_boundary_layer=False,
     )
-    ssnbl.probes.append(Probe(ssnbl.geometry, max(ssnbl.geometry.xf)))  # end wall probe
+    ssnbl.probes.append(
+        Probe(geometry, physics_model, max(geometry.xf))
+    )  # end wall probe
 
     # Solve
     t0 = time.perf_counter()
@@ -156,15 +162,15 @@ def main(
         plt.close("all")
         plt.figure(figsize=(4, 4))
         plt.plot(
-            np.array(ssnbl.probes[0].t) * 1000.0,
-            np.array(ssnbl.probes[0].p) / 1.0e5,
+            np.array(ssnbl.probes[0].data[:, 0]) * 1000.0,
+            np.array(ssnbl.probes[0].data[:, 3]) / 1.0e5,
             "k",
             label=r"$\mathrm{Without\ BL\ Model}$",
             linewidth=2.0,
         )
         plt.plot(
-            np.array(ssbl.probes[0].t) * 1000.0,
-            np.array(ssbl.probes[0].p) / 1.0e5,
+            np.array(ssbl.probes[0].data[:, 0]) * 1000.0,
+            np.array(ssbl.probes[0].data[:, 3]) / 1.0e5,
             "r",
             label=r"$\mathrm{With\ BL\ Model}$",
             linewidth=2.0,

--- a/examples/validation/case2.py
+++ b/examples/validation/case2.py
@@ -4,7 +4,6 @@ import time
 from pathlib import Path
 
 import cantera as ct
-import matplotlib as mpl
 import numpy as np
 from matplotlib import pyplot as plt
 
@@ -33,9 +32,7 @@ def main(
     p2 = 14730.642333
     tFinal = 60e-3
 
-    # plotting parameters
     plot_results = plot_results or show_results
-    fontsize = 12
 
     # provided geometry
     DDriven = 4.5 * 0.0254
@@ -118,7 +115,7 @@ def main(
         include_boundary_layer=True,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
     )
-    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xf)))  # end wall probe
+    ssbl.probes.append(Probe(ssbl.geometry, max(ssbl.geometry.xf)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()
@@ -140,7 +137,7 @@ def main(
         output_every=100,
         include_boundary_layer=False,
     )
-    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xf)))  # end wall probe
+    ssnbl.probes.append(Probe(ssnbl.geometry, max(ssnbl.geometry.xf)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()
@@ -158,8 +155,6 @@ def main(
 
         # make plots of probe and XT diagrams
         plt.close("all")
-        mpl.rcParams["font.size"] = fontsize
-        plt.rc("text", usetex=True)
         plt.figure(figsize=(4, 4))
         plt.plot(
             np.array(ssnbl.probes[0].t) * 1000.0,

--- a/examples/validation/case2.py
+++ b/examples/validation/case2.py
@@ -16,10 +16,12 @@ from stanshock.system.backend import Array
 from stanshock.system.geometry import initialize_geometry
 from stanshock.utils.csv_loader import get_pressure_data
 
+data_dir = Path(__file__).resolve().parent / "../../data"
+
 
 def main(
-    data_filename: str = "data/validation/case2.csv",
-    mech_filename: str = "data/mechanisms/Nitrogen.yaml",
+    data_filename: Path | str = data_dir / "validation/case2.csv",
+    mech_filename: Path | str = data_dir / "mechanisms/Nitrogen.yaml",
     plot_results: bool = True,
     show_results: bool = False,
     results_location: str | None = ".",
@@ -115,7 +117,9 @@ def main(
         include_boundary_layer=True,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
     )
-    ssbl.probes.append(Probe(ssbl.geometry, max(ssbl.geometry.xf)))  # end wall probe
+    ssbl.probes.append(
+        Probe(geometry, physics_model, max(geometry.xf))
+    )  # end wall probe
 
     # Solve
     t0 = time.perf_counter()
@@ -137,7 +141,9 @@ def main(
         output_every=100,
         include_boundary_layer=False,
     )
-    ssnbl.probes.append(Probe(ssnbl.geometry, max(ssnbl.geometry.xf)))  # end wall probe
+    ssnbl.probes.append(
+        Probe(geometry, physics_model, max(geometry.xf))
+    )  # end wall probe
 
     # Solve
     t0 = time.perf_counter()

--- a/examples/validation/case3.py
+++ b/examples/validation/case3.py
@@ -20,10 +20,12 @@ from stanshock.system.backend import Array
 from stanshock.system.geometry import initialize_geometry
 from stanshock.utils.csv_loader import get_pressure_data
 
+data_dir = Path(__file__).resolve().parent / "../../data"
+
 
 def main(
-    data_filename: str = "data/validation/case3.csv",
-    mech_filename: str = "data/mechanisms/Nitrogen.yaml",
+    data_filename: Path | str = data_dir / "validation/case3.csv",
+    mech_filename: Path | str = data_dir / "mechanisms/Nitrogen.yaml",
     plot_results: bool = True,
     show_results: bool = False,
     results_location: str | None = ".",
@@ -166,7 +168,9 @@ def main(
         include_boundary_layer=True,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
     )
-    ssbl.probes.append(Probe(ssbl.geometry, max(ssbl.geometry.xf)))  # end wall probe
+    ssbl.probes.append(
+        Probe(geometry, physics_model, max(geometry.xf))
+    )  # end wall probe
 
     # Solve
     t0 = time.perf_counter()
@@ -188,7 +192,9 @@ def main(
         output_every=100,
         include_boundary_layer=False,
     )
-    ssnbl.probes.append(Probe(ssnbl.geometry, max(ssnbl.geometry.xf)))  # end wall probe
+    ssnbl.probes.append(
+        Probe(geometry, physics_model, max(geometry.xf))
+    )  # end wall probe
 
     # Solve
     t0 = time.perf_counter()

--- a/examples/validation/case3.py
+++ b/examples/validation/case3.py
@@ -4,7 +4,6 @@ import time
 from pathlib import Path
 
 import cantera as ct
-import matplotlib as mpl
 import numpy as np
 from matplotlib import pyplot as plt
 
@@ -37,9 +36,7 @@ def main(
     p2 = 13267.880629
     tFinal = 60e-3
 
-    # plotting parameters
     plot_results = plot_results or show_results
-    fontsize = 12
 
     # provided geometry
     DDriven = 4.5 * 0.0254
@@ -169,7 +166,7 @@ def main(
         include_boundary_layer=True,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
     )
-    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xf)))  # end wall probe
+    ssbl.probes.append(Probe(ssbl.geometry, max(ssbl.geometry.xf)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()
@@ -191,7 +188,7 @@ def main(
         output_every=100,
         include_boundary_layer=False,
     )
-    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xf)))  # end wall probe
+    ssnbl.probes.append(Probe(ssnbl.geometry, max(ssnbl.geometry.xf)))  # end wall probe
 
     # Solve
     t0 = time.perf_counter()
@@ -209,8 +206,6 @@ def main(
 
         # make plots of probe and XT diagrams
         plt.close("all")
-        mpl.rcParams["font.size"] = fontsize
-        plt.rc("text", usetex=True)
         plt.figure(figsize=(4, 4))
         plt.plot(
             np.array(ssnbl.probes[0].t) * 1000.0,

--- a/examples/validation/case4.py
+++ b/examples/validation/case4.py
@@ -13,7 +13,7 @@ from stanshock.numerics.boundary_conditions import BCInput
 from stanshock.physics.fluid_base import FluidPhysics, FluidState
 from stanshock.physics.thermotable import ThermoTable
 from stanshock.processing.initialize import InitializeRiemannProblem
-from stanshock.processing.plot import XTDiagram
+from stanshock.processing.plot import XTDiagram, get_variable_info_map
 from stanshock.processing.probe import Probe
 from stanshock.system.backend import Array
 from stanshock.system.geometry import Geometry, initialize_geometry
@@ -98,9 +98,12 @@ def get_pressure_data_from_image(fileName):
     return (t, p)
 
 
+data_dir = Path(__file__).resolve().parent / "../../data"
+
+
 def main(
-    data_filename: str = "data/validation/case4.png",
-    mech_filename: str = "data/mechanisms/N2O2HeAr.yaml",
+    data_filename: Path | str = data_dir / "validation/case4.png",
+    mech_filename: Path | str = data_dir / "mechanisms/N2O2HeAr.yaml",
     plot_results: bool = True,
     show_results: bool = False,
     results_location: str | None = ".",
@@ -204,6 +207,7 @@ def main(
     initialization = InitializePartialFill(
         geometry, physics_model, state4, state1, xShock
     )
+    variable_info_map = get_variable_info_map(physics_model)
 
     ssbl = ShockTube(
         geometry=geometry,
@@ -221,7 +225,9 @@ def main(
         ("temperature", (T1, 800.0)),
     ]
     ssbl.xt_diagrams += [
-        XTDiagram(ssbl, variable=variable, limits=limits)
+        XTDiagram(
+            ssbl, variable=variable, variable_info_map=variable_info_map, limits=limits
+        )
         for variable, limits in diagram_settings
     ]
 
@@ -251,7 +257,9 @@ def main(
     )
     ssnbl.probes.append(Probe(ssnbl.geometry, max(ssnbl.geometry.xf)))  # end wall probe
     ssnbl.xt_diagrams += [
-        XTDiagram(ssnbl, variable=variable, limits=limits)
+        XTDiagram(
+            ssnbl, variable=variable, variable_info_map=variable_info_map, limits=limits
+        )
         for variable, limits in diagram_settings
     ]
 

--- a/examples/validation/case4.py
+++ b/examples/validation/case4.py
@@ -219,7 +219,9 @@ def main(
         include_boundary_layer=True,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
     )
-    ssbl.probes.append(Probe(ssbl.geometry, max(ssbl.geometry.xf)))  # end wall probe
+    ssbl.probes.append(
+        Probe(geometry, physics_model, max(ssbl.geometry.xf))
+    )  # end wall probe
     diagram_settings = [
         ("pressure", (p1 / 101325, p4 / 101325)),
         ("temperature", (T1, 800.0)),
@@ -255,7 +257,9 @@ def main(
         include_boundary_layer=False,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
     )
-    ssnbl.probes.append(Probe(ssnbl.geometry, max(ssnbl.geometry.xf)))  # end wall probe
+    ssnbl.probes.append(
+        Probe(geometry, physics_model, max(geometry.xf))
+    )  # end wall probe
     ssnbl.xt_diagrams += [
         XTDiagram(
             ssnbl, variable=variable, variable_info_map=variable_info_map, limits=limits

--- a/examples/validation/case4.py
+++ b/examples/validation/case4.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import cantera as ct
 import imageio
-import matplotlib as mpl
 import numpy as np
 from matplotlib import pyplot as plt
 
@@ -113,9 +112,7 @@ def main(
     p4 = 82.0 * 6894.76 * 0.9
     tFinal = 60e-3
 
-    # plotting parameters
     plot_results = plot_results or show_results
-    fontsize = 12
 
     # provided geometry
     DDriven = 4.5 * 0.0254
@@ -218,7 +215,7 @@ def main(
         include_boundary_layer=True,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
     )
-    ssbl.probes.append(Probe(ssbl, max(ssbl.geometry.xf)))  # end wall probe
+    ssbl.probes.append(Probe(ssbl.geometry, max(ssbl.geometry.xf)))  # end wall probe
     diagram_settings = [
         ("pressure", (p1 / 101325, p4 / 101325)),
         ("temperature", (T1, 800.0)),
@@ -252,7 +249,7 @@ def main(
         include_boundary_layer=False,
         wall_temperature=T1,  # assume wall temperature is in thermal eq. with gas
     )
-    ssnbl.probes.append(Probe(ssnbl, max(ssnbl.geometry.xf)))  # end wall probe
+    ssnbl.probes.append(Probe(ssnbl.geometry, max(ssnbl.geometry.xf)))  # end wall probe
     ssnbl.xt_diagrams += [
         XTDiagram(ssnbl, variable=variable, limits=limits)
         for variable, limits in diagram_settings
@@ -277,8 +274,6 @@ def main(
 
         # make plots of probe and XT diagrams
         plt.close("all")
-        mpl.rcParams["font.size"] = fontsize
-        plt.rc("text", usetex=True)
         plt.figure(figsize=(4, 4))
         plt.plot(
             np.array(ssnbl.probes[0].t) * 1000.0,

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -251,7 +251,7 @@ class Combustor:
         """
         # update diagrams
         for diagram in self.xt_diagrams:
-            if iters % (diagram.skipSteps + 1) == 0:
+            if iters % (diagram.skip_steps + 1) == 0:
                 diagram.update(self)
 
     def advance_simulation(self, tFinal: float, res_p_target: float = -1.0) -> None:

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -242,8 +242,8 @@ class Combustor:
 
         # update probes
         for probe in self.probes:
-            if iters % (probe.skipSteps + 1) == 0:
-                probe.update(self)
+            if iters % (probe.skip_steps + 1) == 0:
+                probe.update(self.t, self.state)
 
     def update_XT_diagrams(self, iters: int) -> None:
         """

--- a/src/stanshock/components/shocktube.py
+++ b/src/stanshock/components/shocktube.py
@@ -240,7 +240,11 @@ class ShockTube(Combustor):
             # delete previous probes and create an endwall probe
             self.probes = [
                 Probe(
-                    self.geometry, probe_location, skip_steps=0, name="endwall probe"
+                    self.geometry,
+                    self.physics,
+                    probe_location,
+                    skip_steps=0,
+                    name="endwall probe",
                 ),
             ]
             # solve

--- a/src/stanshock/components/shocktube.py
+++ b/src/stanshock/components/shocktube.py
@@ -239,7 +239,9 @@ class ShockTube(Combustor):
             )
             # delete previous probes and create an endwall probe
             self.probes = [
-                Probe(self.geometry, probe_location, skip_steps=0, name="endwall probe"),
+                Probe(
+                    self.geometry, probe_location, skip_steps=0, name="endwall probe"
+                ),
             ]
             # solve
             if self.verbose:

--- a/src/stanshock/components/shocktube.py
+++ b/src/stanshock/components/shocktube.py
@@ -145,7 +145,7 @@ class ShockTube(Combustor):
         xShock = geometry.xf[
             np.argmax(dpAbs) + 1
         ]  # maximum pressure gradient corresponds to shock
-        (xMin, xMax, probeLocation) = (geometry.xf[0], xShock, geometry.xf[-1])
+        (xMin, xMax, probe_location) = (geometry.xf[0], xShock, geometry.xf[-1])
         LMax = xMax - xMin  # maximum length of constrained optimization
         DMax = min(
             geometry.d_outer(0.0, np.linspace(xMin, xMax))
@@ -239,7 +239,7 @@ class ShockTube(Combustor):
             )
             # delete previous probes and create an endwall probe
             self.probes = [
-                Probe(self, probeLocation, skipSteps=0, probeName="endwall probe"),
+                Probe(self.geometry, probe_location, skip_steps=0, name="endwall probe"),
             ]
             # solve
             if self.verbose:

--- a/src/stanshock/models/jicf.py
+++ b/src/stanshock/models/jicf.py
@@ -4,7 +4,6 @@ import functools
 import warnings
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import numpy as np
 from joblib import Parallel, delayed
 from scipy import integrate, interpolate, optimize, special, stats
@@ -16,26 +15,6 @@ from stanshock.physics.fluid_base import FluidState
 from stanshock.system.backend import Array, Unpack
 from stanshock.system.base import PrecomputeSteps, RightHandSide
 from stanshock.system.geometry import Box
-
-XSMALL_SIZE = 12
-SMALL_SIZE = 14
-MEDIUM_SIZE = 16
-BIGGER_SIZE = 18
-
-plt.rcParams.update(
-    {
-        "text.usetex": True,
-        "font.family": "serif",
-        "font.serif": ["Computer Modern Roman"],
-        "font.size": SMALL_SIZE,
-        "axes.titlesize": SMALL_SIZE,
-        "axes.labelsize": MEDIUM_SIZE,
-        "xtick.labelsize": SMALL_SIZE,
-        "ytick.labelsize": SMALL_SIZE,
-        "legend.fontsize": XSMALL_SIZE,
-        "figure.titlesize": BIGGER_SIZE,
-    }
-)
 
 datadir = Path("./data")
 

--- a/src/stanshock/physics/flamelet.py
+++ b/src/stanshock/physics/flamelet.py
@@ -70,12 +70,12 @@ class FPVTable(FluidPhysics):
             ]
             data_raw: Array = f["Data"][:]
             n_tot = self.Z.size * self.Q.size * self.L.size
-            self.variables: list[TableVariable] = []
+            self.variables: dict[str, TableVariable] = {}
             for i, var in enumerate(var_names):
                 data = data_raw[i * n_tot : (i + 1) * n_tot].reshape(
                     self.Z.size, self.Q.size, self.L.size, order="C"
                 )
-                self.variables.append(TableVariable(var, data, self.Z, self.Q, self.L))
+                self.variables[var] = TableVariable(var, data, self.Z, self.Q, self.L)
 
         self.ox_def: Composition | None = ox_def
         self.fuel_def: Composition | None = fuel_def
@@ -134,9 +134,7 @@ class FPVTable(FluidPhysics):
         """
         C_min: Array = np.zeros_like(Z)
         C_max: Array = np.ones_like(Z)
-        for v in self.variables:
-            if v.name == "PROG":
-                C_max = v.lookup(Z, 0, 1)
+        C_max = self.variables["PROG"].lookup(Z, 0, 1)
         L = (C - C_min) / (C_max - C_min)
         return np.clip(L, 0, 1)
 
@@ -161,12 +159,10 @@ class FPVTable(FluidPhysics):
         """
         Perform a lookup of the variable with the given name at the given Z, Q, and L values.
         """
-        for v in self.variables:
-            if v.name == var:
-                return v.lookup(Z, Q, L)
-
-        msg = f"Variable {var} not found in table {self.filename}."
-        raise ValueError(msg)
+        if var not in self.variables:
+            msg = f"Variable {var} not found in table {self.filename}."
+            raise ValueError(msg)
+        return self.variables[var].lookup(Z, Q, L)
 
     def lookup_all(self, state: FluidState) -> dict[str, Array]:
         """
@@ -181,7 +177,7 @@ class FPVTable(FluidPhysics):
         Q = np.zeros_like(Z)
         L = state.normalized_progress_variable
 
-        return {v.name: v.lookup(Z, Q, L) for v in self.variables}
+        return {var: v.lookup(Z, Q, L) for var, v in self.variables.items()}
 
     def get_gamma(self, state: FluidState) -> Array:
         """

--- a/src/stanshock/physics/fluid_base.py
+++ b/src/stanshock/physics/fluid_base.py
@@ -97,9 +97,7 @@ class FluidPhysics(ABC):
         self.gas: ct.Solution = gas
         self.n_scalars: int = self.gas.n_species
         self.n_scalars_rho_sum: int = self.n_scalars
-        self.scalar_names: list[str] = [
-            species.lower() for species in self.gas.species_names
-        ]
+        self.scalar_names: list[str] = self.gas.species_names
 
         self.is_flamelet: bool = False
 
@@ -170,6 +168,14 @@ class FluidPhysics(ABC):
     def get_sound_speed(self, state: FluidState) -> Array:
         """Compute speed of sound of the gas."""
 
+    def get_density(self, state: FluidState) -> Array:
+        assert state.density is not None
+        return state.density
+
+    def get_velocity(self, state: FluidState) -> Array:
+        assert state.velocity is not None
+        return state.velocity
+
     def get_thermal_diffusivity(self, state: FluidState) -> Array:
         """Compute thermal diffusivity, alpha = kappa / (rho * cp)."""
         kappa = self.get_thermal_conductivity(state)
@@ -224,8 +230,8 @@ class FluidPhysics(ABC):
 
     def get_bilger_mixture_fraction(self, Y: Array) -> Array:
         """Compute the Bilger mixture fraction from given mass fractions."""
-        assert self.Z_weights is not None
-        assert self.Z_offset is not None
+        assert self.ox_def is not None
+        assert self.fuel_def is not None
         tmp = np.dot(Y, self.Z_weights)
         assert isinstance(tmp, np.ndarray)
         return np.clip(tmp + self.Z_offset, 0.0, 1.0)
@@ -261,6 +267,11 @@ class FluidPhysics(ABC):
     def get_composition(self, Y: Array) -> Array:
         """Converts mass fractions to set of transported scalars."""
         return Y
+
+    def get_mass_fractions(self, state: FluidState) -> Array:
+        """Returns mass fractions, computing from transported scalars if needed."""
+        assert state.composition is not None
+        return state.composition
 
     def get_normalized_progress_variable(self, Z: Array, C: Array) -> Array:
         _ = Z, C

--- a/src/stanshock/processing/initialize.py
+++ b/src/stanshock/processing/initialize.py
@@ -533,7 +533,7 @@ class InitializeCanteraArray(InitializeInterpolate):
     def __init__(
         self,
         geometry: Geometry,
-        sol: ct.SolutionArray,
+        sol: ct.SolutionArray[ct.Solution],
     ) -> None:
         """Interpolate properties from a Cantera SolutionArray."""
         self.geometry = geometry

--- a/src/stanshock/processing/plot.py
+++ b/src/stanshock/processing/plot.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 import matplotlib.pyplot as plt
 import numpy as np
 
+from stanshock.system.geometry import AsymmetricBox, Box, Cylinder
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
@@ -63,22 +65,28 @@ class XTDiagram:
         geometry = domain.geometry
 
         if variable in ["density", "r", "rho"]:
+            assert state.density is not None
             self.variable.append(np.interp(self.x, geometry.xc, state.density))
         elif variable in ["velocity", "u"]:
+            assert state.velocity is not None
             self.variable.append(np.interp(self.x, geometry.xc, state.velocity))
         elif variable in ["pressure", "p"]:
+            assert state.pressure is not None
             self.variable.append(np.interp(self.x, geometry.xc, state.pressure))
         elif variable in ["temperature", "t"]:
             T = domain.physics.get_temperature(state)
             self.variable.append(np.interp(self.x, geometry.xc, T))
         elif variable in ["gamma", "g", "specific heat ratio", "heat capacity ratio"]:
+            assert state.gamma is not None
             self.variable.append(np.interp(self.x, geometry.xc, state.gamma))
         elif variable in domain.physics.scalar_names:
+            assert state.composition is not None
             scalarIndex = domain.physics.scalar_names.index(variable)
             self.variable.append(
                 np.interp(self.x, geometry.xc, state.composition[:, scalarIndex])
             )
         elif variable in ["mach", "m"]:
+            assert state.velocity is not None
             M = np.abs(state.velocity) / domain.physics.get_sound_speed(state)
             self.variable.append(np.interp(self.x, geometry.xc, M))
         else:
@@ -86,7 +94,7 @@ class XTDiagram:
             raise Exception(msg)
         self.t.append(domain.t)
         if domain.injector is not None:
-            self.mdot.append(domain.injector.mdot_f_interp(domain.t))
+            self.mdot.append(float(domain.injector.mdot_f_interp(domain.t)))
 
     def plot(self, figdir: Path | str = ".") -> None:
         """
@@ -175,57 +183,67 @@ def add_h_plot(domain: Combustor, ax: Axes, scale: float = 1.0e3) -> Axes:
     geometry = domain.geometry
     t = domain.t
     x = geometry.xf
-    h = geometry.h(t, x) if geometry.h is not None else geometry.d_outer(t, x)
-    ax1.plot(x * scale, h * scale, color="0.8", linestyle="--")
-    ax1.axhline(0, color="0.8", linestyle="--")
+
+    yname = "h"
+    if isinstance(geometry, Cylinder):
+        d = geometry.d_outer(t, x)
+        ax1.plot(x * scale, d * scale, color="0.8", linestyle="--")
+        yname = r"$d_{outer}$"
+    elif isinstance(geometry, Box):
+        ax1.plot(x * scale, geometry.h(t, x) * scale, color="0.8", linestyle="--")
+        ax1.axhline(0, color="0.8", linestyle="--")
+    elif isinstance(geometry, AsymmetricBox):
+        ax1.plot(
+            x * scale, geometry.upper_wall(t, x) * scale, color="0.8", linestyle="--"
+        )
+        ax1.plot(
+            x * scale, geometry.lower_wall(t, x) * scale, color="0.8", linestyle="--"
+        )
+
     ax1.set_aspect("equal")
-    ax1.set_ylabel("h [mm]")
+    ax1.set_ylabel(f"{yname} [mm]")
     return ax1
 
 
-def plot_state(domain: Combustor, filename: Path | str) -> None:
+def plot_state(
+    domain: Combustor, filename: Path | str, plot_geometry: bool = True
+) -> None:
     xscale = 1.0e3
     physics = domain.physics
     state = domain.state
+    assert state.density is not None
+    assert state.velocity is not None
+    assert state.pressure is not None
     geometry = domain.geometry
     idx_cells = geometry.idx_cells
     x = xscale * geometry.xc[idx_cells]
     T = physics.get_temperature(state)
+    nrows = 7 if domain.injector is not None else 6
 
     fig: Figure
-    ax: list[Axes]
-    fig, ax = plt.subplots(7, 1, sharex=True, figsize=(6, 9))
-    ax[0].plot(x, state.density[idx_cells])
-    ax[0].set_ymargin(0.1)
-    ax[0].set_ylabel(r"$\rho$ [kg/m$^3$]")
-    if geometry.h is not None:
-        add_h_plot(domain, ax[0], scale=xscale)
+    axs: list[Axes]
+    fig, axs = plt.subplots(nrows, 1, sharex=True, figsize=(6, 9))
+    axs[0].plot(x, state.density[idx_cells])
+    axs[0].set_ymargin(0.1)
+    axs[0].set_ylabel(r"$\rho$ [kg/m$^3$]")
 
-    ax[1].plot(x, state.velocity[idx_cells])
-    ax[1].set_ymargin(0.1)
-    ax[1].set_ylabel(r"$u$ [m/s]")
-    if geometry.h is not None:
-        add_h_plot(domain, ax[1], scale=xscale)
+    axs[1].plot(x, state.velocity[idx_cells])
+    axs[1].set_ymargin(0.1)
+    axs[1].set_ylabel(r"$u$ [m/s]")
 
-    ax[2].plot(x, state.pressure[idx_cells])
-    ax[2].set_ymargin(0.1)
-    ax[2].set_ylabel(r"$p$ [Pa]")
-    if geometry.h is not None:
-        add_h_plot(domain, ax[2], scale=xscale)
+    axs[2].plot(x, state.pressure[idx_cells])
+    axs[2].set_ymargin(0.1)
+    axs[2].set_ylabel(r"$p$ [Pa]")
 
-    ax[3].plot(x, T[idx_cells])
-    ax[3].set_ymargin(0.1)
-    ax[3].set_ylabel(r"$T$ [K]")
-    if geometry.h is not None:
-        add_h_plot(domain, ax[3], scale=xscale)
+    axs[3].plot(x, T[idx_cells])
+    axs[3].set_ymargin(0.1)
+    axs[3].set_ylabel(r"$T$ [K]")
 
     M = np.abs(state.velocity) / physics.get_sound_speed(state)
-    ax[4].plot(x, M[idx_cells])
-    ax[4].axhline(1.0, color="r", linestyle="--")
-    ax[4].set_ymargin(0.1)
-    ax[4].set_ylabel(r"$M$ [-]")
-    if geometry.h is not None:
-        add_h_plot(domain, ax[4], scale=xscale)
+    axs[4].plot(x, M[idx_cells])
+    axs[4].axhline(1.0, color="r", linestyle="--")
+    axs[4].set_ymargin(0.1)
+    axs[4].set_ylabel(r"$M$ [-]")
 
     if physics.is_flamelet:
         state = physics.set_state(state)
@@ -233,33 +251,35 @@ def plot_state(domain: Combustor, filename: Path | str) -> None:
         Y_OH = physics.lookup("OH", state)[idx_cells]
         Y_H2O = physics.lookup("H2O", state)[idx_cells]
     else:
+        assert state.mass_fractions is not None
         Y = state.mass_fractions[idx_cells]
         Y_H2 = Y[:, physics.gas.species_index("H2")]
         Y_OH = Y[:, physics.gas.species_index("OH")]
         Y_H2O = Y[:, physics.gas.species_index("H2O")]
-    ax[5].plot(x, Y_H2, label=r"$\mathrm{H}_2$")
-    ax[5].plot(x, Y_OH, label=r"$\mathrm{OH}$")
-    ax[5].plot(x, Y_H2O, label=r"$\mathrm{H}_2\mathrm{O}$")
+    axs[5].plot(x, Y_H2, label=r"$\mathrm{H}_2$")
+    axs[5].plot(x, Y_OH, label=r"$\mathrm{OH}$")
+    axs[5].plot(x, Y_H2O, label=r"$\mathrm{H}_2\mathrm{O}$")
     if Y_H2.max() < 1e-6:
-        ax[5].set_ylim(-1e-3, 1e-3)
+        axs[5].set_ylim(-1e-3, 1e-3)
     else:
-        ax[5].set_ymargin(0.1)
-    ax[5].set_ylabel(r"$Y_k$ [-]")
-    ax[5].legend(loc="upper right")
-    if geometry.h is not None:
-        add_h_plot(domain, ax[5], scale=xscale)
+        axs[5].set_ymargin(0.1)
+    axs[5].set_ylabel(r"$Y_k$ [-]")
+    axs[5].legend(loc="upper right")
 
-    ax[6].scatter(
-        domain.injector.fluid_tips[:, 0] * xscale,
-        domain.injector.fluid_tips[:, 1] * 1e3 * domain.injector.n_inj,
-        s=1,
-    )
-    ax[6].set_ymargin(0.1)
-    ax[6].set_ylabel(r"$\dot{m}_f$ [g/s]")
-    if geometry.h is not None:
-        add_h_plot(domain, ax[6], scale=xscale)
+    if domain.injector is not None:
+        axs[6].scatter(
+            domain.injector.fluid_tips[:, 0] * xscale,
+            domain.injector.fluid_tips[:, 1] * 1e3 * domain.injector.n_inj,
+            s=1,
+        )
+        axs[6].set_ymargin(0.1)
+        axs[6].set_ylabel(r"$\dot{m}_f$ [g/s]")
 
-    ax[6].set_xlabel("x [mm]")
+        axs[6].set_xlabel("x [mm]")
+
+    if plot_geometry:
+        for ax in axs:
+            add_h_plot(domain, ax, scale=xscale)
 
     fig.suptitle(rf"$t = {domain.t * 1.0e3:.4f}$ ms")
 

--- a/src/stanshock/processing/plot.py
+++ b/src/stanshock/processing/plot.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
 
+from stanshock.physics.flamelet import FPVTable
+from stanshock.physics.fluid_base import FluidPhysics, FluidState
 from stanshock.system.geometry import AsymmetricBox, Box, Cylinder
 
 if TYPE_CHECKING:
@@ -14,6 +19,146 @@ if TYPE_CHECKING:
 
     from stanshock.components.combustor import Combustor
     from stanshock.system.backend import Array
+
+
+@dataclass
+class VariableInfo:
+    short_name: str
+    plot_label: str
+    fun: Callable[[FluidState], Array]
+    scale: float = 1.0
+
+
+def get_variable_info_map(physics: FluidPhysics) -> dict[str, VariableInfo]:
+    """Create mapping between strings and variable information."""
+    # Common variables available to all FluidPhysics:
+    plot_variables: dict[str, VariableInfo] = {
+        "density": VariableInfo(
+            short_name="r",
+            plot_label=r"$\rho~[\mathrm{kg/m^3}]$",
+            fun=physics.get_density,
+        ),
+        "velocity": VariableInfo(
+            short_name="u", plot_label=r"$u~[\mathrm{m/s}]$", fun=physics.get_velocity
+        ),
+        "pressure": VariableInfo(
+            short_name="p",
+            plot_label=r"$p~[\mathrm{bar}]$",
+            fun=physics.get_pressure,
+            scale=1e-5,
+        ),
+        "temperature": VariableInfo(
+            short_name="t", plot_label=r"$T~[\mathrm{K}]$", fun=physics.get_temperature
+        ),
+        "gamma": VariableInfo(
+            short_name="g", plot_label=r"$\gamma~[\mathrm{-}]$", fun=physics.get_gamma
+        ),
+        "mach": VariableInfo(
+            short_name="m",
+            plot_label=r"$Ma~[\mathrm{-}]$",
+            fun=lambda x: np.abs(physics.get_velocity(x)) / physics.get_sound_speed(x),
+        ),
+    }
+
+    # All transported scalars
+    short_name_map = {"mixture fraction": "Z", "progress variable": "C"}
+    for iscalar, scalar in enumerate(physics.scalar_names):
+        if scalar == "density":
+            continue
+
+        def get_scalar(state: FluidState, idx: int = iscalar) -> Array:
+            assert state.composition is not None
+            return state.composition[:, idx]
+
+        # Check for species mass fractions
+        name = short_name_map.get(scalar, scalar)
+        fancy_name = name if scalar in short_name_map else rf"\mathrm{{{name}}}"
+        if scalar in physics.gas.species_names:
+            name = f"Y_{scalar}"
+
+            # Fancy formatting for species names
+            groups = re.split(r"(?<=[a-zA-Z])(?=\d)|(?<=\d)(?=\D)", scalar)
+            fancy_name = "".join(
+                [f"_{{{group}}}" if group.isnumeric() else group for group in groups]
+            )
+
+        plot_variables[scalar] = VariableInfo(
+            short_name=name,
+            plot_label=rf"${fancy_name}~[\mathrm{{-}}]$",
+            fun=get_scalar,
+        )
+
+    # Physics-specific variables
+    if isinstance(physics, FPVTable):
+        for var in physics.variables:
+
+            def get_lookup(state: FluidState, var: str = var) -> Array:
+                return physics.lookup(var, state)
+
+            # Check for species mass fractions
+            name = var
+            fancy_name = rf"$\mathrm{{{var}}}$"
+            if var in physics.gas.species_names:
+                name = f"Y_{var}"
+
+                # Fancy formatting for species names
+                groups = re.split(r"(?<=[a-zA-Z])(?=\d)|(?<=\d)(?=\D)", var)
+                fancy_name = "".join(
+                    [
+                        f"_{{{group}}}" if group.isnumeric() else group
+                        for group in groups
+                    ]
+                )
+                fancy_name = rf"${{{fancy_name}}}~[\mathrm{{-}}]$"
+
+            plot_variables[var] = VariableInfo(
+                short_name=name,
+                plot_label=fancy_name,
+                fun=get_lookup,
+            )
+
+            def get_L(state: FluidState) -> Array:
+                if state.normalized_progress_variable is None:
+                    state = physics.set_state(state)
+                assert state.normalized_progress_variable is not None
+                return state.normalized_progress_variable
+
+            plot_variables["normalized progress variable"] = VariableInfo(
+                short_name="L", plot_label=r"$L~[\mathrm{-}]$", fun=get_L
+            )
+
+    else:
+        if physics.ox_def is not None and physics.fuel_def is not None:
+
+            def get_Z(state: FluidState) -> Array:
+                Y = physics.get_mass_fractions(state)
+                return physics.get_bilger_mixture_fraction(Y)
+
+            plot_variables["mixture fraction"] = VariableInfo(
+                short_name="Z", plot_label=r"$Z~[\mathrm{-}]$", fun=get_Z
+            )
+
+        if physics.prog_def is not None:
+
+            def get_C(state: FluidState) -> Array:
+                Y = physics.get_mass_fractions(state)
+                return physics.get_progress_variable(Y)
+
+            plot_variables["progress variable"] = VariableInfo(
+                short_name="C", plot_label=r"$C~[\mathrm{-}]$", fun=get_C
+            )
+
+    # Common aliases:
+    plot_variables["rho"] = plot_variables["density"]
+    for vname in ["specific heat ratio", "heat capacity ratio"]:
+        plot_variables[vname] = plot_variables["gamma"]
+
+    keys = list(plot_variables.keys())
+    for key in keys:
+        var_info = plot_variables[key]
+        plot_variables[var_info.short_name] = var_info
+
+    return plot_variables
 
 
 class XTDiagram:
@@ -27,19 +172,24 @@ class XTDiagram:
             limits = tuple of maximum and minimum for the pcolor (vMin,vMax)
     """
 
+    interpolator: Callable[[Array], Array] | None
+
     def __init__(
         self,
         domain: Combustor,
         variable: str,
-        skipSteps: int = 0,
-        x: Array | None = None,
-        limits: tuple[float, float] | None = None,
+        variable_info_map: dict[str, VariableInfo] | None = None,
+        skip_steps: int = 0,  # number of timesteps to skip
+        x: Array | None = None,  # mesh to interpolate solution onto
+        limits: tuple[float, float] | None = None,  # colormap range
     ) -> None:
-        self.skipSteps = 0
+        self.name = variable.lower()
+        if variable_info_map is None:
+            variable_info_map = get_variable_info_map(domain.physics)
+        self.variable_info = variable_info_map[self.name]
+        self.skip_steps = skip_steps
         self.limits = limits
 
-        self.name = variable.lower()
-        self.skipSteps = skipSteps  # number of timesteps to skip
         # check interpolation grid
         geometry = domain.geometry
         if x is None:
@@ -49,6 +199,8 @@ class XTDiagram:
             raise Exception(msg)
         else:
             self.x = x
+
+        self.interpolator = lambda x: np.interp(self.x, geometry.xc, x)
 
         self.variable: list[Array] = []  # list of numpy arrays of the variable w.r.t x
         self.t: list[float] = []  # list of times
@@ -60,39 +212,15 @@ class XTDiagram:
             inputs:
                 XTDiagram: the XTDiagram object
         """
-        variable = self.name
         state = domain.state
-        geometry = domain.geometry
 
-        if variable in ["density", "r", "rho"]:
-            assert state.density is not None
-            self.variable.append(np.interp(self.x, geometry.xc, state.density))
-        elif variable in ["velocity", "u"]:
-            assert state.velocity is not None
-            self.variable.append(np.interp(self.x, geometry.xc, state.velocity))
-        elif variable in ["pressure", "p"]:
-            assert state.pressure is not None
-            self.variable.append(np.interp(self.x, geometry.xc, state.pressure))
-        elif variable in ["temperature", "t"]:
-            T = domain.physics.get_temperature(state)
-            self.variable.append(np.interp(self.x, geometry.xc, T))
-        elif variable in ["gamma", "g", "specific heat ratio", "heat capacity ratio"]:
-            assert state.gamma is not None
-            self.variable.append(np.interp(self.x, geometry.xc, state.gamma))
-        elif variable in domain.physics.scalar_names:
-            assert state.composition is not None
-            scalarIndex = domain.physics.scalar_names.index(variable)
-            self.variable.append(
-                np.interp(self.x, geometry.xc, state.composition[:, scalarIndex])
-            )
-        elif variable in ["mach", "m"]:
-            assert state.velocity is not None
-            M = np.abs(state.velocity) / domain.physics.get_sound_speed(state)
-            self.variable.append(np.interp(self.x, geometry.xc, M))
-        else:
-            msg = f"Invalid Variable Name: {variable}"
-            raise Exception(msg)
+        value = self.variable_info.fun(state) * self.variable_info.scale
+        if self.interpolator is not None:
+            value = self.interpolator(value)
+
+        self.variable.append(value)
         self.t.append(domain.t)
+
         if domain.injector is not None:
             self.mdot.append(float(domain.injector.mdot_f_interp(domain.t)))
 
@@ -102,34 +230,20 @@ class XTDiagram:
             inputs:
                 figdir = directory in which to save the plot
         """
-        t = [t * 1000.0 for t in self.t]
-        mdot = [mdot * 1.0e3 for mdot in self.mdot]
+        t = 1e3 * np.array(self.t)
         X, T = np.meshgrid(self.x, t)
         variableMatrix = np.zeros(X.shape)
         for k, variablek in enumerate(self.variable):
             variableMatrix[k, :] = variablek
-        variable = self.name
-        if variable in ["density", "r", "rho"]:
-            title = r"$\rho~[\mathrm{kg/m^3}]$"
-        elif variable in ["velocity", "u"]:
-            title = r"$u~[\mathrm{m/s}]$"
-        elif variable in ["pressure", "p"]:
-            variableMatrix /= 1.0e5  # convert to bar
-            title = r"$p~[\mathrm{bar}]$"
-        elif variable in ["temperature", "t"]:
-            title = r"$T~[\mathrm{K}]$"
-        elif variable in ["gamma", "g", "specific heat ratio", "heat capacity ratio"]:
-            title = r"$\gamma~[\mathrm{-}]$"
-        elif variable in ["mixture fraction"]:
-            title = r"$Z~[\mathrm{-}]$"
-        elif variable in ["progress variable"]:
-            title = r"$C~[\mathrm{-}]$"
-        elif variable in ["mach", "m"]:
-            title = r"$M~[\mathrm{-}]$"
-        else:
-            title = r"$\mathrm{" + variable + "}$"
 
-        has_mdot = mdot and any(mdot)
+        title = self.variable_info.plot_label
+        short_name = self.variable_info.short_name
+
+        has_mdot = False
+        if self.mdot:
+            mdot = 1e3 * np.array(self.mdot)
+            has_mdot = np.any(mdot)
+
         figsize = (6, 4) if has_mdot else (6, 3)
 
         fig: Figure = plt.figure(figsize=figsize)
@@ -172,7 +286,7 @@ class XTDiagram:
             mdot_ax.grid(True, axis="x", linestyle="--", alpha=0.7)
 
         fig.tight_layout()
-        fig.savefig(Path(figdir) / f"{variable}.png", bbox_inches="tight", dpi=300)
+        fig.savefig(Path(figdir) / f"{short_name}.png", bbox_inches="tight", dpi=300)
 
 
 def add_h_plot(domain: Combustor, ax: Axes, scale: float = 1.0e3) -> Axes:
@@ -200,82 +314,87 @@ def add_h_plot(domain: Combustor, ax: Axes, scale: float = 1.0e3) -> Axes:
             x * scale, geometry.lower_wall(t, x) * scale, color="0.8", linestyle="--"
         )
 
+    ax1.set_xlim(x.min() * scale, x.max() * scale)
     ax1.set_aspect("equal")
     ax1.set_ylabel(f"{yname} [mm]")
     return ax1
 
 
 def plot_state(
-    domain: Combustor, filename: Path | str, plot_geometry: bool = True
+    domain: Combustor,
+    filename: Path | str,
+    variable_info_map: dict[str, VariableInfo] | None = None,
+    plot_geometry: bool = True,
+    plot_variables: list[str | list[str]] | None = None,
 ) -> None:
     xscale = 1.0e3
-    physics = domain.physics
-    state = domain.state
-    assert state.density is not None
-    assert state.velocity is not None
-    assert state.pressure is not None
     geometry = domain.geometry
     idx_cells = geometry.idx_cells
     x = xscale * geometry.xc[idx_cells]
-    T = physics.get_temperature(state)
-    nrows = 7 if domain.injector is not None else 6
+    state = domain.state[idx_cells]
+
+    if variable_info_map is None:
+        variable_info_map = get_variable_info_map(domain.physics)
+
+    # Set default variables to plot
+    if plot_variables is None:
+        plot_variables = ["r", "u", "p", "t", "m"]
+
+        sp_plot = ["Y_H2", "Y_OH", "Y_H2O"]
+        if all(sp in variable_info_map for sp in sp_plot):
+            plot_variables += [sp_plot]
+
+    nrows: int = len(plot_variables)
+    if domain.injector is not None:
+        nrows += 1
 
     fig: Figure
     axs: list[Axes]
     fig, axs = plt.subplots(nrows, 1, sharex=True, figsize=(6, 9))
-    axs[0].plot(x, state.density[idx_cells])
-    axs[0].set_ymargin(0.1)
-    axs[0].set_ylabel(r"$\rho$ [kg/m$^3$]")
 
-    axs[1].plot(x, state.velocity[idx_cells])
-    axs[1].set_ymargin(0.1)
-    axs[1].set_ylabel(r"$u$ [m/s]")
+    for iax, vnames in enumerate(plot_variables):
+        ax = axs[iax]
 
-    axs[2].plot(x, state.pressure[idx_cells])
-    axs[2].set_ymargin(0.1)
-    axs[2].set_ylabel(r"$p$ [Pa]")
+        if isinstance(vnames, list):
+            vmax = 0.0
+            Y_labels = True
+            plot_labels = []
+            for vname in vnames:
+                variable_info = variable_info_map[vname]
+                value = variable_info.fun(state) * variable_info.scale
+                vmax = max(value.max(), vmax)
 
-    axs[3].plot(x, T[idx_cells])
-    axs[3].set_ymargin(0.1)
-    axs[3].set_ylabel(r"$T$ [K]")
+                legend_label = variable_info.plot_label.split("~")[0] + "$"
+                ax.plot(x, value, label=legend_label)
+                plot_labels += [variable_info.plot_label]
+                if variable_info.short_name[0] != "Y":
+                    Y_labels = False
 
-    M = np.abs(state.velocity) / physics.get_sound_speed(state)
-    axs[4].plot(x, M[idx_cells])
-    axs[4].axhline(1.0, color="r", linestyle="--")
-    axs[4].set_ymargin(0.1)
-    axs[4].set_ylabel(r"$M$ [-]")
+            ax.legend(loc="upper right")
+            if Y_labels:
+                plot_label = r"$Y_k~[\mathrm{-}]$"
+                if vmax < 1e-6:
+                    ax.set_ylim(-1e-3, 1e-3)
+            else:
+                plot_label = ", ".join(plot_labels)
+        else:
+            variable_info = variable_info_map[vnames]
+            ax.plot(x, variable_info.fun(state) * variable_info.scale)
+            plot_label = variable_info.plot_label
 
-    if physics.is_flamelet:
-        state = physics.set_state(state)
-        Y_H2 = physics.lookup("H2", state)[idx_cells]
-        Y_OH = physics.lookup("OH", state)[idx_cells]
-        Y_H2O = physics.lookup("H2O", state)[idx_cells]
-    else:
-        assert state.mass_fractions is not None
-        Y = state.mass_fractions[idx_cells]
-        Y_H2 = Y[:, physics.gas.species_index("H2")]
-        Y_OH = Y[:, physics.gas.species_index("OH")]
-        Y_H2O = Y[:, physics.gas.species_index("H2O")]
-    axs[5].plot(x, Y_H2, label=r"$\mathrm{H}_2$")
-    axs[5].plot(x, Y_OH, label=r"$\mathrm{OH}$")
-    axs[5].plot(x, Y_H2O, label=r"$\mathrm{H}_2\mathrm{O}$")
-    if Y_H2.max() < 1e-6:
-        axs[5].set_ylim(-1e-3, 1e-3)
-    else:
-        axs[5].set_ymargin(0.1)
-    axs[5].set_ylabel(r"$Y_k$ [-]")
-    axs[5].legend(loc="upper right")
+        ax.set_ymargin(0.1)
+        ax.set_ylabel(plot_label)
 
+    ax = axs[-1]
     if domain.injector is not None:
-        axs[6].scatter(
+        ax.scatter(
             domain.injector.fluid_tips[:, 0] * xscale,
             domain.injector.fluid_tips[:, 1] * 1e3 * domain.injector.n_inj,
             s=1,
         )
-        axs[6].set_ymargin(0.1)
-        axs[6].set_ylabel(r"$\dot{m}_f$ [g/s]")
-
-        axs[6].set_xlabel("x [mm]")
+        ax.set_ymargin(0.1)
+        ax.set_ylabel(r"$\dot{m}_f$ [g/s]")
+    ax.set_xlabel("x [mm]")
 
     if plot_geometry:
         for ax in axs:

--- a/src/stanshock/processing/plot.py
+++ b/src/stanshock/processing/plot.py
@@ -4,7 +4,7 @@ import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -29,10 +29,13 @@ class VariableInfo:
     scale: float = 1.0
 
 
-def get_variable_info_map(physics: FluidPhysics) -> dict[str, VariableInfo]:
+VariableInfoMap: TypeAlias = dict[str, VariableInfo]
+
+
+def get_variable_info_map(physics: FluidPhysics) -> VariableInfoMap:
     """Create mapping between strings and variable information."""
     # Common variables available to all FluidPhysics:
-    plot_variables: dict[str, VariableInfo] = {
+    plot_variables: VariableInfoMap = {
         "density": VariableInfo(
             short_name="r",
             plot_label=r"$\rho~[\mathrm{kg/m^3}]$",
@@ -48,7 +51,7 @@ def get_variable_info_map(physics: FluidPhysics) -> dict[str, VariableInfo]:
             scale=1e-5,
         ),
         "temperature": VariableInfo(
-            short_name="t", plot_label=r"$T~[\mathrm{K}]$", fun=physics.get_temperature
+            short_name="T", plot_label=r"$T~[\mathrm{K}]$", fun=physics.get_temperature
         ),
         "gamma": VariableInfo(
             short_name="g", plot_label=r"$\gamma~[\mathrm{-}]$", fun=physics.get_gamma
@@ -178,7 +181,7 @@ class XTDiagram:
         self,
         domain: Combustor,
         variable: str,
-        variable_info_map: dict[str, VariableInfo] | None = None,
+        variable_info_map: VariableInfoMap | None = None,
         skip_steps: int = 0,  # number of timesteps to skip
         x: Array | None = None,  # mesh to interpolate solution onto
         limits: tuple[float, float] | None = None,  # colormap range
@@ -338,7 +341,7 @@ def plot_state(
 
     # Set default variables to plot
     if plot_variables is None:
-        plot_variables = ["r", "u", "p", "t", "m"]
+        plot_variables = ["r", "u", "p", "T", "m"]
 
         sp_plot = ["Y_H2", "Y_OH", "Y_H2O"]
         if all(sp in variable_info_map for sp in sp_plot):
@@ -381,6 +384,9 @@ def plot_state(
             variable_info = variable_info_map[vnames]
             ax.plot(x, variable_info.fun(state) * variable_info.scale)
             plot_label = variable_info.plot_label
+
+            if variable_info.short_name == "m":
+                ax.axhline(1.0, color="r", linestyle="--")
 
         ax.set_ymargin(0.1)
         ax.set_ylabel(plot_label)

--- a/src/stanshock/processing/probe.py
+++ b/src/stanshock/processing/probe.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import ClassVar
 
 import numpy as np
 
-from stanshock.physics.fluid_base import FluidState
+from stanshock.physics.fluid_base import FluidPhysics, FluidState
+from stanshock.processing.plot import VariableInfo, get_variable_info_map
 from stanshock.system.backend import Array
 from stanshock.system.geometry import Geometry
 
@@ -27,19 +29,20 @@ class Probe:
     """
 
     n_probes: ClassVar[int] = 0
+    interpolator: Callable[[Array], float]
 
     def __init__(
         self,
         geometry: Geometry,
+        physics: FluidPhysics,
         probe_location: float,
         skip_steps: int = 0,
         name: str | None = None,
+        plot_variables: list[str] | None = None,
+        variable_info_map: dict[str, VariableInfo] | None = None,
     ) -> None:
-        self.geometry = geometry
         self.probe_location = probe_location
-        if probe_location > np.max(self.geometry.xf) or probe_location < np.min(
-            self.geometry.xf
-        ):
+        if probe_location > np.max(geometry.xf) or probe_location < np.min(geometry.xf):
             msg = "Invalid Probe Location"
             raise ValueError(msg)
 
@@ -49,34 +52,37 @@ class Probe:
         # Increment the number of probes currently instantiated
         Probe.n_probes += 1
 
-        self.t: list[float] = []  # time
-        self.r: list[float] = []  # density
-        self.u: list[float] = []  # velocity
-        self.p: list[float] = []  # pressure
-        self.gamma: list[float] = []  # specific heat ratio
-        self.Y: list[Array] = []  # scalars
+        # Set default variables to plot
+        if plot_variables is None:
+            plot_variables = ["r", "u", "p", "g"] + [
+                scalar for scalar in physics.scalar_names if scalar != "density"
+            ]
+        if variable_info_map is None:
+            variable_info_map = get_variable_info_map(physics)
+        self.plot_variables = ["t", *plot_variables]
+        self.variable_info = [variable_info_map[k] for k in plot_variables]
+
+        # Set the initial time index
+        self.idx = 0
+        self.data = np.full((1000, 1 + len(self.plot_variables)), np.nan)
+
+        # Set up the interpolating function
+        self.interpolator = lambda x: interpolate(geometry.xc, x, self.probe_location)
+
+    def __getattr__(self, name) -> Array:
+        if name in self.plot_variables:
+            return self.data[: self.idx, self.plot_variables.index(name)]
+        msg = f"Variable {name} not requested for probe."
+        raise AttributeError(msg)
 
     def update(self, time: float, state: FluidState) -> None:
-        assert state.density is not None
-        assert state.velocity is not None
-        assert state.pressure is not None
-        assert state.gamma is not None
-        assert state.composition is not None
-        xc = self.geometry.xc
-        n_scalars = state.composition.shape[1]
-        self.t.append(time)
-        self.r.append(interpolate(xc, state.density, self.probe_location))
-        self.u.append(interpolate(xc, state.velocity, self.probe_location))
-        self.p.append(interpolate(xc, state.pressure, self.probe_location))
-        self.gamma.append(interpolate(xc, state.gamma, self.probe_location))
-        YProbe = np.array(
-            [
-                interpolate(
-                    xc,
-                    state.composition[:, kSp],
-                    self.probe_location,
-                )
-                for kSp in range(n_scalars)
-            ]
-        )
-        self.Y.append(YProbe)
+        # Expand the data array if needed
+        if self.idx >= self.data.shape[0]:
+            self.data = np.pad(self.data, ((0, 1000), (0, 0)), constant_values=np.nan)
+
+        # Fill the current row
+        self.data[self.idx, 0] = time
+        for i, vinfo in enumerate(self.variable_info):
+            self.data[self.idx, 1 + i] = self.interpolator(vinfo.fun(state))
+
+        self.idx += 1

--- a/src/stanshock/processing/probe.py
+++ b/src/stanshock/processing/probe.py
@@ -1,17 +1,24 @@
 from __future__ import annotations
 
+from typing import ClassVar
+
 import numpy as np
 
+from stanshock.physics.fluid_base import FluidState
+from stanshock.system.backend import Array
+from stanshock.system.geometry import Geometry
 
-def interpolate(xArray, qArray, x):
+
+def interpolate(x_array: Array, q_array: Array, x: float) -> float:
     """
     helper function for the probe
     """
-    xUpper = (xArray[xArray >= x])[0]
-    xLower = (xArray[xArray < x])[-1]
-    qUpper = (qArray[xArray >= x])[0]
-    qLower = (qArray[xArray < x])[-1]
-    return qLower + (qUpper - qLower) / (xUpper - xLower) * (x - xLower)
+    idx: int = np.where(x_array < x)[0][-1]
+    x_upper = float(x_array[idx + 1])
+    x_lower = float(x_array[idx])
+    q_upper = float((q_array[x_array >= x])[0])
+    q_lower = float((q_array[x_array < x])[-1])
+    return q_lower + (q_upper - q_lower) / (x_upper - x_lower) * (x - x_lower)
 
 
 class Probe:
@@ -19,43 +26,57 @@ class Probe:
     This class is used to store the relevant data for the probe
     """
 
-    def __init__(self, domain, probeLocation, skipSteps=0, probeName=None):
-        self.probeLocation = probeLocation
-        geometry = domain.geometry
-        if probeLocation > np.max(geometry.xf) or probeLocation < np.min(geometry.xf):
+    n_probes: ClassVar[int] = 0
+
+    def __init__(
+        self,
+        geometry: Geometry,
+        probe_location: float,
+        skip_steps: int = 0,
+        name: str | None = None,
+    ) -> None:
+        self.geometry = geometry
+        self.probe_location = probe_location
+        if probe_location > np.max(self.geometry.xf) or probe_location < np.min(
+            self.geometry.xf
+        ):
             msg = "Invalid Probe Location"
-            raise Exception(msg)
+            raise ValueError(msg)
 
-        self.skipSteps = skipSteps  # number of timesteps to skip
-        self.name = probeName
-        if probeName is None:
-            self.name = "probe" + str(len(domain.probes))
+        self.skip_steps = skip_steps  # number of timesteps to skip
+        self.name = f"probe{Probe.n_probes:03d}" if name is None else name
 
-        self.t = []
-        self.r = []  # density
-        self.u = []  # velocity
-        self.p = []  # pressure
-        self.gamma = []  # specific heat ratio
-        self.Y = []  # scalars
+        # Increment the number of probes currently instantiated
+        Probe.n_probes += 1
 
-    def update(self, domain):
-        state = domain.state
-        geometry = domain.geometry
-        self.t.append(domain.t)
-        self.r.append(interpolate(geometry.xc, state.density, self.probeLocation))
-        self.u.append(interpolate(geometry.xc, state.velocity, self.probeLocation))
-        self.p.append(interpolate(geometry.xc, state.pressure, self.probeLocation))
-        self.gamma.append(interpolate(geometry.xc, state.gamma, self.probeLocation))
+        self.t: list[float] = []  # time
+        self.r: list[float] = []  # density
+        self.u: list[float] = []  # velocity
+        self.p: list[float] = []  # pressure
+        self.gamma: list[float] = []  # specific heat ratio
+        self.Y: list[Array] = []  # scalars
+
+    def update(self, time: float, state: FluidState) -> None:
+        assert state.density is not None
+        assert state.velocity is not None
+        assert state.pressure is not None
+        assert state.gamma is not None
+        assert state.composition is not None
+        xc = self.geometry.xc
+        n_scalars = state.composition.shape[1]
+        self.t.append(time)
+        self.r.append(interpolate(xc, state.density, self.probe_location))
+        self.u.append(interpolate(xc, state.velocity, self.probe_location))
+        self.p.append(interpolate(xc, state.pressure, self.probe_location))
+        self.gamma.append(interpolate(xc, state.gamma, self.probe_location))
         YProbe = np.array(
             [
-                (
-                    interpolate(
-                        geometry.xc,
-                        state.composition[:, kSp],
-                        self.probeLocation,
-                    )
+                interpolate(
+                    xc,
+                    state.composition[:, kSp],
+                    self.probe_location,
                 )
-                for kSp in range(domain.physics.n_scalars)
+                for kSp in range(n_scalars)
             ]
         )
         self.Y.append(YProbe)


### PR DESCRIPTION
The following changes are implemented by this update:

- Matplotlib style settings have been removed from the source code in favor of storing them in `.mplstyle` files.
  - See: https://matplotlib.org/stable/users/explain/customizing.html#customizing-with-style-sheets
  - The previously-employed style can be employed using:
```python
import matplotlib.pyplot as plt
plt.style.use("data/stylelib/publication.mplstyle")
```
- A new function `stanshock.processing.plot.get_variable_info_map` analyzes a `FluidPhysics` object and produces a dictionary which maps variable names to info relevant to plotting.
  - The variable info includes the plot label to use, any scaling factors to apply, and a function which takes in a `FluidState` object and returns the requested value.
  - The dictionary can be modified/extended by a user to e.g. change variable units or add new functions to plot.
  - This dictionary is used by plotting functions/classes to facilitate generation of arbitrary plots.
- `XTDiagram`, `plot_state`, and `Probe` have had some updates:
  - Setup steps have been moved to the `__init__` method to simplify the `update` method.
  - The user can now provide a list of variable names to include in the plot/probe, with the original behavior retained if no list is provided.
  - Probes now pre-initialize an array of values to fill instead of creating several lists, expanding the size of the array as-needed.