### PR TITLE
Vectorize WENO scheme and improve ghost cell treatment.

### DIFF
--- a/examples/hyshot_ii.py
+++ b/examples/hyshot_ii.py
@@ -63,7 +63,7 @@ BC_inlet = SpecifiedFace(
     reference_state=(gas_init.density, U_in, gas_init.P, gas_init.Y)
 )
 BC_outlet = "outflow"
-BCs: BCInput = {"left": BC_inlet, "right": BC_outlet}
+BCs: BCInput = {"left": [BC_inlet], "right": [BC_outlet]}
 
 
 # Define the fuel inflow

--- a/examples/hyshot_ii_jic/hyshot_ii_jic.py
+++ b/examples/hyshot_ii_jic/hyshot_ii_jic.py
@@ -211,7 +211,7 @@ BC_inlet = SpecifiedFace(
     reference_state=(gas_init.density, U_in, gas_init.P, (1.0, 0.0, 0.0))
 )
 BC_outlet = "outflow"
-BCs: BCInput = {"left": BC_inlet, "right": BC_outlet}
+BCs: BCInput = {"left": [BC_inlet], "right": [BC_outlet]}
 
 # Load the FPV table
 fpv_table = FPVTable(

--- a/examples/laminar_flame.py
+++ b/examples/laminar_flame.py
@@ -52,10 +52,10 @@ def main(
     geometry = initialize_geometry(xf)
 
     boundary_conditions: BCInput = {
-        "left": FreezeCells(
-            "left"
-        ),  # (gasUnburned.density, uUnburned, None, gasUnburned.Y),
-        "right": FreezeCells("right"),  # (None, None, gasBurned.P, None),
+        "left": [FreezeCells("left")],
+        "right": [FreezeCells("right")],
+        # "left": [(gasUnburned.density, uUnburned, None, gasUnburned.Y)],
+        # "right": [(None, None, gasBurned.P, None)],
     }
     if physics_model == "ThermoTable":
         physics = ThermoTable(gas)

--- a/examples/laminar_flame.py
+++ b/examples/laminar_flame.py
@@ -8,7 +8,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from stanshock.components.combustor import Combustor
-from stanshock.numerics.boundary_conditions import BCInput, FreezeCells
+from stanshock.numerics.boundary_conditions import BCInput, DeactivateWenoCells
 from stanshock.physics.cantera_interface import CanteraInterface
 from stanshock.physics.thermotable import ThermoTable
 from stanshock.processing.initialize import InitializeCanteraArray
@@ -52,8 +52,8 @@ def main(
     geometry = initialize_geometry(xf)
 
     boundary_conditions: BCInput = {
-        "left": [FreezeCells("left")],
-        "right": [FreezeCells("right")],
+        "left": [DeactivateWenoCells("left")],
+        "right": [DeactivateWenoCells("right")],
         # "left": [(gasUnburned.density, uUnburned, None, gasUnburned.Y)],
         # "right": [(None, None, gasBurned.P, None)],
     }

--- a/examples/optimization.py
+++ b/examples/optimization.py
@@ -117,7 +117,7 @@ def main(
     gas4.TPX = T4, p4, "HE:1"
 
     # set up solver parameters
-    boundary_conditions: BCInput = {"left": "reflecting", "right": "reflecting"}
+    boundary_conditions: BCInput = {"left": ["reflecting"], "right": ["reflecting"]}
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)

--- a/examples/sod_problem.py
+++ b/examples/sod_problem.py
@@ -191,13 +191,13 @@ geometry = Geometry(xf, area=1.0)
 
 # Get analytical solution on fine mesh
 t_final = sod_case["t_final"]
-x_analytical = np.linspace(-0.5 * L, L, 2001)
+x_analytical = np.linspace(-0.5 * L, 0.5 * L, 2001)
 p_analytical, rho_analytical, u_analytical = analytical_sod_solution(
     t_final, x_analytical, g
 )
 
 # Set up solver parameters
-boundary_conditions: BCInput = {"left": "reflecting", "right": "reflecting"}
+boundary_conditions: BCInput = {"left": ["reflecting"], "right": ["reflecting"]}
 physics = ThermoTable(gas_left)
 initialization = InitializeRiemannProblem(
     geometry, physics, left_state, right_state, 0.0

--- a/examples/umdci/constant_area_duct.py
+++ b/examples/umdci/constant_area_duct.py
@@ -60,7 +60,7 @@ BC_inlet = SpecifiedFace(
     location="left", reference_state=(gas1.density, u1, gas1.P, (1.0,))
 )
 BC_outlet = SpecifiedFace(location="right", reference_state=(None, None, p2, None))
-BCs: BCInput = {"left": BC_inlet, "right": BC_outlet}
+BCs: BCInput = {"left": [BC_inlet], "right": [BC_outlet]}
 init = InitializeConstant(geometry, physics_model, gas1, u1)
 wall_models = (CompressibleInertSkinFriction(), CompressibleHeatFlux())
 

--- a/examples/validation/case1.py
+++ b/examples/validation/case1.py
@@ -102,7 +102,7 @@ def main(
 
     # set up solver parameters
     print("Solving with boundary layer terms")
-    boundary_conditions: BCInput = {"left": "reflecting", "right": "reflecting"}
+    boundary_conditions: BCInput = {"left": ["reflecting"], "right": ["reflecting"]}
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
@@ -132,7 +132,6 @@ def main(
 
     # without  boundary layer model
     print("Solving without boundary layer model")
-    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
     gas1.TP = T1, p1
     gas4.TP = T4, p4
     ssnbl = ShockTube(

--- a/examples/validation/case2.py
+++ b/examples/validation/case2.py
@@ -103,7 +103,7 @@ def main(
 
     # set up solver parameters
     print("Solving with boundary layer terms")
-    boundary_conditions: BCInput = {"left": "reflecting", "right": "reflecting"}
+    boundary_conditions: BCInput = {"left": ["reflecting"], "right": ["reflecting"]}
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
@@ -133,7 +133,6 @@ def main(
 
     # without  boundary layer model
     print("Solving without boundary layer model")
-    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
     gas1.TP = T1, p1
     gas4.TP = T4, p4
     ssnbl = ShockTube(

--- a/examples/validation/case3.py
+++ b/examples/validation/case3.py
@@ -154,7 +154,7 @@ def main(
 
     # set up solver parameters
     print("Solving with boundary layer terms")
-    boundary_conditions: BCInput = {"left": "reflecting", "right": "reflecting"}
+    boundary_conditions: BCInput = {"left": ["reflecting"], "right": ["reflecting"]}
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
@@ -184,7 +184,6 @@ def main(
 
     # without  boundary layer model
     print("Solving without boundary layer model")
-    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
     gas1.TP = T1, p1
     gas4.TP = T4, p4
     ssnbl = ShockTube(

--- a/examples/validation/case4.py
+++ b/examples/validation/case4.py
@@ -204,7 +204,7 @@ def main(
     )
 
     # solve with boundary layer model
-    boundary_conditions: BCInput = {"left": "reflecting", "right": "reflecting"}
+    boundary_conditions: BCInput = {"left": ["reflecting"], "right": ["reflecting"]}
     state1 = (gas1, u1)
     state4 = (gas4, u4)
     physics_model = ThermoTable(gas1)
@@ -248,7 +248,6 @@ def main(
             diagram.plot()
 
     # Solve without boundary layer model
-    boundary_conditions = {"left": "reflecting", "right": "reflecting"}
     gas1.TP = T1, p1
     gas4.TP = T4, p4
     ssnbl = ShockTube(

--- a/src/stanshock/numerics/boundary_conditions.py
+++ b/src/stanshock/numerics/boundary_conditions.py
@@ -204,7 +204,7 @@ class AdiabaticWallFace(ExtrapolateFace):
 
 
 ReferenceStateType: TypeAlias = tuple[
-    float | None, float | None, float | None, Sequence[float] | None
+    float | None, float | None, float | None, Array | Sequence[float] | None
 ]
 
 
@@ -338,8 +338,8 @@ BCLike: TypeAlias = BCType | BCNamesType | ReferenceStateType
 
 
 class BCInput(TypedDict):
-    left: BCLike | Sequence[BCLike]
-    right: BCLike | Sequence[BCLike]
+    left: Sequence[BCLike]
+    right: Sequence[BCLike]
 
 
 def set_boundary_conditions(
@@ -349,38 +349,32 @@ def set_boundary_conditions(
 
     # If ghost layer method not specified, default to freezing (hold constant)
     default_ghost_layers: dict[str, GhostCell | GhostCellPrimitive] = {
-        "left": DeactivateWenoCells(mt=mt, location="left"),
-        "right": DeactivateWenoCells(mt=mt, location="right"),
+        "left": ExtrapolateCells(mt=mt, location="left"),
+        "right": ExtrapolateCells(mt=mt, location="right"),
     }
 
     # Convert lists into BoundaryConditions:
     if not isinstance(boundary_conditions, BoundaryConditions):
-        bc_locs: list[Literal["left", "right"]] = ["left", "right"]
         bcs: list[BCType] = []
-        for bc_loc in bc_locs:
-            if isinstance(boundary_conditions[bc_loc], str | BoundaryCondition | tuple):
-                bc_tmp = [boundary_conditions[bc_loc]]
-            else:
-                bc_tmp = boundary_conditions[bc_loc]
-
-            for bc_specification in bc_tmp:
-                if isinstance(bc_specification, str):
-                    if bc_specification == "periodic":
-                        bcs += [PeriodicCells(mt, location=bc_loc)]
-                    elif bc_specification == "extrapolate":
-                        bcs += [ExtrapolateCells(mt, location=bc_loc)]
-                    elif bc_specification == "outflow":
-                        bcs += [ExtrapolateFace(location=bc_loc)]
-                    elif bc_specification in ["symmetry", "reflecting"]:
-                        bcs += [SymmetryCells(mt, location=bc_loc)]
-                    elif bc_specification == "wall":
-                        bcs += [AdiabaticWallFace(location=bc_loc)]
-                elif isinstance(bc_specification, BoundaryCondition):
-                    bcs += [bc_specification]
-                elif isinstance(bc_specification, tuple):
-                    bcs += [
-                        SpecifiedFace(reference_state=bc_specification, location=bc_loc)
-                    ]
+        bc_loc: Literal["left", "right"]
+        for bc_loc, bc_specification in boundary_conditions.items():  # type: ignore[assignment]
+            if isinstance(bc_specification, str):
+                if bc_specification == "periodic":
+                    bcs += [PeriodicCells(mt, location=bc_loc)]
+                elif bc_specification == "extrapolate":
+                    bcs += [ExtrapolateCells(mt, location=bc_loc)]
+                elif bc_specification == "outflow":
+                    bcs += [ExtrapolateFace(location=bc_loc)]
+                elif bc_specification in ["symmetry", "reflecting"]:
+                    bcs += [SymmetryCells(mt, location=bc_loc)]
+                elif bc_specification == "wall":
+                    bcs += [AdiabaticWallFace(location=bc_loc)]
+            elif isinstance(bc_specification, BoundaryCondition):
+                bcs += [bc_specification]
+            elif isinstance(bc_specification, tuple):
+                bcs += [
+                    SpecifiedFace(reference_state=bc_specification, location=bc_loc)
+                ]
 
         boundary_conditions = BoundaryConditions(boundary_conditions=bcs)
 

--- a/src/stanshock/numerics/boundary_conditions.py
+++ b/src/stanshock/numerics/boundary_conditions.py
@@ -132,37 +132,8 @@ class SymmetryCells(GhostCell):
         return target
 
 
-class DeactivateWenoCells(GhostCellPrimitive):
-    """Applies large values and variance to primitives in ghost layers.
-
-    This is one approach to forcing the WENO stencil to only consider interior cells.
-    """
-
-    def __init__(
-        self, mt: int = 3, location: Literal["left", "right"] = "left"
-    ) -> None:
-        super().__init__(location)
-        if self.location == "left":
-            self.values = (10.0 * np.arange(mt, 0, -1)) ** 10.0
-            self.idx_exterior: Index = np.s_[:mt]
-        else:
-            self.values = (10.0 * np.arange(1, mt + 1)) ** 10.0
-            self.idx_exterior = np.s_[-mt:]
-
-    def update(self, time: float, target: FluidState) -> FluidState:
-        _: float = time
-        assert target.density is not None
-        assert target.velocity is not None
-        assert target.pressure is not None
-        assert target.composition is not None
-
-        values = self.values.copy()
-        target.density[self.idx_exterior] = values
-        target.velocity[self.idx_exterior] = values
-        target.pressure[self.idx_exterior] = values
-        target.composition[self.idx_exterior] = values[:, None]
-
-        return target
+class DeactivateWenoCells(FreezeCells):
+    """Indicates these ghost cells are not to be used within WENO calculations."""
 
 
 class ExtrapolateFace(RiemannFlux):
@@ -274,6 +245,16 @@ class BoundaryConditions:
         self._boundary_conditions += [boundary_condition]
 
     @property
+    def disable_ghost_layers(self) -> tuple[bool, bool]:
+        disable: list[bool] = [False, False]
+        map_lr = {"left": 0, "right": 1}
+        for bc in self._boundary_conditions:
+            if isinstance(bc, DeactivateWenoCells):
+                disable[map_lr[bc.location]] = True
+
+        return disable[0], disable[1]
+
+    @property
     def ghost_cells(self) -> list[GhostCell]:
         return [
             boundary_condition
@@ -347,10 +328,11 @@ def set_boundary_conditions(
 ) -> BoundaryConditions:
     """Convenience function to initialize different boundary conditions."""
 
-    # If ghost layer method not specified, default to freezing (hold constant)
+    # If ghost layer method not specified, default to freezing (hold constant) with
+    # ghost layers disabled for the WENO scheme.
     default_ghost_layers: dict[str, GhostCell | GhostCellPrimitive] = {
-        "left": ExtrapolateCells(mt=mt, location="left"),
-        "right": ExtrapolateCells(mt=mt, location="right"),
+        "left": DeactivateWenoCells(location="left"),
+        "right": DeactivateWenoCells(location="right"),
     }
 
     # Convert lists into BoundaryConditions:

--- a/src/stanshock/numerics/face_extrapolation.py
+++ b/src/stanshock/numerics/face_extrapolation.py
@@ -279,21 +279,19 @@ def weno5(
         L /= cAverage**2.0
 
         # Perform WENO interpolation in characteristic variables
-        for iVar in range(nVar):
-            for iStencil in range(nStencil):
-                iCellStencil = iStencil - 2 + iCell
+        for iStencil in range(nStencil):
+            iCellStencil = iStencil - 2 + iCell
 
-                # Conservative variables [rhou, rhoE, rhoY1, rhoY2, ...]
-                U[0] = r[iCellStencil] * u[iCellStencil]  # momentum
-                U[1] = (
-                    p[iCellStencil] / (gammaAverage - 1.0)
-                    + 0.5 * r[iCellStencil] * u[iCellStencil] ** 2.0
-                )  # energy
-                for kSc in range(nSc):
-                    U[mn + kSc] = (
-                        r[iCellStencil] * Y[iCellStencil, kSc]
-                    )  # scalar densities
+            # Conservative variables [rhou, rhoE, rhoY1, rhoY2, ...]
+            U[0] = r[iCellStencil] * u[iCellStencil]  # momentum
+            U[1] = (
+                p[iCellStencil] / (gammaAverage - 1.0)
+                + 0.5 * r[iCellStencil] * u[iCellStencil] ** 2.0
+            )  # energy
+            for kSc in range(nSc):
+                U[mn + kSc] = r[iCellStencil] * Y[iCellStencil, kSc]  # scalar densities
 
+            for iVar in range(nVar):
                 CStencil[iStencil, iVar] = 0.0
                 for jVar in range(nVar):
                     CStencil[iStencil, iVar] += L[iVar, jVar] * U[jVar]
@@ -437,6 +435,262 @@ def weno5(
                 PLR[N, iFace, iVar] = P[iCell, iVar] + 0.5 * phi * (
                     P[iCell, iVar] - P[iCellm1, iVar]
                 )
+
+    return PLR
+
+
+# Cell weight (WL(i,j,k); i=left(1) or right(2), j=stencil #, k=weight #)
+W = (
+    np.array(
+        [[[2, 5, -1], [-1, 5, 2], [2, -7, 11]], [[11, -7, 2], [2, 5, -1], [-1, 5, 2]]]
+    )
+    / 6.0
+)
+
+# Stencil Weight (i=left(1) or right(2), j=stencil #)
+D = np.empty((2, 3))
+D = np.array([[0.3, 0.6, 0.1], [0.1, 0.6, 0.3]])
+
+
+def weno5_vectorized(
+    r: Array,
+    u: Array,
+    p: Array,
+    Y: Array,
+    gamma: Array,
+    n_ghost_layers: int,
+    n_scalars_rho_sum: int,
+) -> Array:
+    """
+    This method implements the fifth-order WENO interpolation. This method
+    follows that of Houim and Kuo (JCP2011)
+        inputs:
+            r=density
+            u=velocity
+            p=pressure
+            Y=scalar variables matrix [x,scalars]
+            gamma=specific heat ratio
+            n_ghost_layers=number of ghost layers
+            n_scalars_rho_sum=number of scalars that are summed into density
+        outputs:
+            PLR=a matrix of the primitive variables [LR,]
+    """
+    nLR = 2
+    nCells = len(r) - 2 * n_ghost_layers
+    nFaces = nCells + 1
+    nSc = len(Y[0])  # number of scalars
+    nVar = mn + nSc  # [rhou, rhoE, rhoY1, rhoY2, ...]
+    nStencil = 2 * n_ghost_layers
+    epWENO = 1.0e-06
+
+    B1 = 1.083333333333333
+    B2 = 0.25
+
+    PLR = np.empty((nLR, nFaces, nVar + 1))
+
+    iCell0 = n_ghost_layers - 1
+    iCell1 = nFaces + n_ghost_layers - 1
+    idx_left = slice(iCell0, iCell1)
+    idx_right = slice(iCell0 + 1, iCell1 + 1)
+    idx_sc = np.arange(nSc, dtype=int)
+
+    # Face averages
+    rAverage = 0.5 * (r[idx_left] + r[idx_right])
+    uAverage = 0.5 * (u[idx_left] + u[idx_right])
+    pAverage = 0.5 * (p[idx_left] + p[idx_right])
+    gammaAverage = 0.5 * (gamma[idx_left] + gamma[idx_right])
+    YAverage = 0.5 * (Y[idx_left] + Y[idx_right])
+    eAverage = pAverage / (rAverage * (gammaAverage - 1.0)) + 0.5 * uAverage**2.0
+    hAverage = eAverage + pAverage / rAverage
+    cAverage = np.sqrt(gammaAverage * pAverage / rAverage)
+
+    # Right eigenvector matrix [rhou, rhoE, rhoY1, rhoY2, ...]
+    R = np.zeros((nFaces, nVar, nVar))
+
+    # Acoustic waves (columns 0 and -1)
+    R[:, 0, 0] = uAverage - cAverage  # momentum, left acoustic
+    R[:, 1, 0] = hAverage - uAverage * cAverage  # energy, left acoustic
+    R[:, 0, -1] = uAverage + cAverage  # momentum, right acoustic
+    R[:, 1, -1] = hAverage + uAverage * cAverage  # energy, right acoustic
+
+    # Entropy waves (columns 1 to nSp)
+    R[:, 0, idx_sc + 1] = uAverage[:, None]  # momentum, entropy wave i
+    R[:, 1, idx_sc + 1] = 0.5 * uAverage[:, None] ** 2.0  # energy, entropy wave i
+    R[:, idx_sc + mn, idx_sc + 1] = 1.0  # scalar i density, entropy wave i
+
+    # Scalar densities for acoustic waves
+    R[:, idx_sc + mn, 0] = YAverage  # scalar i, left acoustic
+    R[:, idx_sc + mn, -1] = YAverage  # scalar i, right acoustic
+
+    # Left eigenvector matrix [rhou, rhoE, rhoY1, rhoY2, ...]
+    L = np.zeros((nFaces, nVar, nVar))
+    gammaHat = gammaAverage - 1.0
+    phi = 0.5 * gammaHat * uAverage**2.0
+    firstRowConstant = 0.5 * (phi + uAverage * cAverage)
+    lastRowConstant = 0.5 * (phi - uAverage * cAverage)
+
+    # Acoustic wave rows (rows 0 and -1)
+    # left acoustic, momentum
+    L[:, 0, 0] = -0.5 * (gammaHat * uAverage + cAverage)
+    L[:, 0, 1] = 0.5 * gammaHat  # left acoustic, energy
+    # right acoustic, momentum
+    L[:, -1, 0] = -0.5 * (gammaHat * uAverage - cAverage)
+    L[:, -1, 1] = 0.5 * gammaHat  # right acoustic, energy
+
+    # Acoustic wave interactions with scalars
+    L[:, 0, idx_sc + mn] = firstRowConstant[:, None]  # left acoustic, scalar i
+    L[:, -1, idx_sc + mn] = lastRowConstant[:, None]  # right acoustic, scalar i
+
+    # Entropy wave rows (rows 1 to nSp)
+    # entropy wave i, momentum
+    L[:, idx_sc + 1, 0] = YAverage * (gammaHat * uAverage)[:, None]
+    # entropy wave i, energy
+    L[:, idx_sc + 1, 1] = -YAverage * gammaHat[:, None]
+
+    # Entropy wave interactions with scalars
+    # entropy wave i, scalar j
+    L[:, 1 : nSc + 1, mn : nSc + mn] = -YAverage[:, :, None] * phi[:, None, None]
+    L[:, idx_sc + 1, idx_sc + mn] += cAverage[:, None] ** 2.0  # diagonal correction
+    L /= cAverage[:, None, None] ** 2.0
+
+    # Conservative variables [rhou, rhoE, rhoY1, rhoY2, ...]
+    U0 = np.concatenate(
+        (
+            (r * u)[:, None],  # momentum
+            (0.5 * r * u**2.0)[:, None],  # energy
+            r[:, None] * Y,  # scalar densities
+        ),
+        axis=1,
+    )
+    CStencil = np.empty((nFaces, nStencil, nVar))
+    # ^ all the characteristic values in the stencil
+    for iStencil in range(nStencil):
+        idx = slice(iCell0 + iStencil - 2, iCell1 + iStencil - 2)
+        U = U0[idx].copy()
+        U[:, 1] += p[idx] / (gammaAverage - 1.0)
+        CStencil[:, iStencil] = np.sum(L * U[:, None, :], axis=-1)
+
+    # WENO interpolation in characteristic variables
+    for N in range(nLR):
+        NO = N + 2
+
+        # Smoothness parameters
+        B = np.stack(
+            (
+                (
+                    B1
+                    * (
+                        CStencil[:, NO]
+                        - 2.0 * CStencil[:, NO + 1]
+                        + CStencil[:, NO + 2]
+                    )
+                    ** 2.0
+                    + B2
+                    * (
+                        3.0 * CStencil[:, NO]
+                        - 4.0 * CStencil[:, NO + 1]
+                        + CStencil[:, NO + 2]
+                    )
+                    ** 2
+                ),
+                (
+                    B1
+                    * (
+                        CStencil[:, NO - 1]
+                        - 2.0 * CStencil[:, NO]
+                        + CStencil[:, NO + 1]
+                    )
+                    ** 2.0
+                    + B2 * (CStencil[:, NO - 1] - CStencil[:, NO + 1]) ** 2
+                ),
+                (
+                    B1
+                    * (
+                        CStencil[:, NO - 2]
+                        - 2.0 * CStencil[:, NO - 1]
+                        + CStencil[:, NO]
+                    )
+                    ** 2.0
+                    + B2
+                    * (
+                        CStencil[:, NO - 2]
+                        - 4.0 * CStencil[:, NO - 1]
+                        + 3.0 * CStencil[:, NO]
+                    )
+                    ** 2
+                ),
+            ),
+            axis=1,
+        )
+
+        # Edge interpolation
+        idx = NO - np.arange(n_ghost_layers, dtype=int)
+        CINT = (
+            W[N, None, :, 0, None] * CStencil[:, idx]
+            + W[N, None, :, 1, None] * CStencil[:, idx + 1]
+            + W[N, None, :, 2, None] * CStencil[:, idx + 2]
+        )
+        A = D[N, None, :, None] / ((epWENO + B) ** 2)
+        ATOT = np.sum(A, axis=1)
+        CW = np.sum(CINT * A, axis=1)
+        CiVar = CW / ATOT
+        U = np.sum(R * CiVar[:, None, :], axis=2)
+
+        # Reconstruct primitives from conservatives
+        rLR = np.sum(U[..., mn : mn + n_scalars_rho_sum], axis=-1)
+        rLR = np.maximum(rLR, 1e-30)
+        uLR = U[..., 0] / rLR
+        eLR = U[..., 1] / rLR
+        pLR = rLR * (gammaAverage - 1.0) * (eLR - 0.5 * uLR**2.0)
+
+        # Fill primitive matrix [rho, u, p, Y1, Y2, ...]
+        PLR[N] = np.concatenate(
+            (
+                rLR[:, None],
+                uLR[:, None],
+                pLR[:, None],
+                U[:, mn : mn + nSc] / rLR[:, None],
+            ),
+            axis=1,
+        )
+
+    # Create primitive matrix for limiter
+    P = np.concatenate((r[:, None], u[:, None], p[:, None], Y), axis=-1)
+
+    # Apply limiter
+    alpha = 2.0
+    threshold = 1e-6
+    epsilon = 1.0e-15
+    for N in range(nLR):
+        iCell = np.arange(iCell0, iCell1, dtype=int) + N
+        iCellm1 = iCell - 1 + 2 * N
+        iCellp1 = iCell + 1 - 2 * N
+        iCellm2 = iCell - 2 + 4 * N
+        iCellp2 = iCell + 2 - 4 * N
+        # check the error threshold for smooth regions
+        error = np.abs(
+            (-P[iCellm2] + 4.0 * P[iCellm1] + 4.0 * P[iCellp1] - P[iCellp2] + epsilon)
+            / (6.0 * P[iCell] + epsilon)
+            - 1.0
+        )
+        # compute limiter
+        idx = np.where(error >= threshold)
+        phi = np.full_like(error[idx], alpha)
+
+        denom = P[iCell][idx] - P[iCellm1][idx]
+        sign = np.sign(denom)
+        numer = np.minimum(
+            sign * alpha * (P[iCellp1][idx] - P[iCell][idx]),
+            sign * 2.0 * (PLR[N][idx] - P[iCell][idx]),
+        )
+        denom = np.abs(denom)
+        phi = np.divide(numer, denom, out=phi, where=denom != 0.0)
+        phi = np.clip(phi, 0.0, alpha)
+
+        # apply limiter
+        PLR[N, idx[0], idx[1]] = P[iCell][idx] + 0.5 * phi * (
+            P[iCell][idx] - P[iCellm1][idx]
+        )
 
     return PLR
 

--- a/src/stanshock/numerics/face_extrapolation.py
+++ b/src/stanshock/numerics/face_extrapolation.py
@@ -687,14 +687,14 @@ def weno5_vectorized(
         idx = np.where(error >= threshold)
         phi = np.full_like(error[idx], alpha)
 
-        denom = P[iCell][idx] - P[iCellm1][idx]
-        sign = np.sign(denom)
-        numer = np.minimum(
+        den = P[iCell][idx] - P[iCellm1][idx]
+        sign = np.sign(den)
+        num = np.minimum(
             sign * alpha * (P[iCellp1][idx] - P[iCell][idx]),
             sign * 2.0 * (PLR[N][idx] - P[iCell][idx]),
         )
-        denom = np.abs(denom)
-        phi = np.divide(numer, denom, out=phi, where=denom != 0.0)
+        den = np.abs(den)
+        phi = np.divide(num, den, out=phi, where=den != 0.0)
         phi = np.clip(phi, 0.0, alpha)
 
         # apply limiter

--- a/src/stanshock/numerics/face_extrapolation.py
+++ b/src/stanshock/numerics/face_extrapolation.py
@@ -460,6 +460,7 @@ def weno5_vectorized(
     gamma: Array,
     n_ghost_layers: int,
     n_scalars_rho_sum: int,
+    disable_ghost_layers: tuple[bool, bool] = (False, False),
 ) -> Array:
     """
     This method implements the fifth-order WENO interpolation. This method
@@ -631,6 +632,15 @@ def weno5_vectorized(
             + W[N, None, :, 2, None] * CStencil[:, idx + 2]
         )
         A = D[N, None, :, None] / ((epWENO + B) ** 2)
+
+        # Optionally disable use of ghost layer points:
+        if disable_ghost_layers[0]:
+            for i in range(1, n_ghost_layers):
+                A[i - N, i:] = 0.0
+        if disable_ghost_layers[1]:
+            for i in range(1, n_ghost_layers):
+                A[-i - N, : n_ghost_layers - i] = 0.0
+
         ATOT = np.sum(A, axis=1)
         CW = np.sum(CINT * A, axis=1)
         CiVar = CW / ATOT
@@ -698,6 +708,15 @@ def weno5_vectorized(
 class FifthOrderWeno(FaceExtrapolator):
     minimum_ghost_layers: int = 3
 
+    def __init__(
+        self,
+        n_scalars_rho_sum: int,
+        n_ghost_layers: int = minimum_ghost_layers,
+        disable_ghost_layers: tuple[bool, bool] = (False, False),
+    ) -> None:
+        super().__init__(n_scalars_rho_sum, n_ghost_layers)
+        self.disable_ghost_layers = disable_ghost_layers
+
     def __call__(self, state: FluidState) -> FluidState:
         """First order interpolation to the edge states."""
         assert state.density is not None
@@ -728,7 +747,7 @@ class FifthOrderWeno(FaceExtrapolator):
             assert state.gamma is not None
             gamma = state.gamma
 
-        face_states_array: Array = weno5(
+        face_states_array: Array = weno5_vectorized(
             r=state.density,
             u=state.velocity,
             p=state.pressure,
@@ -736,6 +755,7 @@ class FifthOrderWeno(FaceExtrapolator):
             gamma=gamma,
             n_ghost_layers=self.n_ghost_layers,
             n_scalars_rho_sum=self.n_scalars_rho_sum,
+            disable_ghost_layers=self.disable_ghost_layers,
         )
 
         return FluidState(

--- a/src/stanshock/numerics/inviscid_flux.py
+++ b/src/stanshock/numerics/inviscid_flux.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 import numpy as np
 from numba import double, njit
 
+from stanshock.numerics.face_extrapolation import FifthOrderWeno
 from stanshock.physics.fluid_base import FluidState
 from stanshock.system.backend import Array, TypeAlias, Unpack
 from stanshock.system.base import PrecomputeStepName, PrecomputeSteps, RightHandSide
@@ -293,6 +294,14 @@ class InviscidFlux(RightHandSide):
         self.dx: Array | float = self.geometry.dx
         if isinstance(self.dx, np.ndarray):
             self.dx = self.dx[self.geometry.idx_cells]
+
+        # Inform the face extrapolator whether the ghost layers are to be disabled
+        # for the given boundary conditions
+        if isinstance(self.face_extrapolator, FifthOrderWeno):
+            assert self.boundary_conditions is not None
+            self.face_extrapolator.disable_ghost_layers = (
+                self.boundary_conditions.disable_ghost_layers
+            )
 
     def source_implementation(
         self,


### PR DESCRIPTION
This adds a new `weno_flux_vectorized` routine to improve performance when not using Numba. This routine additionally provides an explicit option for restricting the WENO stencil to interior points only, which is enabled simply by checking for the presence of a `DeactivateWenoCells` boundary condition, which now simply duplicates the `FreezeCells` behavior (i.e. no-op).