### PR TITLE
Decouple ThermoTable physics from Cantera

### DIFF
--- a/src/stanshock/numerics/viscous_flux.py
+++ b/src/stanshock/numerics/viscous_flux.py
@@ -41,7 +41,7 @@ class ViscousFlux(RightHandSide):
         diffusivities = self.physics.get_mass_diffusivity(avg_face_states) * self.F
         enthalpies = self.physics.get_species_enthalpies(avg_face_states)
         density = avg_face_states.density
-        Y = avg_face_states.mass_fractions
+        Y = self.physics.get_mass_fractions(avg_face_states)
 
         # Get gradients across the faces
         dudx = face_gradients.velocity

--- a/src/stanshock/physics/fluid_base.py
+++ b/src/stanshock/physics/fluid_base.py
@@ -17,6 +17,7 @@ class FluidState:
     density: Array | None = None
     temperature: Array | None = None
     pressure: Array | None = None
+    enthalpy: Array | None = None
     internal_energy: Array | None = None
     mass_fractions: Array | None = None
     mole_fractions: Array | None = None
@@ -29,12 +30,15 @@ class FluidState:
     gamma: Array | None = None
     viscosity: Array | None = None
     thermal_conductivity: Array | None = None
+    mass_diffusivity: Array | None = None
     sound_speed: Array | None = None
 
     velocity: Array | None = None
 
     gamma_star: Array | None = None
     e0_star: Array | None = None
+
+    logT_poly: Array | None = None
 
     _cache_valid: bool = False
 
@@ -98,6 +102,7 @@ class FluidPhysics(ABC):
         self.n_scalars: int = self.gas.n_species
         self.n_scalars_rho_sum: int = self.n_scalars
         self.scalar_names: list[str] = self.gas.species_names
+        self.molecular_weights: Array = gas.molecular_weights
 
         self.is_flamelet: bool = False
 
@@ -272,6 +277,12 @@ class FluidPhysics(ABC):
         """Returns mass fractions, computing from transported scalars if needed."""
         assert state.composition is not None
         return state.composition
+
+    def get_mole_fractions(self, state: FluidState) -> Array:
+        """Returns mole fractions, computing from mass fractions if needed."""
+        Y = self.get_mass_fractions(state)
+        Y_W = Y / self.molecular_weights[None, :]
+        return Y_W / np.sum(Y_W, axis=-1, keepdims=True)
 
     def get_normalized_progress_variable(self, Z: Array, C: Array) -> Array:
         _ = Z, C

--- a/src/stanshock/physics/thermotable.py
+++ b/src/stanshock/physics/thermotable.py
@@ -15,13 +15,13 @@ double3D = double[:, :, :]
 
 
 @njit(double1D(double2D, double1D))
-def get_specific_gas_constant_compiled(Y: Array, molecularWeights: Array) -> Array:
+def get_specific_gas_constant_compiled(Y: Array, molecular_weights: Array) -> Array:
     """
     Function used by the thermoTable class to find the gas constant. This
     function is compiled for speed-up.
         inputs:
             Y: scalar [nX,nSp]
-            molecularWeights: species molecular weights [nSp]
+            molecular_weights: species molecular weights [nSp]
         output:
             R: gas constants [nX]
     """
@@ -33,7 +33,7 @@ def get_specific_gas_constant_compiled(Y: Array, molecularWeights: Array) -> Arr
     for iX in range(nX):
         molecularWeight: float = 0.0
         for iSp in range(nSp):
-            molecularWeight += Y[iX, iSp] / molecularWeights[iSp]
+            molecularWeight += Y[iX, iSp] / molecular_weights[iSp]
         molecularWeight = 1.0 / molecularWeight
         R[iX] = ct.gas_constant / molecularWeight
     return R
@@ -98,43 +98,66 @@ class ThermoTable(CanteraInterface):
         enthalpies at the table points.
         """
         super().__init__(gas, ox_def, fuel_def, prog_def)
-        nSp: int = gas.n_species
+        nsp: int = gas.n_species
         self.TMin: float = gas.min_temp
-        nT = 21
+        nT = 101
         self.TMax: float = gas.max_temp
         # vector of temperatures assuming thermal equilibrium between species
         self.T: Array = np.linspace(self.TMin, self.TMax, nT, dtype=np.float64)
         self.dT = (self.TMax - self.TMin) / (nT - 1)
         # matrix of species enthalpies per temperature
-        self.h: Array = np.zeros((nT, nSp))
+        self.h: Array = np.zeros((nT, nsp))
         # cpk = ak*T+bk for T in [Tk,Tk+1], k in {0,1,2,...,nT-1}
         # matrix of species first order coefficients
-        self.a: Array = np.zeros((nT, nSp))
+        self.a: Array = np.zeros((nT, nsp))
         # matrix of species zeroth order coefficients
-        self.b: Array = np.zeros((nT, nSp))
-        self.molecularWeights: Array = gas.molecular_weights
+        self.b: Array = np.zeros((nT, nsp))
+        # transport property curve fit coefficients
+        polynomial_order: int = 4
+        self.viscosity_coeffs: Array = np.zeros((polynomial_order + 1, nsp))
+        self.conductivity_coeffs: Array = np.zeros((polynomial_order + 1, nsp))
+        self.binary_diff_coeffs: Array = np.zeros((polynomial_order + 1, nsp, nsp))
+        self.polynomial_order = polynomial_order
+        self.nsp = nsp
+
         # determine the coefficients
-        for kSp, species in enumerate(gas.species()):
+        for ksp, species in enumerate(gas.species()):
             # initialize with actual cp
-            cpk = species.thermo.cp(self.T[0]) / self.molecularWeights[kSp]
-            hk = species.thermo.h(self.T[0]) / self.molecularWeights[kSp]
+            cpk = species.thermo.cp(self.T[0]) / self.molecular_weights[ksp]
+            hk = species.thermo.h(self.T[0]) / self.molecular_weights[ksp]
             for kT, Tk in enumerate(self.T):
                 # compute next
                 Tkp1 = Tk + self.dT
-                hkp1 = species.thermo.h(Tkp1) / self.molecularWeights[kSp]
+                hkp1 = species.thermo.h(Tkp1) / self.molecular_weights[ksp]
                 dh = hkp1 - hk
                 # store
-                self.h[kT, kSp] = hk
-                self.a[kT, kSp] = 2.0 / self.dT * (dh / self.dT - cpk)
-                self.b[kT, kSp] = cpk - self.a[kT, kSp] * Tk
+                self.h[kT, ksp] = hk
+                self.a[kT, ksp] = 2.0 / self.dT * (dh / self.dT - cpk)
+                self.b[kT, ksp] = cpk - self.a[kT, ksp] * Tk
                 # update
-                cpk = self.a[kT, kSp] * (Tkp1) + self.b[kT, kSp]
+                cpk = self.a[kT, ksp] * (Tkp1) + self.b[kT, ksp]
                 hk = hkp1
+
+            # Load transport property coefficients
+            self.viscosity_coeffs[:, ksp] = gas.get_viscosity_polynomial(i=ksp)
+            self.conductivity_coeffs[:, ksp] = gas.get_thermal_conductivity_polynomial(
+                i=ksp
+            )
+            for jsp in range(nsp):
+                self.binary_diff_coeffs[:, ksp, jsp] = (
+                    gas.get_binary_diff_coeffs_polynomial(i=ksp, j=jsp)
+                )
+
         # Compute the matching species internal energies
         self.e = (
-            self.h - ct.gas_constant * self.T[:, None] / self.molecularWeights[None, :]
+            self.h - ct.gas_constant * self.T[:, None] / self.molecular_weights[None, :]
         )
-        self.c = self.b - ct.gas_constant / self.molecularWeights[None, :]
+        self.c = self.b - ct.gas_constant / self.molecular_weights[None, :]
+
+        # Precompute some constants used by viscosity mixing rule.
+        ratio = self.molecular_weights[:, None] / self.molecular_weights[None, :]
+        self.W_ratio_4 = ratio**-0.25
+        self.W_bottom_sqrt = (1.0 + ratio) ** -0.5
 
     def get_specific_gas_constant(self, state: FluidState) -> Array:
         """
@@ -144,9 +167,9 @@ class ThermoTable(CanteraInterface):
             outputs:
                 R: vector of mixture-specific gas constants [n]
         """
-        assert state.composition is not None
+        Y = self.get_mass_fractions(state)
         return get_specific_gas_constant_compiled(
-            state.composition.reshape((-1, self.n_scalars)), self.molecularWeights
+            Y.reshape((-1, self.n_scalars)), self.molecular_weights
         ).reshape(state.shape)
 
     def get_cp(self, state: FluidState) -> Array:
@@ -159,16 +182,13 @@ class ThermoTable(CanteraInterface):
             outputs:
                 cp: vector of constant pressure specific heats
         """
-        assert state.composition is not None
-        if state.temperature is None:
-            state.temperature = self.get_temperature(state)
-        return get_cp_compiled(
-            state.temperature.flatten(),
-            state.composition.reshape((-1, self.n_scalars)),
-            self.T,
-            self.a,
-            self.b,
-        ).reshape(state.shape)
+        if state.cp is None:
+            Y = self.get_mass_fractions(state)
+            T = self.get_temperature(state)
+            state.cp = get_cp_compiled(
+                T.flatten(), Y.reshape((-1, self.n_scalars)), self.T, self.a, self.b
+            ).reshape(state.shape)
+        return state.cp
 
     def get_gamma(self, state: FluidState) -> Array:
         """
@@ -178,9 +198,88 @@ class ThermoTable(CanteraInterface):
             outputs:
                 gamma: vector of specific heat ratios [n]
         """
-        cp = self.get_cp(state)
-        R = self.get_specific_gas_constant(state)
-        return cp / (cp - R)
+        if state.gamma is None:
+            cp = self.get_cp(state)
+            R = self.get_specific_gas_constant(state)
+            state.gamma = cp / (cp - R)
+        return state.gamma
+
+    def get_logT_poly(self, state: FluidState) -> Array:
+        if state.logT_poly is None:
+            logT = np.log(self.get_temperature(state))
+            state.logT_poly = np.stack(
+                [logT**i for i in range(self.polynomial_order + 1)], axis=-1
+            )
+        return state.logT_poly
+
+    def get_mu(self, state: FluidState) -> Array:
+        if state.viscosity is None:
+            T = self.get_temperature(state)[:, None]
+            logT_poly = self.get_logT_poly(state)
+            X = self.get_mole_fractions(state)
+
+            # Compute species viscosities
+            sqrt_muk = T**0.25 * (logT_poly @ self.viscosity_coeffs)
+            muk = sqrt_muk**2
+
+            # Compute mixture viscosity using modified Wilke's rule
+            top_sqrt = (
+                1.0 + sqrt_muk[..., None] / sqrt_muk[..., None, :] * self.W_ratio_4
+            )
+            phi_kj = top_sqrt * top_sqrt * self.W_bottom_sqrt
+
+            sumi = np.sum(X[..., None, :] * phi_kj, axis=-1)
+            sumo = np.sum(X * muk / sumi, axis=-1)
+
+            state.viscosity = sumo * np.sqrt(np.asarray(8.0))
+        return state.viscosity
+
+    def get_thermal_conductivity(self, state: FluidState) -> Array:
+        if state.thermal_conductivity is None:
+            T = self.get_temperature(state)[:, None]
+            logT_poly = self.get_logT_poly(state)
+            X = self.get_mole_fractions(state)
+
+            # Compute species thermal conductivities
+            kappak = np.sqrt(T) * (logT_poly @ self.conductivity_coeffs)
+
+            # Compute mixture thermal conductivity
+            state.thermal_conductivity = 0.5 * (
+                np.sum(X * kappak, axis=-1) + 1.0 / np.sum(X / kappak, axis=-1)
+            )
+        return state.thermal_conductivity
+
+    def get_mass_diffusivity(self, state: FluidState) -> Array:
+        if state.mass_diffusivity is None:
+            T = self.get_temperature(state)[:, None]
+            logT_poly = self.get_logT_poly(state)
+            P = self.get_pressure(state)[:, None]
+            Y = self.get_mass_fractions(state)
+            X = self.get_mole_fractions(state)
+
+            # Compute binary diffusion coefficients
+            diffkj = (T**1.5 / P)[..., None] * np.einsum(
+                "...i,ijk->...jk", logT_poly, self.binary_diff_coeffs
+            )
+
+            # Compute mixture-averaged diffusion coefficients
+            invdiffkj = 1.0 / diffkj
+
+            idx_diag = np.arange(self.nsp, dtype=int)
+            invdiffkk = invdiffkj[..., idx_diag, idx_diag]
+
+            oneminusYk = 1.0 - Y
+            sumXjoverDkj = oneminusYk * (
+                np.sum(X[..., None, :] * invdiffkj, axis=-1) - X * invdiffkk
+            )
+            sumYjoverDkj = X * (
+                np.sum(Y[..., None, :] * invdiffkj, axis=-1) - Y * invdiffkk
+            )
+
+            state.mass_diffusivity = oneminusYk / np.maximum(
+                sumXjoverDkj + sumYjoverDkj, np.asarray(1e-30)
+            )
+        return state.mass_diffusivity
 
     def get_temperature(self, state: FluidState) -> Array:
         """
@@ -190,16 +289,18 @@ class ThermoTable(CanteraInterface):
             outputs:
                 T: vector of temperatures
         """
+        if state.temperature is not None:
+            return state.temperature
+
         if state.pressure is not None and state.density is not None:
             # Compute temperature using ideal gas law
             R = self.get_specific_gas_constant(state)
             state.temperature = state.pressure / (state.density * R)
         else:
             # Compute temperature from the internal energy
-            assert state.composition is not None
             assert state.internal_energy is not None
             R = self.get_specific_gas_constant(state)
-            Y = state.composition
+            Y = self.get_mass_fractions(state)
             e_int_ref = Y @ self.e.T
 
             if not np.all(e_int_ref[:, :-1] <= e_int_ref[:, 1:]):
@@ -252,14 +353,11 @@ class ThermoTable(CanteraInterface):
         return state.pressure
 
     def get_internal_energy(self, state: FluidState) -> Array:
-        if state.internal_energy is not None:
-            return state.internal_energy
-
-        assert state.temperature is not None
-        T = state.temperature
-        R = self.get_specific_gas_constant(state)
-        h = self.get_enthalpy(state)
-        state.internal_energy = h - R * T
+        if state.internal_energy is None:
+            T = self.get_temperature(state)
+            R = self.get_specific_gas_constant(state)
+            h = self.get_enthalpy(state)
+            state.internal_energy = h - R * T
         return state.internal_energy
 
     def get_index(self, T: Array) -> Index:
@@ -270,10 +368,7 @@ class ThermoTable(CanteraInterface):
         return index, 0.5 * self.a[index] * (T + self.T[index])[:, None] + self.b[index]
 
     def get_species_enthalpies(self, state: FluidState) -> Array:
-        if state.temperature is None:
-            T = self.get_temperature(state)
-        else:
-            T = state.temperature
+        T = self.get_temperature(state)
 
         if any(np.logical_or(self.TMin > T, self.TMax < T)):
             msg = "Temperature not within table"
@@ -292,14 +387,16 @@ class ThermoTable(CanteraInterface):
             outputs:
                 h0: vector of frozen enthalpies for the mixture [n]
         """
-        assert state.composition is not None
-        hk = self.get_species_enthalpies(state)
-        return np.sum(state.composition * hk, axis=-1)
+        if state.enthalpy is None:
+            Y = self.get_mass_fractions(state)
+            hk = self.get_species_enthalpies(state)
+            state.enthalpy = np.sum(Y * hk, axis=-1)
+        return state.enthalpy
 
     def get_sound_speed(self, state: FluidState) -> Array:
-        assert state.pressure is not None
-        assert state.density is not None
-        gamma = state.gamma
-        if gamma is None:
+        if state.sound_speed is None:
+            assert state.pressure is not None
+            assert state.density is not None
             gamma = self.get_gamma(state)
-        return np.sqrt(gamma * state.pressure / state.density)
+            state.sound_speed = np.sqrt(gamma * state.pressure / state.density)
+        return state.sound_speed

--- a/src/stanshock/physics/thermotable.py
+++ b/src/stanshock/physics/thermotable.py
@@ -67,7 +67,7 @@ def get_cp_compiled(T: Array, Y: Array, TTable: Array, a: Array, b: Array) -> Ar
     # determine cp
     cp = np.zeros((nX,))
     for iX in range(nX):
-        if (T[iX] < TMin) or (T[iX] > TMax):
+        if (T[iX] < 0.99 * TMin) or (T[iX] > 1.01 * TMax):
             msg = f"Temperature out of bounds: {T[iX]} not in range [{TMin}, {TMax}]"
             raise ValueError(msg)
         index = indices[iX]
@@ -370,8 +370,8 @@ class ThermoTable(CanteraInterface):
     def get_species_enthalpies(self, state: FluidState) -> Array:
         T = self.get_temperature(state)
 
-        if any(np.logical_or(self.TMin > T, self.TMax < T)):
-            msg = "Temperature not within table"
+        if any(np.logical_or(0.99 * self.TMin > T, 1.01 * self.TMax < T)):
+            msg = f"Temperature not within table. {T.min() = }, {T.max() = }"
             raise ValueError(msg)
 
         index, bbar = self.get_bbar(T)

--- a/src/stanshock/physics/thermotable.py
+++ b/src/stanshock/physics/thermotable.py
@@ -6,7 +6,7 @@ from numba import double, njit
 
 from stanshock.physics.cantera_interface import CanteraInterface
 from stanshock.physics.fluid_base import FluidState
-from stanshock.system.backend import Array, Composition
+from stanshock.system.backend import Array, Composition, Index
 
 # Type signatures for numba
 double1D = double[:]
@@ -99,23 +99,19 @@ class ThermoTable(CanteraInterface):
         """
         super().__init__(gas, ox_def, fuel_def, prog_def)
         nSp: int = gas.n_species
-        self.TMin: float = 50.0
-        self.dT: float = 100.0
-        self.TMax: float = 9950.0
-        self.T: Array = np.arange(
-            self.TMin, self.TMax, self.dT, dtype=np.float64
-        )  # vector of temperatures assuming thermal equilibrium between species
-        nT = len(self.T)
-        self.h: Array = np.zeros(
-            (nT, nSp)
-        )  # matrix of species enthalpies per temperature
+        self.TMin: float = gas.min_temp
+        nT = 21
+        self.TMax: float = gas.max_temp
+        # vector of temperatures assuming thermal equilibrium between species
+        self.T: Array = np.linspace(self.TMin, self.TMax, nT, dtype=np.float64)
+        self.dT = (self.TMax - self.TMin) / (nT - 1)
+        # matrix of species enthalpies per temperature
+        self.h: Array = np.zeros((nT, nSp))
         # cpk = ak*T+bk for T in [Tk,Tk+1], k in {0,1,2,...,nT-1}
-        self.a: Array = np.zeros(
-            (nT, nSp)
-        )  # matrix of species first order coefficients
-        self.b: Array = np.zeros(
-            (nT, nSp)
-        )  # matrix of species zeroth order coefficients
+        # matrix of species first order coefficients
+        self.a: Array = np.zeros((nT, nSp))
+        # matrix of species zeroth order coefficients
+        self.b: Array = np.zeros((nT, nSp))
         self.molecularWeights: Array = gas.molecular_weights
         # determine the coefficients
         for kSp, species in enumerate(gas.species()):
@@ -134,6 +130,11 @@ class ThermoTable(CanteraInterface):
                 # update
                 cpk = self.a[kT, kSp] * (Tkp1) + self.b[kT, kSp]
                 hk = hkp1
+        # Compute the matching species internal energies
+        self.e = (
+            self.h - ct.gas_constant * self.T[:, None] / self.molecularWeights[None, :]
+        )
+        self.c = self.b - ct.gas_constant / self.molecularWeights[None, :]
 
     def get_specific_gas_constant(self, state: FluidState) -> Array:
         """
@@ -169,27 +170,6 @@ class ThermoTable(CanteraInterface):
             self.b,
         ).reshape(state.shape)
 
-    def get_frozen_enthalpy(self, T: Array, Y: Array) -> Array:
-        """
-        This method computes the enthalpy according to Billet and Abgrall (2003).
-        This is the enthalpy that is frozen over the time step
-            inputs:
-                T: vector of temperatures [n]
-                Y: matrix of mass fractions [n,nSp]
-            outputs:
-                h0: vector of frozen enthalpies for the mixture [n]
-        """
-        if any(np.logical_or(self.TMin > T, self.TMax < T)):
-            msg = "Temperature not within table"
-            raise ValueError(msg)
-        nT = len(T)
-        indices = [int((Tk - self.TMin) / self.dT) for Tk in T]
-        h0 = np.zeros(nT)
-        for k, index in enumerate(indices):
-            bbar = self.a[index, :] / 2.0 * (T[k] + self.T[index]) + self.b[index, :]
-            h0[k] = np.dot(Y[k, :], self.h[index] - bbar * self.T[index])
-        return h0
-
     def get_gamma(self, state: FluidState) -> Array:
         """
         This method computes the specific heat ratio, gamma.
@@ -210,13 +190,47 @@ class ThermoTable(CanteraInterface):
             outputs:
                 T: vector of temperatures
         """
-        R = self.get_specific_gas_constant(state)
-        if state.pressure is None:
-            state = self.set_state(state)
-            state.temperature = self.sol.T
-        else:
-            assert state.density is not None
+        if state.pressure is not None and state.density is not None:
+            # Compute temperature using ideal gas law
+            R = self.get_specific_gas_constant(state)
             state.temperature = state.pressure / (state.density * R)
+        else:
+            # Compute temperature from the internal energy
+            assert state.composition is not None
+            assert state.internal_energy is not None
+            R = self.get_specific_gas_constant(state)
+            Y = state.composition
+            e_int_ref = Y @ self.e.T
+
+            if not np.all(e_int_ref[:, :-1] <= e_int_ref[:, 1:]):
+                msg = "Tabulated internal energy for the mixture is not monotonic in temperature."
+                raise ValueError(msg)
+
+            N = state.shape[0]
+            index = np.zeros(state.shape[0], dtype=int)
+            for i in range(N):
+                index[i] = max(
+                    np.searchsorted(
+                        e_int_ref[i], state.internal_energy[i], side="right"
+                    )
+                    - 1,
+                    0,
+                )
+            de = state.internal_energy - e_int_ref[np.arange(N, dtype=int), index]
+
+            # Solve quadratic formula - always pick larger real root
+            a: Array = np.sum(Y * (0.5 * self.a[index]), axis=-1)
+            b: Array = np.sum(Y * self.c[index], axis=-1)
+            Tm: Array = self.T[index]
+            c = -((a * Tm + b) * Tm + de)
+
+            state.temperature = np.divide(
+                np.sqrt(b**2 - 4.0 * a * c) - b,
+                2.0 * a,
+                out=-c / b,
+                where=np.abs(a) > 1e-14,
+            )
+
         return state.temperature
 
     def get_pressure(self, state: FluidState) -> Array:
@@ -237,6 +251,24 @@ class ThermoTable(CanteraInterface):
             state.pressure = state.temperature * R * state.density
         return state.pressure
 
+    def get_internal_energy(self, state: FluidState) -> Array:
+        if state.internal_energy is not None:
+            return state.internal_energy
+
+        assert state.temperature is not None
+        T = state.temperature
+        R = self.get_specific_gas_constant(state)
+        h = self.get_enthalpy(state)
+        state.internal_energy = h - R * T
+        return state.internal_energy
+
+    def get_index(self, T: Array) -> Index:
+        return np.asarray((T - self.TMin) / self.dT, dtype=int)
+
+    def get_bbar(self, T: Array) -> tuple[Index, Array]:
+        index = self.get_index(T)
+        return index, 0.5 * self.a[index] * (T + self.T[index])[:, None] + self.b[index]
+
     def get_species_enthalpies(self, state: FluidState) -> Array:
         if state.temperature is None:
             T = self.get_temperature(state)
@@ -247,12 +279,22 @@ class ThermoTable(CanteraInterface):
             msg = "Temperature not within table"
             raise ValueError(msg)
 
-        indices = np.floor((T - self.TMin) / self.dT, casting="unsafe", dtype=int)
-        bbar = (
-            0.5 * self.a[indices, :] * (T + self.T[indices])[..., None]
-            + self.b[indices, :]
-        )
-        return self.h[indices, :] - bbar * self.T[indices, None]
+        index, bbar = self.get_bbar(T)
+        return self.h[index, :] + bbar * (T - self.T[index])[:, None]
+
+    def get_enthalpy(self, state: FluidState) -> Array:
+        """
+        This method computes the enthalpy according to Billet and Abgrall (2003).
+        This is the enthalpy that is frozen over the time step
+            inputs:
+                T: vector of temperatures [n]
+                Y: matrix of mass fractions [n,nSp]
+            outputs:
+                h0: vector of frozen enthalpies for the mixture [n]
+        """
+        assert state.composition is not None
+        hk = self.get_species_enthalpies(state)
+        return np.sum(state.composition * hk, axis=-1)
 
     def get_sound_speed(self, state: FluidState) -> Array:
         assert state.pressure is not None

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -21,17 +21,17 @@ mech = "data/mechanisms/HeliumArgon.yaml"
 
 
 def test_table_computes_correct_temperatures() -> None:
-    N = 101
+    N = 1001
     gas = ct.Solution(mech)
     sol = ct.SolutionArray(gas, (N,))
     argon_mass_fractions = np.linspace(0, 1, N)[:, None]
     helium_mass_fractions = 1.0 - argon_mass_fractions
     mass_fractions = np.hstack([argon_mass_fractions, helium_mass_fractions])
-    densities = np.logspace(-1, 1, N)
+    temperatures = np.logspace(np.log10(gas.max_temp), np.log10(gas.min_temp), N)
     pressures = np.logspace(6, 4, N)
 
-    sol.DPY = densities, pressures, mass_fractions
-    actual_temperatures = sol.T
+    sol.TPY = temperatures, pressures, mass_fractions
+    densities = sol.density_mass
 
     table = ThermoTable(gas)
 
@@ -44,7 +44,7 @@ def test_table_computes_correct_temperatures() -> None:
             composition=mass_fractions,
         )
     )
-    assert actual_temperatures == pytest.approx(predicted_temperatures)
+    assert temperatures == pytest.approx(predicted_temperatures)
 
     # Energy to temperature
     predicted_temperatures = table.get_temperature(
@@ -54,10 +54,10 @@ def test_table_computes_correct_temperatures() -> None:
             composition=mass_fractions,
         )
     )
-    assert actual_temperatures == pytest.approx(predicted_temperatures, rel=0.01)
+    assert temperatures == pytest.approx(predicted_temperatures, rel=0.013)
 
 
-def test_monatomic_gas_has_constant_gamma():
+def test_monatomic_gas_has_constant_gamma() -> None:
     gas = ct.Solution(mech)
     temperatures = np.linspace(gas.min_temp, gas.max_temp)[:, None]
     mass_fractions = np.hstack(
@@ -74,7 +74,7 @@ def test_monatomic_gas_has_constant_gamma():
     assert gammas == pytest.approx(gammas[0])
 
 
-def test_single_species_gas_has_correct_constant():
+def test_single_species_gas_has_correct_constant() -> None:
     molecular_weight = np.array([7.0, 3.0])
     mass_fraction = np.array([1, 0])[None, :]
     actual_gas_constant = ct.gas_constant / molecular_weight[0]
@@ -84,7 +84,7 @@ def test_single_species_gas_has_correct_constant():
     assert actual_gas_constant == predicted_gas_constant
 
 
-def test_cp_increases_with_larger_coefficients():
+def test_cp_increases_with_larger_coefficients() -> None:
     temperatures = np.linspace(300, 3000)
     temperature_table = temperatures
     mass_fractions = np.ones_like(temperatures)[:, None]

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -20,34 +20,46 @@ get_cp_compiled = get_cp_compiled.__wrapped__
 mech = "data/mechanisms/HeliumArgon.yaml"
 
 
-def test_table_computes_correct_temperatures():
+def test_table_computes_correct_temperatures() -> None:
+    N = 101
     gas = ct.Solution(mech)
-    argon_mass_fractions = np.linspace(0, 1)[:, np.newaxis]
+    sol = ct.SolutionArray(gas, (N,))
+    argon_mass_fractions = np.linspace(0, 1, N)[:, None]
     helium_mass_fractions = 1.0 - argon_mass_fractions
     mass_fractions = np.hstack([argon_mass_fractions, helium_mass_fractions])
-    densities = np.logspace(-1, 1)
-    pressures = np.logspace(6, 4)
-    actual_temperatures = []
-    for state in zip(densities, pressures, mass_fractions, strict=False):
-        gas.DPY = state
-        actual_temperatures.append(gas.T)
-    actual_temperatures = np.array(actual_temperatures)
+    densities = np.logspace(-1, 1, N)
+    pressures = np.logspace(6, 4, N)
+
+    sol.DPY = densities, pressures, mass_fractions
+    actual_temperatures = sol.T
 
     table = ThermoTable(gas)
+
+    # Ideal gas law
     predicted_temperatures = table.get_temperature(
         FluidState(
-            shape=len(pressures),
+            shape=(N,),
             density=densities,
             pressure=pressures,
             composition=mass_fractions,
         )
     )
-    assert np.allclose(actual_temperatures, predicted_temperatures)
+    assert actual_temperatures == pytest.approx(predicted_temperatures)
+
+    # Energy to temperature
+    predicted_temperatures = table.get_temperature(
+        FluidState(
+            shape=(N,),
+            internal_energy=sol.int_energy_mass,
+            composition=mass_fractions,
+        )
+    )
+    assert actual_temperatures == pytest.approx(predicted_temperatures, rel=0.01)
 
 
 def test_monatomic_gas_has_constant_gamma():
     gas = ct.Solution(mech)
-    temperatures = np.linspace(50.0, 5000.0)[:, np.newaxis]
+    temperatures = np.linspace(gas.min_temp, gas.max_temp)[:, None]
     mass_fractions = np.hstack(
         [np.ones_like(temperatures), np.zeros_like(temperatures)]
     )
@@ -59,13 +71,12 @@ def test_monatomic_gas_has_constant_gamma():
             composition=mass_fractions,
         )
     )
-    gammas_are_constant = np.allclose(gammas, gammas[0])
-    assert gammas_are_constant
+    assert gammas == pytest.approx(gammas[0])
 
 
 def test_single_species_gas_has_correct_constant():
     molecular_weight = np.array([7.0, 3.0])
-    mass_fraction = np.array([1, 0])[np.newaxis, :]
+    mass_fraction = np.array([1, 0])[None, :]
     actual_gas_constant = ct.gas_constant / molecular_weight[0]
     predicted_gas_constant = get_specific_gas_constant_compiled(
         mass_fraction, molecular_weight
@@ -76,7 +87,7 @@ def test_single_species_gas_has_correct_constant():
 def test_cp_increases_with_larger_coefficients():
     temperatures = np.linspace(300, 3000)
     temperature_table = temperatures
-    mass_fractions = np.ones_like(temperatures)[:, np.newaxis]
+    mass_fractions = np.ones_like(temperatures)[:, None]
     a = np.ones_like(mass_fractions)
     b = np.ones_like(mass_fractions)
     specific_heats_with_small_a = get_cp_compiled(
@@ -95,24 +106,10 @@ def test_cp_increases_with_larger_coefficients():
     assert np.all(specific_heats_with_small_b <= specific_heats_with_large_b)
 
 
-def test_formation_enthalpy_is_invariant_to_temperature():
-    temperatures = np.array([1000.0, 5000.0])
-    gas = ct.Solution(mech)
-    table = ThermoTable(gas)
-    mass_fractions = np.hstack(
-        [
-            np.ones_like(temperatures)[:, np.newaxis],
-            np.zeros_like(temperatures)[:, np.newaxis],
-        ]
-    )
-    enthalpies = table.get_frozen_enthalpy(temperatures, mass_fractions)
-    assert enthalpies[0] == pytest.approx(enthalpies[1], rel=1e-3)
-
-
 def test_out_of_bounds_temperature_raises_exception():
     temperatures = np.array([-100, -90])
     temperature_table = temperatures + 100
-    mass_fractions = np.ones_like(temperatures)[:, np.newaxis]
+    mass_fractions = np.ones_like(temperatures)[:, None]
     a = np.ones_like(mass_fractions)
     b = np.ones_like(mass_fractions)
     with pytest.raises(ValueError, match="Temperature out of bounds"):
@@ -121,4 +118,4 @@ def test_out_of_bounds_temperature_raises_exception():
     gas = ct.Solution(mech)
     table = ThermoTable(gas)
     with pytest.raises(ValueError, match="Temperature not within table"):
-        table.get_frozen_enthalpy(temperatures, mass_fractions)
+        table.get_species_enthalpies(FluidState(shape=(2,), temperature=temperatures))


### PR DESCRIPTION
Adds an energy-to-temperature conversion and transport property evaluations to the `ThermoTable` class. This should effectively decouple the fluid physics from Cantera with the exception of the reaction rates which currently can only be computed via a call to Cantera.