### PR TITLE
Add Multiple-Injector Option

### DIFF
--- a/examples/hyshot_ii_jic/hyshot_ii_jic.py
+++ b/examples/hyshot_ii_jic/hyshot_ii_jic.py
@@ -9,6 +9,10 @@ from scipy import optimize
 
 from stanshock.components.combustor import Combustor
 from stanshock.models.jicf import JICModel
+from stanshock.models.wall_models import (
+    CompressibleHeatFlux,
+    CompressibleReactingSkinFriction,
+)
 from stanshock.numerics.boundary_conditions import BCInput, SpecifiedFace
 from stanshock.physics.flamelet import FPVTable
 from stanshock.processing.csv_writer import CSVWriter
@@ -176,7 +180,8 @@ t_phi_gl_schedule = np.array(
     ]
 )
 
-t_f = np.zeros(t_phi_gl_schedule.shape[0])
+t_f = t_phi_gl_schedule[:, 0]
+phi_f = t_phi_gl_schedule[:, 1]
 rho_f = np.zeros(t_phi_gl_schedule.shape[0])
 U_f = np.zeros(t_phi_gl_schedule.shape[0])
 T_f = np.zeros(t_phi_gl_schedule.shape[0])
@@ -184,8 +189,6 @@ for i in range(t_phi_gl_schedule.shape[0]):
     t_f[i] = t_phi_gl_schedule[i, 0]
     rho_f[i], U_f[i], T_f[i] = fuel_props_from_phi(t_phi_gl_schedule[i, 1])
 # NOTE: Assuming perfect gas & isentropic choked flow, only rho_f changes with phi/mdot
-U_f = U_f[-1]
-T_f = T_f[-1]
 
 # Define the grid
 N_x = 200
@@ -228,12 +231,12 @@ fpv_table = FPVTable(
 
 # Build the injector model
 jic = JICModel(
-    fuel="H2",
     x_inj=x_inj,
     x_noz=L_const,
     n_inj=N_f,
     d_inj=2 * r_f,
     t_inj=t_f,
+    phi_inj=phi_f,
     rho_inj=rho_f,
     u_inj=U_f,
     T_inj=T_f,
@@ -253,7 +256,7 @@ jic = JICModel(
 ss = Combustor(
     geometry=geometry,
     wall_temperature=300.0,
-    include_boundary_layer=True,
+    wall_models=(CompressibleReactingSkinFriction(), CompressibleHeatFlux()),
     initialization=InitializeConstant(geometry, fpv_table, gas_init, U_in),
     boundary_conditions=BCs,
     source_terms=None,
@@ -272,7 +275,6 @@ csv_writer = CSVWriter(
     combustor=ss,
     filename=figdir / "data.csv",  # Will become test_00000.csv, test_00001.csv, etc.
     interval=100,  # Same as plot_state_interval=100
-    wall_temperature=300.0,
 )
 ss.csv_writers = [csv_writer]
 

--- a/src/stanshock/components/combustor.py
+++ b/src/stanshock/components/combustor.py
@@ -41,7 +41,7 @@ from stanshock.processing.initialize import Initialization, InitializeRestart
 from stanshock.processing.plot import VariableInfo, XTDiagram, plot_state
 from stanshock.processing.probe import Probe
 from stanshock.system.backend import Array
-from stanshock.system.base import RightHandSide
+from stanshock.system.base import CombinedSource, RightHandSide
 from stanshock.system.geometry import Geometry
 
 
@@ -93,7 +93,12 @@ class Combustor:
         self.verbose = verbose
         self.output_every = output_every
         self.use_double_flux = use_double_flux
-        self.injector = injector
+        if injector is None:
+            self.injectors: list[JICModel] = []
+        elif isinstance(injector, list):
+            self.injectors = injector
+        else:
+            self.injectors = [injector]
         self.optimization_iteration = optimization_iteration
         self.physics: FluidPhysics = physics
         self.initialization: Initialization = initialization
@@ -145,17 +150,23 @@ class Combustor:
         integrators: list[TimeIntegrator] = []
         advection = SSPRK3(self.inviscid_flux)
         chemistry: TimeIntegrator
+
         if reacting and self.physics.is_flamelet:
-            if self.injector is not None:
-                chemistry = HeunsMethod(
-                    JICFChemistrySource(
-                        self.injector, geometry=self.geometry, physics=self.physics
-                    )
+            if self.injectors:
+                chemistry_source = CombinedSource(
+                    [
+                        JICFChemistrySource(
+                            inj, geometry=self.geometry, physics=self.physics
+                        )
+                        for inj in self.injectors
+                    ]
                 )
             else:
-                chemistry = HeunsMethod(
-                    ChemistrySource(geometry=self.geometry, physics=self.physics)
+                chemistry_source = ChemistrySource(
+                    geometry=self.geometry, physics=self.physics
                 )
+            chemistry = HeunsMethod(chemistry_source)
+
             integrators += [advection, chemistry]
         elif reacting and self.physics.gas.n_reactions > 0:
             chemistry = ScipyIVP(
@@ -201,11 +212,7 @@ class Combustor:
             else:
                 integrators += [HeunsMethod(source_terms)]
 
-        if self.injector is not None:
-            if not self.physics.is_flamelet:
-                msg = "JIC injector model requires FPVTable physics."
-                raise Exception(msg)
-            integrators += [HeunsMethod(self.injector)]
+        integrators += [HeunsMethod(inj) for inj in self.injectors]
 
         # Apply Lie splitting approach
         self.time_integrator = LieSplitting(tuple(integrators), update_double_flux=True)
@@ -300,11 +307,15 @@ class Combustor:
             p_old = p_new + 0.0
 
             # Update the injector
-            if self.injector is not None:
+            if self.injectors is not None:
                 assert self.state.velocity is not None
-                self.injector.update_fluid_tip_positions(
-                    dt, self.t, self.state.velocity[self.geometry.idx_cells]
-                )
+                for inj in self.injectors:
+                    inj.update_fluid_tip_positions(
+                        dt, self.t, self.state.velocity[self.geometry.idx_cells]
+                    )
+                # self.injector.update_fluid_tip_positions(
+                #     dt, self.t, self.state.velocity[self.geometry.idx_cells]
+                # )
 
             # Update the system state
             self.t, state_array, gamma_star, e0_star = self.time_integrator.advance(
@@ -328,9 +339,9 @@ class Combustor:
             res_p = float(np.linalg.norm(p_new - p_old))
             if self.verbose and iters % self.output_every == 0:
                 print(
-                    f"Iteration: {iters}. Current time: {self.t}. Time step: {dt:e}. "
-                    + f"Max T[K]: {self.physics.get_temperature(self.state).max()}. "
-                    + f"Residual(p): {res_p}."
+                    f"Iteration: {iters}. Current time: {self.t:.3e}. Time step: {dt:.3e}. "
+                    + f"Max T[K]: {self.physics.get_temperature(self.state).max():.3e}. "
+                    + f"Residual(p): {res_p:.3e}."
                 )
             if (self.plot_state_interval > 0) and (
                 iters % self.plot_state_interval == 0

--- a/src/stanshock/models/jicf.py
+++ b/src/stanshock/models/jicf.py
@@ -16,8 +16,6 @@ from stanshock.system.backend import Array, Unpack
 from stanshock.system.base import PrecomputeSteps, RightHandSide
 from stanshock.system.geometry import Box
 
-datadir = Path("./data")
-
 
 class JICModel(RightHandSide):
     """
@@ -26,12 +24,12 @@ class JICModel(RightHandSide):
 
     def __init__(
         self,
-        fuel: str,
         x_inj: float,
         x_noz: float,
         n_inj: float,
         d_inj: float,
         t_inj: Array,
+        phi_inj: Array,
         rho_inj: Array,
         u_inj: Array,
         T_inj: Array,
@@ -39,6 +37,8 @@ class JICModel(RightHandSide):
         u: float,
         T: float,
         alpha: float,
+        datadir: Path | str = "./data",
+        theta_inj: float | None = None,
         load_Z_3D: bool = False,
         load_Z_avg_var_profiles: bool = False,
         load_chemical_sources: bool = False,
@@ -48,8 +48,6 @@ class JICModel(RightHandSide):
         """
         This method initializes the Jet-in-Crossflow model with the following
         parameters:
-        fuel: str
-            The fuel species
         x_inj: float
             The x-coordinate of the injection point
         x_noz: float
@@ -58,8 +56,12 @@ class JICModel(RightHandSide):
             The number of injected jets
         d_inj: float
             The diameter of the injected jet
+        theta_inj: float
+            The angle of the jet relative to the x axis (rads)
         t_inj: np.ndarray
             Time array for the injection profile
+        phi_inj: np.ndarray
+            Scheduled equivalence ratio of injected jet
         rho_inj: np.ndarray
             The density of the injected jet, as a function of time
         u_inj: np.ndarray
@@ -74,6 +76,8 @@ class JICModel(RightHandSide):
             The temperature of the crossflow
         alpha: float
             The relaxation parameter (used here only for storage)
+        datadir: str
+            Where to access or store tables written for this injector
         load_Z_3D: bool
             Whether to load the 3D Z table
         load_Z_avg_var_profiles: bool
@@ -92,8 +96,12 @@ class JICModel(RightHandSide):
         assert isinstance(self.physics, FPVTable)
         self.fpv_table: FPVTable = self.physics
 
+        assert self.physics.fuel_def is not None
+        self.fuel_def = self.physics.fuel_def
+        assert self.physics.ox_def is not None
+        self.ox_def = self.physics.ox_def
+
         gas = self.physics.gas
-        self.fuel = fuel
 
         # Extract some information about the geometry
         self.xc = self.geometry.xc[self.idx_input]
@@ -107,15 +115,16 @@ class JICModel(RightHandSide):
         self.h = float(self.geometry.h(0.0, np.array(self.x_inj)))
         self.n_inj = n_inj
         self.d_inj = d_inj
+        self.theta_inj = theta_inj if theta_inj is not None else 0.0
 
         self.rho_inj = rho_inj
         self.u_inj = u_inj
         self.T_inj = T_inj
-        self.rho = rho
-        self.u = u
-        self.T = T
 
-        self.alpha = alpha
+        self.rho = rho
+
+        self.alpha = alpha if alpha is not None else 1e6
+        self.datadir = Path(datadir)
 
         # Geometry parameters
         self.L = self.xc[-1] - self.xc[0]
@@ -123,25 +132,34 @@ class JICModel(RightHandSide):
         self.A_inj = np.pi * (self.d_inj / 2.0) ** 2
 
         # Free stream properties
-        gas.TDX = self.T, self.rho, "O2:0.21,N2:0.79"
+        self.u = u
+        self.T = T
+        gas.TDX = self.T, self.rho, self.ox_def
         self.p = gas.P
         self.W = gas.mean_molecular_weight
         self.gamma = gas.cp / gas.cv
         self.c = gas.sound_speed
         self.M = self.u / self.c
+        self.Y_ox = gas.Y
 
         # Properties of the injected fluid
         self.t_inj = t_inj
+        self.phi_inj = phi_inj
         self.p_inj = np.zeros_like(self.t_inj)
+        self.c_inj = np.zeros_like(self.t_inj)
+
         for i in range(len(self.t_inj)):
             if np.isnan(self.rho_inj[i]):
                 continue
-            gas.TDX = self.T_inj, self.rho_inj[i], f"{self.fuel}:1"
+            gas.TDX = self.T_inj[i], self.rho_inj[i], self.fuel_def
             self.p_inj[i] = gas.P
+            self.c_inj[i] = gas.sound_speed
+        self.Y_fuel = gas.Y
+
         self.E_inj = gas.int_energy_mass + 0.5 * self.u_inj**2
         self.W_inj = gas.mean_molecular_weight
         self.gamma_inj = gas.cp / gas.cv
-        self.c_inj = gas.sound_speed
+
         self.M_inj = 1.0
         self.mdot_inj = self.n_inj * self.rho_inj * self.u_inj * self.A_inj
         self.mdot_inj[np.isnan(self.mdot_inj)] = 0.0
@@ -151,20 +169,20 @@ class JICModel(RightHandSide):
         self.mdot_inj_unique_idx = self.mdot_inj_unique_idx[
             np.argsort(self.mdot_inj_unique)
         ]
+
         self.mdot_inj_unique = self.mdot_inj[self.mdot_inj_unique_idx]
         self.rho_inj_unique = self.rho_inj[self.mdot_inj_unique_idx]
+        self.u_inj_unique = self.u_inj[self.mdot_inj_unique_idx]
         self.p_inj_unique = self.p_inj[self.mdot_inj_unique_idx]
 
         # Position of the first injected fluid particle
         self.fluid_tips = np.array([[self.x_inj, self.mdot_inj[0]]])
 
-        # Properties behind the bow shock (assuming normal shock)
-        # self.rho_2 = self.rho * (self.gamma + 1) * self.M**2 / ((self.gamma - 1) * self.M**2 + 2)
-        # self.u_2 = self.u * self.rho / self.rho_2
-
         # Integral of Z across centerline normal plane
         A_inj = np.pi * (self.d_inj / 2.0) ** 2
-        self.Z_cl_int = self.rho_inj_unique * self.u_inj * A_inj / (self.rho * self.u)
+        self.Z_cl_int = (
+            self.rho_inj_unique * self.u_inj_unique * A_inj / (self.rho * self.u)
+        )
         self.d_eff = np.sqrt(self.Z_cl_int / (2 * np.pi))
 
         # Stoichiometry
@@ -174,17 +192,15 @@ class JICModel(RightHandSide):
         self.phi_gl_unique = np.zeros_like(self.mdot_inj_unique)
         self.Z_gl_unique = np.zeros_like(self.mdot_inj_unique)
         for i_m in range(len(self.mdot_inj_unique)):
-            gas.TDY = (
-                self.T,
-                self.rho,
-                f"O2:{0.233 * mdot_a},N2:{0.767 * mdot_a},{self.fuel}:{mdot_f_unique[i_m]}",
-            )
-            self.phi_gl_unique[i_m] = gas.equivalence_ratio(
-                self.fuel, "O2:0.21,N2:0.79"
-            )
-            self.Z_gl_unique[i_m] = gas.mixture_fraction(self.fuel, "O2:0.21,N2:0.79")
+            Y_ox = mdot_a / (mdot_a + mdot_f_unique[i_m])
+            gas.TDY = self.T, self.rho, Y_ox * self.Y_ox + (1.0 - Y_ox) * self.Y_fuel
+            self.phi_gl_unique[i_m] = gas.equivalence_ratio(self.fuel_def, self.ox_def)
+            self.Z_gl_unique[i_m] = gas.mixture_fraction(self.fuel_def, self.ox_def)
         self.mdot_f_interp = interpolate.interp1d(
             self.t_inj, mdot_f, bounds_error=False, fill_value=0.0
+        )
+        self.phi_f_interp = interpolate.interp1d(
+            self.t_inj, self.phi_inj, bounds_error=False, fill_value=0.0
         )
 
         # Compute the non-dimensional parameters
@@ -204,10 +220,10 @@ class JICModel(RightHandSide):
 
         # Precompute a 3D array of the mixture fraction and generate an interpolator
         if load_Z_3D:
-            self.x_3D_data = np.load(datadir / "Z_3D_x.npy")
-            self.y_3D_data = np.load(datadir / "Z_3D_y.npy")
-            self.z_3D_data = np.load(datadir / "Z_3D_z.npy")
-            self.Z_3D_data = np.load(datadir / "Z_3D.npy")
+            self.x_3D_data = np.load(self.datadir / "Z_3D_x.npy")
+            self.y_3D_data = np.load(self.datadir / "Z_3D_y.npy")
+            self.z_3D_data = np.load(self.datadir / "Z_3D_z.npy")
+            self.Z_3D_data = np.load(self.datadir / "Z_3D.npy")
             self.Z_3D_interp = []
             for i_m in range(len(self.mdot_inj_unique)):
                 interp = interpolate.RegularGridInterpolator(
@@ -221,8 +237,8 @@ class JICModel(RightHandSide):
 
         # Precompute the axial mean and variance profiles of Z
         if load_Z_avg_var_profiles:
-            self.Z_avg_profile = np.load(datadir / "Z_avg_profile.npy")
-            self.Z_var_profile = np.load(datadir / "Z_var_profile.npy")
+            self.Z_avg_profile = np.load(self.datadir / "Z_avg_profile.npy")
+            self.Z_var_profile = np.load(self.datadir / "Z_var_profile.npy")
         else:
             self.calc_Z_avg_var_profiles(write=True)
 
@@ -236,10 +252,10 @@ class JICModel(RightHandSide):
 
         # Precompute and tabulate chemical source terms
         if load_chemical_sources:
-            self.Zbar_vec = np.load(datadir / "Zbar_vec.npy")
-            self.Lbar_vec = np.load(datadir / "Lbar_vec.npy")
-            self.logsigma2_vec = np.load(datadir / "logsigma2_vec.npy")
-            self.omega_C_int = np.load(datadir / "omega_C_int.npy")
+            self.Zbar_vec = np.load(self.datadir / "Zbar_vec.npy")
+            self.Lbar_vec = np.load(self.datadir / "Lbar_vec.npy")
+            self.logsigma2_vec = np.load(self.datadir / "logsigma2_vec.npy")
+            self.omega_C_int = np.load(self.datadir / "omega_C_int.npy")
             self.omega_C_int_interp = interpolate.RegularGridInterpolator(
                 (self.Zbar_vec, self.Lbar_vec, self.logsigma2_vec), self.omega_C_int
             )
@@ -249,8 +265,8 @@ class JICModel(RightHandSide):
         # Calculate the progress variable and chemical energy profiles for the
         # mixed is burned (MIB) model
         if load_MIB_profile:
-            self.C_profile = np.load(datadir / "C_profile_MIB.npy")
-            self.E_CHEM_profile = np.load(datadir / "E_CHEM_profile_MIB.npy")
+            self.C_profile = np.load(self.datadir / "C_profile_MIB.npy")
+            self.E_CHEM_profile = np.load(self.datadir / "E_CHEM_profile_MIB.npy")
         else:
             self.calc_MIB_profile(write=True)
 
@@ -367,18 +383,6 @@ class JICModel(RightHandSide):
         return self.__nearest_on_cl_single(x, y, dz)
 
     def Z_cl(self, x_cl):
-        # if isinstance(x_cl, np.ndarray):
-        #     rho_inj_unique = self.rho_inj_unique[:, np.newaxis]
-        #     r_u_unique = self.r_u_unique[:, np.newaxis]
-        # else:
-        #     rho_inj_unique = self.rho_inj_unique
-        #     r_u_unique = self.r_u_unique
-
-        # Following Torrez 2011
-        # xi = 0.85 * ((self.rho_inj_unique / self.rho) * (self.u / self.u_inj) * (self.d_inj / x_cl)**2)**(1.0/3.0)
-        # Z = xi * self.r_W / (1 + (self.r_W - 1) * xi)
-
-        # Taking Z directly
         Z = (
             0.85
             * (1 / self.r_u_unique)
@@ -475,7 +479,10 @@ class JICModel(RightHandSide):
         """
         Z = 0.0
         for z_inj in self.z_inj:
-            Z += self.Z_3D_single_inj(x, y, z, z_inj)
+            Z_temp = self.Z_3D_single_inj(x, y, z, z_inj)
+            if isinstance(Z_temp, np.ndarray):
+                Z_temp = Z_temp[0]
+            Z += Z_temp
         return Z
 
     def grad_Z_3D(self, x, y, z):
@@ -554,25 +561,10 @@ class JICModel(RightHandSide):
                 x_arr, y_arr, z_arr - z_inj, i_m
             )
 
-        # If we haven't passed the edge of the injector, assume it's still a perfect cylinder
-        # if x_cl < self.d_inj / 2:
-        #     if n2 < (self.d_inj / 2)**2:
-        #         return 1.0
-        #     else:
-        #         return 0.0
-
-        # Compute the centerline fuel mass fraction
         Z_cl = self.Z_cl(x_cl)
 
-        # Spreading based on scalar conservation
-        # (Assume gaussian, rho_inj * u_inj * Z_inj * A_inj = rho * u * int(Z * dA))
-        # where int(Z * dA) = 2 * pi * sigma^2 * Z_cl
         sigma2 = self.Z_cl_int / (Z_cl * 2 * np.pi)
-        Z = Z_cl * np.exp(-n2 / (2 * sigma2))
-
-        if np.isscalar(x):
-            return Z[0]
-        return Z
+        return Z_cl * np.exp(-n2 / (2 * sigma2))
 
     def grad_Z_3D_single_inj(self, x, y, z, z_inj):
         """
@@ -635,10 +627,10 @@ class JICModel(RightHandSide):
         self.Z_3D_data[np.isnan(self.rho_inj_unique)] = 0.0
 
         if write:
-            np.save(datadir / "Z_3D_x.npy", self.x_3D_data)
-            np.save(datadir / "Z_3D_y.npy", self.y_3D_data)
-            np.save(datadir / "Z_3D_z.npy", self.z_3D_data)
-            np.save(datadir / "Z_3D.npy", self.Z_3D_data)
+            np.save(self.datadir / "Z_3D_x.npy", self.x_3D_data)
+            np.save(self.datadir / "Z_3D_y.npy", self.y_3D_data)
+            np.save(self.datadir / "Z_3D_z.npy", self.z_3D_data)
+            np.save(self.datadir / "Z_3D.npy", self.Z_3D_data)
 
         self.Z_3D_interp = []
         for i_m in range(len(self.mdot_inj_unique)):
@@ -736,8 +728,8 @@ class JICModel(RightHandSide):
                 )
 
         if write:
-            np.save(datadir / "Z_avg_profile.npy", self.Z_avg_profile)
-            np.save(datadir / "Z_var_profile.npy", self.Z_var_profile)
+            np.save(self.datadir / "Z_avg_profile.npy", self.Z_avg_profile)
+            np.save(self.datadir / "Z_var_profile.npy", self.Z_var_profile)
 
     def C_E_CHEM_avg_MIB(self, x):
         C_avg = np.zeros_like(self.mdot_inj_unique)
@@ -813,8 +805,8 @@ class JICModel(RightHandSide):
         #         self.C_profile[:,i], self.E_CHEM_profile[:, i] = self.C_E_CHEM_avg_MIB(self.x[i])
 
         if write:
-            np.save(datadir / "C_profile_MIB.npy", self.C_profile)
-            np.save(datadir / "E_CHEM_profile_MIB.npy", self.E_CHEM_profile)
+            np.save(self.datadir / "C_profile_MIB.npy", self.C_profile)
+            np.save(self.datadir / "E_CHEM_profile_MIB.npy", self.E_CHEM_profile)
 
     def estimate_p_Z(self, x, Z):
         """
@@ -870,23 +862,9 @@ class JICModel(RightHandSide):
         state_array_local = np.reshape(state_array_local, self.shape_input)
         rhs = np.zeros_like(state_array_local)
 
-        # rho = state_array_local[:, 2]
-        # rhoZ = state_array_local[:, 3]
-
-        # Z = rhoZ / rho
-        # mdot_inj = np.interp(
-        #     self.xc,
-        #     np.flip(self.fluid_tips, axis=0)[:, 0],
-        #     np.flip(self.fluid_tips, axis=0)[:, 1],
-        # )
-        # Z_target = self.Z_avg_profile_interp((mdot_inj, self.xc))
-        # mdot = rho * self.alpha * (Z_target - Z)
-
-        # # Treat small (pre-injector) values
-        # mdot[Z_target < 1e-6] = 0.0
-
         mdot = np.interp(time, self.t_inj, self.mdot_inj)
-
+        u_inj = np.interp(time, self.t_inj, self.u_inj)
+        E_inj = np.interp(time, self.t_inj, self.E_inj)
         L_src = 3e-2
         xf = self.geometry.xf
         idx = (
@@ -899,8 +877,8 @@ class JICModel(RightHandSide):
         mdot *= dx / L_src
 
         # Compute the source term
-        rhs[idx, 0] = mdot * self.u_inj  # momentum
-        rhs[idx, 1] = mdot * self.E_inj  # total energy
+        rhs[idx, 0] = mdot * u_inj * np.cos(self.theta_inj)  # momentum
+        rhs[idx, 1] = mdot * E_inj  # total energy
         rhs[idx, 2] = mdot  # density
         rhs[idx, 3] = mdot  # mixture fraction
         rhs[idx, 4] = 0.0  # progress variable
@@ -1015,10 +993,10 @@ class JICModel(RightHandSide):
         self.omega_C_int[np.isnan(self.omega_C_int)] = 0.0
 
         if write:
-            np.save(datadir / "Zbar_vec.npy", self.Zbar_vec)
-            np.save(datadir / "Lbar_vec.npy", self.Lbar_vec)
-            np.save(datadir / "logsigma2_vec.npy", self.logsigma2_vec)
-            np.save(datadir / "omega_C_int.npy", self.omega_C_int)
+            np.save(self.datadir / "Zbar_vec.npy", self.Zbar_vec)
+            np.save(self.datadir / "Lbar_vec.npy", self.Lbar_vec)
+            np.save(self.datadir / "logsigma2_vec.npy", self.logsigma2_vec)
+            np.save(self.datadir / "omega_C_int.npy", self.omega_C_int)
 
         # Build 3D table interpolator
         self.omega_C_int_interp = interpolate.RegularGridInterpolator(

--- a/src/stanshock/physics/flamelet.py
+++ b/src/stanshock/physics/flamelet.py
@@ -219,6 +219,8 @@ class FPVTable(FluidPhysics):
         """
         Compute the dynamic viscosity at the given Z, Q, and L values.
         """
+        if state.temperature is None:
+            state.temperature = self.get_temperature(state)
         assert state.temperature is not None
         mu0 = self.lookup("MU0", state)
         T0 = self.lookup("T0", state)

--- a/src/stanshock/processing/plot.py
+++ b/src/stanshock/processing/plot.py
@@ -229,9 +229,11 @@ class XTDiagram:
 
         self.variable.append(value)
         self.t.append(domain.t)
-
-        if domain.injector is not None:
-            self.mdot.append(float(domain.injector.mdot_f_interp(domain.t)))
+        if domain.injectors is not None:
+            mdot_f = 0.0
+            for inj in domain.injectors:
+                mdot_f += float(inj.mdot_f_interp(domain.t))
+            self.mdot.append(mdot_f)
 
     def plot(self, figdir: Path | str = ".") -> None:
         """
@@ -322,6 +324,20 @@ def add_h_plot(domain: Combustor, ax: Axes, scale: float = 1.0e3) -> Axes:
         ax1.plot(x * scale, upper * scale, color="0.8", linestyle="--")
         ax1.plot(x * scale, lower * scale, color="0.8", linestyle="--")
 
+    if domain.injectors is not None:
+        for inj in domain.injectors:
+            h_inj = 0.0
+            ax1.annotate(
+                "",
+                xy=(inj.x_inj * scale, h_inj * scale),
+                xytext=(inj.x_inj * scale, h_inj * scale - 0.02),
+                arrowprops={"arrowstyle": "-|>", "color": "0.5", "lw": 1},
+            )
+            # ax1.scatter(inj.x_inj * scale, h_inj * scale,
+            #             s=10,
+            #             c='k',
+            #             marker="^")
+
     ax1.set_xlim(x.min() * scale, x.max() * scale)
     ax1.set_aspect("equal")
     ax1.set_ylabel(f"{yname} [mm]")
@@ -353,7 +369,7 @@ def plot_state(
             plot_variables += [sp_plot]
 
     nrows: int = len(plot_variables)
-    if domain.injector is not None:
+    if domain.injectors is not None:
         nrows += 1
 
     fig: Figure
@@ -397,12 +413,16 @@ def plot_state(
         ax.set_ylabel(plot_label)
 
     ax = axs[-1]
-    if domain.injector is not None:
-        ax.scatter(
-            domain.injector.fluid_tips[:, 0] * xscale,
-            domain.injector.fluid_tips[:, 1] * 1e3 * domain.injector.n_inj,
-            s=1,
-        )
+    if domain.injectors is not None:
+        phi_tot = 0.0
+        for inj in domain.injectors:
+            ax.scatter(
+                inj.fluid_tips[:, 0] * xscale,
+                inj.fluid_tips[:, 1] * 1e3 * inj.n_inj,
+                s=1,
+            )
+            phi_tot += inj.phi_f_interp(domain.t)
+        ax.set_title(rf"$\phi={phi_tot:.2f}$")
         ax.set_ymargin(0.1)
         ax.set_ylabel(r"$\dot{m}_f$ [g/s]")
     ax.set_xlabel("x [mm]")


### PR DESCRIPTION
`Combustor` objects can now be initialized with one or more injectors. Plotting routines were updated to show the injector location(s). Also cleared out some hardcoded values within the JICF routines.