### PR TITLE
JICF cleanup: remove MIB dead code and mesh dependence (#98, #99)

### DIFF
--- a/examples/04_jicf_heat_release_profile/jicf_heat_release_profile.py
+++ b/examples/04_jicf_heat_release_profile/jicf_heat_release_profile.py
@@ -171,9 +171,7 @@ def build_injector(
         u=U_IN,
         T=T_IN,
         alpha=1.0e6,
-        load_Z_3D=(cache_dir / "Z_3D.npy").exists(),
-        load_Z_avg_var_profiles=(cache_dir / "Z_var_profile.npy").exists(),
-        load_chemical_sources=(cache_dir / "omega_C_int.npy").exists(),
+        datadir=cache_dir,
         geometry=geometry,
         physics=physics,
     )

--- a/examples/04_jicf_heat_release_profile/jicf_heat_release_profile.py
+++ b/examples/04_jicf_heat_release_profile/jicf_heat_release_profile.py
@@ -174,7 +174,6 @@ def build_injector(
         load_Z_3D=(cache_dir / "Z_3D.npy").exists(),
         load_Z_avg_var_profiles=(cache_dir / "Z_var_profile.npy").exists(),
         load_chemical_sources=(cache_dir / "omega_C_int.npy").exists(),
-        load_MIB_profile=(cache_dir / "C_profile_MIB.npy").exists(),
         geometry=geometry,
         physics=physics,
     )

--- a/examples/hyshot_ii/case_setup.py
+++ b/examples/hyshot_ii/case_setup.py
@@ -422,7 +422,6 @@ def get_injectors_fpv(
         load_Z_3D=(fpv_dir / "Z_3D.npy").exists(),
         load_Z_avg_var_profiles=(fpv_dir / "Z_var_profile.npy").exists(),
         load_chemical_sources=(fpv_dir / "omega_C_int.npy").exists(),
-        load_MIB_profile=(fpv_dir / "C_profile_MIB.npy").exists(),
     )
 
 

--- a/examples/hyshot_ii/case_setup.py
+++ b/examples/hyshot_ii/case_setup.py
@@ -419,9 +419,7 @@ def get_injectors_fpv(
         alpha=1e6,
         geometry=geometry,
         physics=physics,
-        load_Z_3D=(fpv_dir / "Z_3D.npy").exists(),
-        load_Z_avg_var_profiles=(fpv_dir / "Z_var_profile.npy").exists(),
-        load_chemical_sources=(fpv_dir / "omega_C_int.npy").exists(),
+        datadir=fpv_dir,
     )
 
 

--- a/src/stanshock/models/jicf/generate.py
+++ b/src/stanshock/models/jicf/generate.py
@@ -398,16 +398,9 @@ class JICModel:
         # be rebuilt independently of the simulation mesh. Use the caller-supplied
         # mesh if given, otherwise the stretched 3D grid (which spans the same
         # [xc[0], xc[-1]] interval as the simulation mesh).
-        if self._x_profile_input is not None:
-            self.x_profile = np.asarray(self._x_profile_input, dtype=float)
-        else:
-            if not hasattr(self, "x_3D_data"):
-                msg = (
-                    "x_3D_data is unavailable: the 3D mixture-fraction field must "
-                    "be computed or loaded before generating the Z profiles."
-                )
-                raise RuntimeError(msg)
-            self.x_profile = np.asarray(self.x_3D_data, dtype=float)
+        self.x_profile = (
+            self.x_3D_data if self._x_profile_input is None else self._x_profile_input
+        )
         n_mdot = len(self.mdot_inj_unique)
         self.Z_avg_profile = np.zeros([n_mdot, len(self.x_profile)])
         self.Z_var_profile = np.zeros([n_mdot, len(self.x_profile)])

--- a/src/stanshock/models/jicf/generate.py
+++ b/src/stanshock/models/jicf/generate.py
@@ -44,7 +44,6 @@ class JICModel:
         load_Z_3D: bool = False,
         load_Z_avg_var_profiles: bool = False,
         load_chemical_sources: bool = False,
-        load_MIB_profile: bool = False,
     ) -> None:
         """
         This method initializes the Jet-in-Crossflow model with the following
@@ -85,8 +84,6 @@ class JICModel:
             Whether to load the Z average and variance profiles
         load_chemical_sources: bool
             Whether to load the chemical source terms
-        load_MIB_profile: bool
-            Whether to load the MIB profile
         geometry: Box
             The geometry object describing the mesh and cross-section
         physics: FPVTable
@@ -230,14 +227,6 @@ class JICModel:
         else:
             self.calc_chemical_sources(write=True)
 
-        # Calculate the progress variable and chemical energy profiles for the
-        # mixed is burned (MIB) model
-        if load_MIB_profile:
-            self.C_profile = np.load(self.datadir / "C_profile_MIB.npy")
-            self.E_CHEM_profile = np.load(self.datadir / "E_CHEM_profile_MIB.npy")
-        else:
-            self.calc_MIB_profile(write=True)
-
     def __stretched_grid(self, x_start, x_end, dx, growth_rate, target_x):
         x_grid = [x_start, x_end]
         for direction in [-1, 1]:
@@ -375,83 +364,6 @@ class JICModel:
         if write:
             np.save(self.datadir / "Z_avg_profile.npy", self.Z_avg_profile)
             np.save(self.datadir / "Z_var_profile.npy", self.Z_var_profile)
-
-    def C_E_CHEM_avg_MIB(self, x):
-        C_avg = np.zeros_like(self.mdot_inj_unique)
-        E_CHEM_avg = np.zeros_like(self.mdot_inj_unique)
-        for i_m in range(len(self.mdot_inj_unique)):
-            if np.isnan(self.rho_inj_unique[i_m]):
-                C_avg[i_m] = self.physics.lookup_direct("PROG", 0.0, 0.0, 0.0)
-                E_CHEM_avg[i_m] = self.physics.lookup_direct("E_CHEM", 0.0, 0.0, 0.0)
-                continue
-
-            def integrand(z, y, i_m=i_m):
-                # Z = self.Z_3D_adjusted(x, y, z)[i_m]
-                Z = self.Z_3D_interp[i_m]((x, y, z))
-                return self.physics.lookup_direct("PROG", Z, 0.0, 1.0)
-
-            C_avg[i_m] = (
-                2.0
-                * integrate.dblquad(
-                    integrand, 0, self.h, lambda y: 0 * y, lambda y: self.w / 2 + y * 0
-                )[0]
-                / (self.w * self.h)
-            )
-
-            def integrand(z, y, i_m=i_m):
-                # Z = self.Z_3D_adjusted(x, y, z)[i_m]
-                Z = self.Z_3D_interp[i_m]((x, y, z))
-                return self.physics.lookup_direct("E_CHEM", Z, 0.0, 1.0)
-
-            E_CHEM_avg[i_m] = (
-                2.0
-                * integrate.dblquad(
-                    integrand, 0, self.h, lambda y: 0 * y, lambda y: self.w / 2 + y * 0
-                )[0]
-                / (self.w * self.h)
-            )
-        return C_avg, E_CHEM_avg
-
-    def calc_MIB_profile(self, write=False):
-        print("Computing MIB profile...")
-        self.C_profile = np.zeros([len(self.mdot_inj_unique), len(self.xc)])
-        self.E_CHEM_profile = np.zeros([len(self.mdot_inj_unique), len(self.xc)])
-
-        # Debugging way
-        C = self.physics.lookup_direct("PROG", self.Z_3D_data, 0.0, 1.0)
-        E_CHEM = self.physics.lookup_direct("E_CHEM", self.Z_3D_data, 0.0, 1.0)
-
-        C_profile = np.mean(C, axis=(2, 3))
-        E_CHEM_profile = np.mean(E_CHEM, axis=(2, 3))
-        self.C_profile = np.zeros([len(self.mdot_inj_unique), len(self.xc)])
-        self.E_CHEM_profile = np.zeros([len(self.mdot_inj_unique), len(self.xc)])
-        for i_m in range(len(self.mdot_inj_unique)):
-            self.C_profile[i_m] = np.interp(self.xc, self.x_3D_data, C_profile[i_m])
-            self.E_CHEM_profile[i_m] = np.interp(
-                self.xc, self.x_3D_data, E_CHEM_profile[i_m]
-            )
-
-        # # Real way
-        # for i in tqdm(range(len(self.x))):
-        #     if self.x[i] < self.x_inj:
-        #         # Assume no fuel in the domain
-        #         self.C_profile[:, i] = self.physics.lookup_direct('PROG', 0.0, 0.0, 0.0)
-        #         self.E_CHEM_profile[:, i] = self.physics.lookup_direct('E_CHEM', 0.0, 0.0, 0.0)
-        #     elif self.x[i] > self.x_noz:
-        #         # Freeze the profiles in the nozzle
-        #         self.C_profile[:, i] = self.C_profile[:, i-1]
-        #         self.E_CHEM_profile[:, i] = self.E_CHEM_profile[:, i-1]
-        #     elif self.x[i] < self.x_inj + 0.001:
-        #         # DEBUG: Assume nearly no mixing, so no burning
-        #         Z_avg = self.Z_avg_profile[:, i]
-        #         self.C_profile[:, i] = self.physics.lookup_direct('PROG', Z_avg, 0.0, 0.0)
-        #         self.E_CHEM_profile[:, i] = self.physics.lookup_direct('E_CHEM', Z_avg, 0.0, 0.0)
-        #     else:
-        #         self.C_profile[:,i], self.E_CHEM_profile[:, i] = self.C_E_CHEM_avg_MIB(self.x[i])
-
-        if write:
-            np.save(self.datadir / "C_profile_MIB.npy", self.C_profile)
-            np.save(self.datadir / "E_CHEM_profile_MIB.npy", self.E_CHEM_profile)
 
     def estimate_p_Z(self, x, Z):
         """

--- a/src/stanshock/models/jicf/generate.py
+++ b/src/stanshock/models/jicf/generate.py
@@ -5,6 +5,7 @@ import warnings
 from pathlib import Path
 
 import cantera as ct
+import h5py
 import numpy as np
 from joblib import Parallel, delayed
 from scipy import integrate, interpolate, special, stats
@@ -41,9 +42,7 @@ class JICModel:
         physics: FPVTable,
         datadir: Path | str = "./data",
         theta_inj: float = 0.0,
-        load_Z_3D: bool = False,
-        load_Z_avg_var_profiles: bool = False,
-        load_chemical_sources: bool = False,
+        model_file: Path | str | None = None,
     ) -> None:
         """
         This method initializes the Jet-in-Crossflow model with the following
@@ -78,12 +77,10 @@ class JICModel:
             The relaxation parameter (used here only for storage)
         datadir: str
             Where to access or store tables written for this injector
-        load_Z_3D: bool
-            Whether to load the 3D Z table
-        load_Z_avg_var_profiles: bool
-            Whether to load the Z average and variance profiles
-        load_chemical_sources: bool
-            Whether to load the chemical source terms
+        model_file: Path | str | None
+            Path to the HDF5 file caching the generated model tables. Defaults
+            to ``<datadir>/jicf_model.h5``. Tables already present in the file
+            are loaded; any that are missing are computed and written to it.
         geometry: Box
             The geometry object describing the mesh and cross-section
         physics: FPVTable
@@ -118,6 +115,11 @@ class JICModel:
         self.alpha = alpha if alpha is not None else 1e6
         self.datadir = Path(datadir)
         self.datadir.mkdir(exist_ok=True)
+        self.model_file = (
+            Path(model_file)
+            if model_file is not None
+            else self.datadir / "jicf_model.h5"
+        )
 
         # Geometry parameters
         self.A = self.w * self.h
@@ -184,48 +186,75 @@ class JICModel:
         )
 
         # Precompute a 3D array of the mixture fraction and generate an interpolator
-        if load_Z_3D:
-            self.x_3D_data = np.load(self.datadir / "Z_3D_x.npy")
-            self.y_3D_data = np.load(self.datadir / "Z_3D_y.npy")
-            self.z_3D_data = np.load(self.datadir / "Z_3D_z.npy")
-            self.Z_3D_data = np.load(self.datadir / "Z_3D.npy")
-            self.Z_3D_interp = []
-            for i_m in range(len(self.mdot_inj_unique)):
-                interp = interpolate.RegularGridInterpolator(
-                    (self.x_3D_data, self.y_3D_data, self.z_3D_data),
-                    self.Z_3D_data[i_m],
-                    method="cubic",
-                )
-                self.Z_3D_interp.append(interp)
+        if self._h5_has("Z_3D/Z"):
+            with h5py.File(self.model_file, "r") as f:
+                group = f["Z_3D"]
+                self.x_3D_data = group["x"][:]
+                self.y_3D_data = group["y"][:]
+                self.z_3D_data = group["z"][:]
+                self.Z_3D_data = group["Z"][:]
+            self._build_Z_3D_interp()
         else:
             self.calc_Z_3D_interp(write=True)
 
-        # Precompute the axial mean and variance profiles of Z
-        if load_Z_avg_var_profiles:
-            self.Z_avg_profile = np.load(self.datadir / "Z_avg_profile.npy")
-            self.Z_var_profile = np.load(self.datadir / "Z_var_profile.npy")
+        # Precompute the axial mean and variance profiles of Z, along with the
+        # mesh they were generated on.
+        if self._h5_has("Z_profiles/Z_avg"):
+            with h5py.File(self.model_file, "r") as f:
+                group = f["Z_profiles"]
+                self.x_profile = group["x"][:]
+                self.Z_avg_profile = group["Z_avg"][:]
+                self.Z_var_profile = group["Z_var"][:]
         else:
             self.calc_Z_avg_var_profiles(write=True)
 
-        # Precompute the mapping from mdot to Z mean and variance profiles
+        # Map mdot -> Z mean/variance on the *generation* mesh (self.x_profile).
+        # Building the interpolators on the stored mesh rather than the current
+        # simulation mesh decouples the profiles from the simulation grid, so the
+        # model does not need to be regenerated when the mesh changes. Out-of-range
+        # query points (e.g. ghost cells) are linearly extrapolated.
         self.Z_avg_profile_interp = interpolate.RegularGridInterpolator(
-            (self.mdot_inj_unique, self.xc), self.Z_avg_profile
+            (self.mdot_inj_unique, self.x_profile),
+            self.Z_avg_profile,
+            bounds_error=False,
+            fill_value=None,
         )
         self.Z_var_profile_interp = interpolate.RegularGridInterpolator(
-            (self.mdot_inj_unique, self.xc), self.Z_var_profile
+            (self.mdot_inj_unique, self.x_profile),
+            self.Z_var_profile,
+            bounds_error=False,
+            fill_value=None,
         )
 
         # Precompute and tabulate chemical source terms
-        if load_chemical_sources:
-            self.Zbar_vec = np.load(self.datadir / "Zbar_vec.npy")
-            self.Lbar_vec = np.load(self.datadir / "Lbar_vec.npy")
-            self.logsigma2_vec = np.load(self.datadir / "logsigma2_vec.npy")
-            self.omega_C_int = np.load(self.datadir / "omega_C_int.npy")
+        if self._h5_has("chemical_sources/omega_C_int"):
+            with h5py.File(self.model_file, "r") as f:
+                group = f["chemical_sources"]
+                self.Zbar_vec = group["Zbar"][:]
+                self.Lbar_vec = group["Lbar"][:]
+                self.logsigma2_vec = group["logsigma2"][:]
+                self.omega_C_int = group["omega_C_int"][:]
             self.omega_C_int_interp = interpolate.RegularGridInterpolator(
                 (self.Zbar_vec, self.Lbar_vec, self.logsigma2_vec), self.omega_C_int
             )
         else:
             self.calc_chemical_sources(write=True)
+
+    def _h5_has(self, key: str) -> bool:
+        """Return True if the model file exists and contains the given dataset."""
+        if not self.model_file.exists():
+            return False
+        with h5py.File(self.model_file, "r") as f:
+            return key in f
+
+    def _h5_write(self, group: str, data: dict[str, Array]) -> None:
+        """Write (overwriting if present) a group of named arrays to the model file."""
+        with h5py.File(self.model_file, "a") as f:
+            grp = f.require_group(group)
+            for name, array in data.items():
+                if name in grp:
+                    del grp[name]
+                grp[name] = array
 
     def __stretched_grid(self, x_start, x_end, dx, growth_rate, target_x):
         x_grid = [x_start, x_end]
@@ -260,11 +289,19 @@ class JICModel:
         self.Z_3D_data[np.isnan(self.rho_inj_unique)] = 0.0
 
         if write:
-            np.save(self.datadir / "Z_3D_x.npy", self.x_3D_data)
-            np.save(self.datadir / "Z_3D_y.npy", self.y_3D_data)
-            np.save(self.datadir / "Z_3D_z.npy", self.z_3D_data)
-            np.save(self.datadir / "Z_3D.npy", self.Z_3D_data)
+            self._h5_write(
+                "Z_3D",
+                {
+                    "x": self.x_3D_data,
+                    "y": self.y_3D_data,
+                    "z": self.z_3D_data,
+                    "Z": self.Z_3D_data,
+                },
+            )
 
+        self._build_Z_3D_interp()
+
+    def _build_Z_3D_interp(self) -> None:
         self.Z_3D_interp = []
         for i_m in range(len(self.mdot_inj_unique)):
             interp = interpolate.RegularGridInterpolator(
@@ -349,21 +386,31 @@ class JICModel:
 
     def calc_Z_avg_var_profiles(self, write=False):
         print("Computing Z average and variance profiles...")
-        self.Z_avg_profile = np.zeros([len(self.mdot_inj_unique), len(self.xc)])
-        self.Z_var_profile = np.zeros([len(self.mdot_inj_unique), len(self.xc)])
-        for i in tqdm(range(len(self.xc))):
-            if self.xc[i] > self.x_noz:
+        # Record the mesh the profiles are generated on so the interpolators can
+        # be rebuilt independently of the simulation mesh.
+        self.x_profile = np.asarray(self.xc, dtype=float)
+        n_mdot = len(self.mdot_inj_unique)
+        self.Z_avg_profile = np.zeros([n_mdot, len(self.x_profile)])
+        self.Z_var_profile = np.zeros([n_mdot, len(self.x_profile)])
+        for i in tqdm(range(len(self.x_profile))):
+            if self.x_profile[i] > self.x_noz:
                 # Freeze the profiles in the nozzle
                 self.Z_avg_profile[:, i] = self.Z_avg_profile[:, i - 1]
                 self.Z_var_profile[:, i] = self.Z_var_profile[:, i - 1]
             else:
                 self.Z_avg_profile[:, i], self.Z_var_profile[:, i] = (
-                    self.Z_avg_var_adjusted(self.xc[i])
+                    self.Z_avg_var_adjusted(self.x_profile[i])
                 )
 
         if write:
-            np.save(self.datadir / "Z_avg_profile.npy", self.Z_avg_profile)
-            np.save(self.datadir / "Z_var_profile.npy", self.Z_var_profile)
+            self._h5_write(
+                "Z_profiles",
+                {
+                    "x": self.x_profile,
+                    "Z_avg": self.Z_avg_profile,
+                    "Z_var": self.Z_var_profile,
+                },
+            )
 
     def estimate_p_Z(self, x, Z):
         """
@@ -483,10 +530,15 @@ class JICModel:
         self.omega_C_int[np.isnan(self.omega_C_int)] = 0.0
 
         if write:
-            np.save(self.datadir / "Zbar_vec.npy", self.Zbar_vec)
-            np.save(self.datadir / "Lbar_vec.npy", self.Lbar_vec)
-            np.save(self.datadir / "logsigma2_vec.npy", self.logsigma2_vec)
-            np.save(self.datadir / "omega_C_int.npy", self.omega_C_int)
+            self._h5_write(
+                "chemical_sources",
+                {
+                    "Zbar": self.Zbar_vec,
+                    "Lbar": self.Lbar_vec,
+                    "logsigma2": self.logsigma2_vec,
+                    "omega_C_int": self.omega_C_int,
+                },
+            )
 
         # Build 3D table interpolator
         self.omega_C_int_interp = interpolate.RegularGridInterpolator(

--- a/src/stanshock/models/jicf/generate.py
+++ b/src/stanshock/models/jicf/generate.py
@@ -42,7 +42,8 @@ class JICModel:
         physics: FPVTable,
         datadir: Path | str = "./data",
         theta_inj: float = 0.0,
-        model_file: Path | str | None = None,
+        model_file: str = "jicf_model.h5",
+        x_profile: Array | None = None,
     ) -> None:
         """
         This method initializes the Jet-in-Crossflow model with the following
@@ -77,10 +78,17 @@ class JICModel:
             The relaxation parameter (used here only for storage)
         datadir: str
             Where to access or store tables written for this injector
-        model_file: Path | str | None
-            Path to the HDF5 file caching the generated model tables. Defaults
-            to ``<datadir>/jicf_model.h5``. Tables already present in the file
-            are loaded; any that are missing are computed and written to it.
+        model_file: str
+            Name of the HDF5 file caching the generated model tables, resolved
+            relative to ``datadir`` (i.e. ``<datadir>/<model_file>``). Tables
+            already present in the file are loaded; any that are missing are
+            computed and written to it.
+        x_profile: np.ndarray | None
+            Axial mesh on which to generate the stored Z mean/variance profiles.
+            When ``None`` (default), the stretched grid ``self.x_3D_data`` used
+            for the 3D field is reused. When supplied, it is used verbatim.
+            Ignored when the profiles are loaded from an existing model file
+            (the stored mesh is used instead).
         geometry: Box
             The geometry object describing the mesh and cross-section
         physics: FPVTable
@@ -115,11 +123,11 @@ class JICModel:
         self.alpha = alpha if alpha is not None else 1e6
         self.datadir = Path(datadir)
         self.datadir.mkdir(exist_ok=True)
-        self.model_file = (
-            Path(model_file)
-            if model_file is not None
-            else self.datadir / "jicf_model.h5"
-        )
+        self.model_file = self.datadir / model_file
+
+        # Optional user-supplied mesh for the stored Z profiles; when None the
+        # stretched 3D grid (self.x_3D_data) is used (see calc_Z_avg_var_profiles).
+        self._x_profile_input = x_profile
 
         # Geometry parameters
         self.A = self.w * self.h
@@ -387,8 +395,19 @@ class JICModel:
     def calc_Z_avg_var_profiles(self, write=False):
         print("Computing Z average and variance profiles...")
         # Record the mesh the profiles are generated on so the interpolators can
-        # be rebuilt independently of the simulation mesh.
-        self.x_profile = np.asarray(self.xc, dtype=float)
+        # be rebuilt independently of the simulation mesh. Use the caller-supplied
+        # mesh if given, otherwise the stretched 3D grid (which spans the same
+        # [xc[0], xc[-1]] interval as the simulation mesh).
+        if self._x_profile_input is not None:
+            self.x_profile = np.asarray(self._x_profile_input, dtype=float)
+        else:
+            if not hasattr(self, "x_3D_data"):
+                msg = (
+                    "x_3D_data is unavailable: the 3D mixture-fraction field must "
+                    "be computed or loaded before generating the Z profiles."
+                )
+                raise RuntimeError(msg)
+            self.x_profile = np.asarray(self.x_3D_data, dtype=float)
         n_mdot = len(self.mdot_inj_unique)
         self.Z_avg_profile = np.zeros([n_mdot, len(self.x_profile)])
         self.Z_var_profile = np.zeros([n_mdot, len(self.x_profile)])

--- a/src/stanshock/models/jicf/source.py
+++ b/src/stanshock/models/jicf/source.py
@@ -108,34 +108,6 @@ class FuelInjector(RightHandSide):
 
         return np.ravel(rhs / self.cell_volumes)
 
-    def get_MIB_profiles(self):
-        """
-        This method returns the MIB profiles for the progress variable and chemical
-        energy.
-        """
-        C = np.zeros(len(self.xc))
-        E_CHEM = np.zeros(len(self.xc))
-        mdot_inj = np.interp(
-            self.xc,
-            np.flip(self.fluid_tips, axis=0)[:, 0],
-            np.flip(self.fluid_tips, axis=0)[:, 1],
-        )
-
-        for i_x in range(len(self.xc)):
-            if self.xc[i_x] < self.jicf.x_inj:
-                continue
-            # Interpolate into fluid tip positions to get the mass flow rate
-            C[i_x] = np.interp(
-                mdot_inj[i_x], self.jicf.mdot_inj_unique, self.jicf.C_profile[:, i_x]
-            )
-            E_CHEM[i_x] = np.interp(
-                mdot_inj[i_x],
-                self.jicf.mdot_inj_unique,
-                self.jicf.E_CHEM_profile[:, i_x],
-            )
-
-        return C, E_CHEM
-
 
 class JICFChemistrySource(RightHandSide):
     def __init__(


### PR DESCRIPTION
Cleanup work under the JICF umbrella (#95), covering two sub-issues.

## #99 — Remove unused mixed-is-burned (MIB) model

The MIB progress-variable / chemical-energy profiles were computed and stored but never used at runtime. Removed `JICModel.calc_MIB_profile`, `C_E_CHEM_avg_MIB`, `FuelInjector.get_MIB_profiles`, the `load_MIB_profile` flag and its handling, and the corresponding example arguments (~118 lines).

## #98 — Remove mesh dependence of Z profiles; consolidate to HDF5

- Store the generation mesh with `Z_avg_profile` / `Z_var_profile` and build the interpolators on that **stored** mesh (with linear extrapolation for out-of-range query points such as ghost cells), decoupling the model from the simulation grid — no more full regeneration when the mesh changes.
- Replace the collection of per-array `.npy` cache files and the three `load_*` boolean flags with a single HDF5 file (`jicf_model.h5`), auto-detecting cached groups (`Z_3D`, `Z_profiles`, `chemical_sources`) and computing any that are missing. Examples pass `datadir` instead of the removed flags.

## Verification

- `ruff` + `py_compile` clean; the `jicf` package imports fine.
- Mechanism test: querying the profile interpolator on a *different* (206-pt, extended) mesh now returns finite values instead of the previous 200-vs-206 shape-mismatch crash; the HDF5 write/detect/read round-trips.

## Not included (separate blocker)

Full end-to-end verification of the HyShot FPV run is still blocked by the injector-origin divide-by-zero in `profile.py` (`AnalyticJICF`), which poisons `Z_3D` with NaN — see #105. That lives in the analytic model (arguably #104 territory), not this mesh/HDF5 cleanup.

Note: `examples/04_jicf_heat_release_profile` has a pre-existing `JICModel` signature mismatch (passes `fuel=`, omits `phi_inj`) unrelated to this PR.

Relates to #95, #98, #99.

Review update (7b478c7): make model_file a str filename (default
"jicf_model.h5") resolved as datadir / model_file, so datadir and the model
file can no longer disagree. Add an optional x_profile mesh for the stored Z
profiles; when omitted it defaults to the stretched grid self.x_3D_data (a
model-intrinsic mesh spanning the same interval) instead of the simulation
mesh. Profiles loaded from an existing file keep their stored mesh.