### PR TITLE
[#101] Add JICF Analysis and Plotting Utilities

### DIFF
--- a/examples/hyshot_ii/case_setup.py
+++ b/examples/hyshot_ii/case_setup.py
@@ -9,7 +9,7 @@ from injector_models import fuel_props_from_phi
 
 from stanshock.components.combustor import Combustor
 from stanshock.models.inlet_diffuser import InletDiffuser
-from stanshock.models.jicf import JICModel
+from stanshock.models.jicf import JICModel, plot_jicf_flowfield
 from stanshock.models.wall_models import (
     CompressibleHeatFlux,
     CompressibleReactingSkinFriction,
@@ -403,7 +403,7 @@ def get_injectors_fpv(
     # U_f = U_f[-1]
     # T_f = T_f[-1]
 
-    return JICModel(
+    jicf = JICModel(
         x_inj=x_inj,
         x_noz=L_const,
         n_inj=N_f,
@@ -421,6 +421,11 @@ def get_injectors_fpv(
         physics=physics,
         datadir=fpv_dir,
     )
+
+    # Generate plots of the fuel jets
+    plot_jicf_flowfield(jicf)
+
+    return jicf
 
 
 class Hyshot2Interface:

--- a/src/stanshock/models/jicf/__init__.py
+++ b/src/stanshock/models/jicf/__init__.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
-__all__ = ["AnalyticJICF", "FuelInjector", "JICFChemistrySource", "JICModel"]
+__all__ = [
+    "AnalyticJICF",
+    "FuelInjector",
+    "JICFChemistrySource",
+    "JICModel",
+    "plot_jicf_flowfield",
+]
 
 from stanshock.models.jicf.generate import JICModel
+from stanshock.models.jicf.plot import plot_jicf_flowfield
 from stanshock.models.jicf.profile import AnalyticJICF
 from stanshock.models.jicf.source import FuelInjector, JICFChemistrySource

--- a/src/stanshock/models/jicf/generate.py
+++ b/src/stanshock/models/jicf/generate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import warnings
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import cantera as ct
 import h5py
@@ -15,8 +16,11 @@ from tqdm import tqdm
 
 from stanshock.models.jicf.profile import AnalyticJICF
 from stanshock.physics.flamelet import FPVTable
-from stanshock.system.backend import Array
 from stanshock.system.geometry import Box
+from stanshock.utils.h5 import RectilinearVtkhdf, h5_getarray, h5_has, h5_write
+
+if TYPE_CHECKING:
+    from stanshock.system.backend import Array
 
 
 class JICModel:
@@ -43,7 +47,7 @@ class JICModel:
         datadir: Path | str = "./data",
         theta_inj: float = 0.0,
         alpha: float = 1e6,
-        model_file: str = "jicf_model.h5",
+        model_file: str = "jicf_model.vtkhdf",
         x_profile: Array | None = None,
     ) -> None:
         """
@@ -192,27 +196,25 @@ class JICModel:
         )
 
         # Precompute a 3D array of the mixture fraction and generate an interpolator
-        if self._h5_has("Z_3D/Z"):
-            with h5py.File(str(self.model_file), "r") as f:
-                group = f["Z_3D"]
-                assert isinstance(group, h5py.Group)
-                self.x_3D_data = self._h5_getarray(group, "x")
-                self.y_3D_data = self._h5_getarray(group, "y")
-                self.z_3D_data = self._h5_getarray(group, "z")
-                self.Z_3D_data = self._h5_getarray(group, "Z")
+        if h5_has(self.model_file, "VTKHDF/PointData/Z"):
+            vtk = RectilinearVtkhdf.from_vtkhdf(self.model_file)
+            self.x_3D_data = vtk.x
+            self.y_3D_data = vtk.y
+            self.z_3D_data = vtk.z
+            self.Z_3D_data = vtk.vals["Z"]
             self._build_Z_3D_interp()
         else:
             self.calc_Z_3D_interp(write=True)
 
         # Precompute the axial mean and variance profiles of Z, along with the
         # mesh they were generated on.
-        if self._h5_has("Z_profiles/Z_avg"):
+        if h5_has(self.model_file, "Z_profiles/Z_avg"):
             with h5py.File(str(self.model_file), "r") as f:
                 group = f["Z_profiles"]
                 assert isinstance(group, h5py.Group)
-                self.x_profile = self._h5_getarray(group, "x")
-                self.Z_avg_profile = self._h5_getarray(group, "Z_avg")
-                self.Z_var_profile = self._h5_getarray(group, "Z_var")
+                self.x_profile = h5_getarray(group, "x")
+                self.Z_avg_profile = h5_getarray(group, "Z_avg")
+                self.Z_var_profile = h5_getarray(group, "Z_var")
         else:
             self.calc_Z_avg_var_profiles(write=True)
 
@@ -235,41 +237,19 @@ class JICModel:
         )
 
         # Precompute and tabulate chemical source terms
-        if self._h5_has("chemical_sources/omega_C_int"):
+        if h5_has(self.model_file, "chemical_sources/omega_C_int"):
             with h5py.File(str(self.model_file), "r") as f:
                 group = f["chemical_sources"]
                 assert isinstance(group, h5py.Group)
-                self.Zbar_vec = self._h5_getarray(group, "Zbar")
-                self.Lbar_vec = self._h5_getarray(group, "Lbar")
-                self.logsigma2_vec = self._h5_getarray(group, "logsigma2")
-                self.omega_C_int = self._h5_getarray(group, "omega_C_int")
+                self.Zbar_vec = h5_getarray(group, "Zbar")
+                self.Lbar_vec = h5_getarray(group, "Lbar")
+                self.logsigma2_vec = h5_getarray(group, "logsigma2")
+                self.omega_C_int = h5_getarray(group, "omega_C_int")
             self.omega_C_int_interp = RegularGridInterpolator(
                 (self.Zbar_vec, self.Lbar_vec, self.logsigma2_vec), self.omega_C_int
             )
         else:
             self.calc_chemical_sources(write=True)
-
-    def _h5_has(self, key: str) -> bool:
-        """Return True if the model file exists and contains the given dataset."""
-        if not self.model_file.exists():
-            return False
-        with h5py.File(str(self.model_file), "r") as f:
-            return key in f
-
-    def _h5_getarray(self, h: h5py.File | h5py.Group, key: str) -> Array:
-        """Load array data from h5 file in a way that respects type checking."""
-        data_handle = h[key]
-        assert isinstance(data_handle, h5py.Dataset)
-        return np.asarray(data_handle[...], dtype=float)
-
-    def _h5_write(self, group: str, data: dict[str, Array]) -> None:
-        """Write (overwriting if present) a group of named arrays to the model file."""
-        with h5py.File(str(self.model_file), "a") as f:
-            grp = f.require_group(group)
-            for name, array in data.items():
-                if name in grp:
-                    del grp[name]
-                grp[name] = array
 
     def __stretched_grid(
         self,
@@ -309,15 +289,15 @@ class JICModel:
         self.Z_3D_data[np.isnan(self.Z_3D_data)] = 0.0
 
         if write:
-            self._h5_write(
-                "Z_3D",
-                {
-                    "x": self.x_3D_data,
-                    "y": self.y_3D_data,
-                    "z": self.z_3D_data,
-                    "Z": self.Z_3D_data,
-                },
+            vtk = RectilinearVtkhdf(
+                self.x_3D_data,
+                self.y_3D_data,
+                self.z_3D_data,
+                {"Z": self.Z_3D_data},
+                self.model_file,
+                self.mdot_inj_unique,
             )
+            vtk.save()
 
         self._build_Z_3D_interp()
 
@@ -466,7 +446,8 @@ class JICModel:
         self.Z_var_profile[idx, :] = self.Z_var_profile[ifreeze, :]
 
         if write:
-            self._h5_write(
+            h5_write(
+                self.model_file,
                 "Z_profiles",
                 {
                     "x": self.x_profile,
@@ -591,7 +572,8 @@ class JICModel:
         self.omega_C_int[np.isnan(self.omega_C_int)] = 0.0
 
         if write:
-            self._h5_write(
+            h5_write(
+                self.model_file,
                 "chemical_sources",
                 {
                     "Zbar": self.Zbar_vec,

--- a/src/stanshock/models/jicf/generate.py
+++ b/src/stanshock/models/jicf/generate.py
@@ -268,7 +268,7 @@ class JICModel:
                 spacing *= growth_rate
         return np.sort(np.unique(x_grid))
 
-    def calc_Z_3D_interp(self, write: bool = False) -> None:
+    def calc_Z_3D_interp(self, write: bool = False, debug: bool = False) -> None:
         print("Computing Z 3D array...")
         dx = 5.0e-4
         Ny = int(np.ceil(self.h / dx))
@@ -288,12 +288,25 @@ class JICModel:
         self.Z_3D_data[..., self.u_inj_unique == 0.0] = 0.0
         self.Z_3D_data[np.isnan(self.Z_3D_data)] = 0.0
 
+        results: dict[str, Array] = {"Z": self.Z_3D_data}
+
+        if debug:
+            z_inj = self.analytic.z_inj[0]
+            x_cl, y_cl, n2 = self.analytic.nearest_on_cl(
+                self.x_3D_data[:, None, None] - self.x_inj,
+                self.y_3D_data[None, :, None],
+                self.z_3D_data[None, None, :] - z_inj,
+            )
+            results["x_cl"] = x_cl
+            results["y_cl"] = y_cl
+            results["n"] = np.sqrt(n2)
+
         if write:
             vtk = RectilinearVtkhdf(
                 self.x_3D_data,
                 self.y_3D_data,
                 self.z_3D_data,
-                {"Z": self.Z_3D_data},
+                results,
                 self.model_file,
                 self.mdot_inj_unique,
             )

--- a/src/stanshock/models/jicf/plot.py
+++ b/src/stanshock/models/jicf/plot.py
@@ -23,7 +23,13 @@ class PlotOptions:
     figsize: tuple[float, float]
 
 
-def _contour_plot(x: Array, y: Array, z: Array, opts: PlotOptions) -> None:
+def _contour_plot(
+    x: Array,
+    y: Array,
+    z: Array,
+    opts: PlotOptions,
+    extra: dict[str, tuple[Array, Array]] | None = None,
+) -> None:
     fig, ax = plt.subplots(figsize=opts.figsize)
 
     vmin = z.min()
@@ -33,6 +39,16 @@ def _contour_plot(x: Array, y: Array, z: Array, opts: PlotOptions) -> None:
     norm = Normalize(vmin=vmin, vmax=vmax)
     axcb = fig.colorbar(cs, fraction=0.046, pad=0.01).ax
     _cb = ColorbarBase(axcb, cmap=plt.get_cmap("inferno"), norm=norm)
+
+    if extra is not None:
+        # Overlay lines on the contour plot, adding a legend if there are more than one
+        multi = len(extra) > 1
+
+        for label, (xl, yl) in extra.items():
+            ax.plot(xl, yl, "-" if multi else "r--", label=label)
+
+        if multi:
+            ax.legend(loc="best")
 
     ax.set_aspect("equal", "box")
     ax.set_xlabel(opts.xlabel)
@@ -44,7 +60,7 @@ def _contour_plot(x: Array, y: Array, z: Array, opts: PlotOptions) -> None:
     plt.close(fig)
 
 
-def plot_jicf_flowfield(jicf: JICModel, plot_dir: Path = Path("plots/jicf")) -> None:
+def plot_jicf_flowfield(jicf: JICModel, plot_dir: Path = Path("figures/jicf")) -> None:
     """Generate contour plots of the JICF flow field"""
     plot_dir.mkdir(parents=True, exist_ok=True)
     x = jicf.x_3D_data
@@ -52,26 +68,47 @@ def plot_jicf_flowfield(jicf: JICModel, plot_dir: Path = Path("plots/jicf")) -> 
     z = jicf.z_3D_data
     Z = jicf.Z_3D_data
 
-    # Generate plot along injector centerlines
-    z_inj = jicf.analytic.z_inj
+    # Get injector location info for constraining the plots
+    x_min = 0.9 * jicf.x_inj + 0.1 * x[0]
+    ix_min = np.argmin(np.abs(x - x_min))
+    x_max = 0.6 * jicf.x_inj + 0.4 * x[-1]
+    ix_max = np.argmin(np.abs(x - x_max))
+    x = x[ix_min:ix_max]
+    Z = Z[ix_min:ix_max]
 
+    z_inj = jicf.analytic.z_inj
+    nx = len(x)
+    ix_inj = np.argmin(np.abs(x - jicf.x_inj))
+
+    # Compute jet centerline profiles
+    jicf.analytic.i_m = slice(None)
+    x_cl = np.linspace(0.0, x[-1] - jicf.x_inj, 1001)
+    y_cl = jicf.analytic.y_cl(x_cl[:, None])
+    x_cl += jicf.x_inj
+    y_cl[y_cl > y[-1]] = np.nan
+
+    # Generate plot along injector centerlines
     opts = PlotOptions(
         "Centerline Mixture Fraction",
         "x [m]",
         "y [m]",
         plot_dir / "Z_centerline.png",
-        (38.4, 3.2),
+        (38.4, 4.0),
     )
+
     for i in range(len(z_inj)):
         iz_inj = np.argmin(np.abs(z - z_inj[i]))
         for iJ in range(jicf.nJ):
             opts.title = f"Jet Centerline Mixture Fraction at z={z_inj[i]:.3f}, J={jicf.analytic.J[iJ]:.2f}"
-            opts.filename = plot_dir / f"Z_cl_z{i:02d}_J{iJ:02d}.png"
+            opts.filename = plot_dir / f"Z_z{i:02d}_J{iJ:02d}.png"
             _contour_plot(x, y, Z[:, :, iz_inj, iJ].T, opts)
 
+            opts.filename = plot_dir / f"Z_z{i:02d}_J{iJ:02d}_cl.png"
+            _contour_plot(
+                x, y, Z[:, :, iz_inj, iJ].T, opts, extra={"": (x_cl, y_cl[:, iJ])}
+            )
+
     # Generate plots in transverse slices
-    nx = len(x)
-    ix_inj = np.argmin(np.abs(x - jicf.x_inj))
     n_plot = 5
     di = (nx - ix_inj) // (n_plot - 1)
     if n_plot * di + ix_inj > nx - 1:
@@ -82,6 +119,8 @@ def plot_jicf_flowfield(jicf: JICModel, plot_dir: Path = Path("plots/jicf")) -> 
     for i in range(n_plot):
         ix = ix_inj + i * di
         for iJ in range(jicf.nJ):
-            opts.title = f"Mixture Fraction at x={x[ix]:.3f}, J={jicf.analytic.J[iJ]:.2f}"
+            opts.title = (
+                f"Mixture Fraction at x={x[ix]:.3f}, J={jicf.analytic.J[iJ]:.2f}"
+            )
             opts.filename = plot_dir / f"Z_x{i:02d}_J{iJ:02d}.png"
             _contour_plot(z, y, Z[ix, :, :, iJ], opts)

--- a/src/stanshock/models/jicf/plot.py
+++ b/src/stanshock/models/jicf/plot.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.colorbar import ColorbarBase
+from matplotlib.colors import Normalize
+
+if TYPE_CHECKING:
+    from stanshock.models.jicf.generate import JICModel
+    from stanshock.system.backend import Array
+
+
+@dataclass
+class PlotOptions:
+    title: str
+    xlabel: str
+    ylabel: str
+    filename: Path
+    figsize: tuple[float, float]
+
+
+def _contour_plot(x: Array, y: Array, z: Array, opts: PlotOptions) -> None:
+    fig, ax = plt.subplots(figsize=opts.figsize)
+    # ax.tick_params(axis="both", which="major", labelsize="18")
+
+    vmin = z.min()
+    vmax = z.max()
+    cs = ax.contourf(x, y, z, 256, cmap="inferno", vmin=vmin, vmax=vmax)
+
+    norm = Normalize(vmin=vmin, vmax=vmax)
+    axcb = fig.colorbar(cs, fraction=0.046, pad=0.01).ax
+    _cb = ColorbarBase(axcb, cmap=plt.get_cmap("inferno"), norm=norm)
+    # _cb.ax.tick_params(labelsize=18)
+
+    ax.set_xlabel(opts.xlabel)
+    ax.set_ylabel(opts.ylabel)
+    ax.set_title(opts.title)
+
+    fig.tight_layout()
+    fig.savefig(opts.filename)
+    plt.close(fig)
+
+
+def plot_jicf_flowfield(jicf: JICModel, plot_dir: Path = Path("plots/jicf")) -> None:
+    """Generate contour plots of the JICF flow field"""
+    plot_dir.mkdir(parents=True, exist_ok=True)
+    x = jicf.x_3D_data
+    y = jicf.y_3D_data
+    z = jicf.z_3D_data
+    Z = jicf.Z_3D_data
+
+    # Generate plot along injector centerline
+    z_inj = jicf.analytic.z_inj
+    k_center = np.argmin(np.abs(z - z_inj[0]))
+
+    opts = PlotOptions(
+        "Centerline Mixture Fraction",
+        "x [m]",
+        "y [m]",
+        plot_dir / "Z_centerline.png",
+        (19.2, 6.4),
+    )
+    for iJ in range(jicf.nJ):
+        opts.title = f"Centerline Mixture Fraction, J={jicf.analytic.J[iJ]}"
+        _contour_plot(x, y, Z[:, :, k_center, iJ], opts)

--- a/src/stanshock/models/jicf/plot.py
+++ b/src/stanshock/models/jicf/plot.py
@@ -25,7 +25,6 @@ class PlotOptions:
 
 def _contour_plot(x: Array, y: Array, z: Array, opts: PlotOptions) -> None:
     fig, ax = plt.subplots(figsize=opts.figsize)
-    # ax.tick_params(axis="both", which="major", labelsize="18")
 
     vmin = z.min()
     vmax = z.max()
@@ -34,8 +33,8 @@ def _contour_plot(x: Array, y: Array, z: Array, opts: PlotOptions) -> None:
     norm = Normalize(vmin=vmin, vmax=vmax)
     axcb = fig.colorbar(cs, fraction=0.046, pad=0.01).ax
     _cb = ColorbarBase(axcb, cmap=plt.get_cmap("inferno"), norm=norm)
-    # _cb.ax.tick_params(labelsize=18)
 
+    ax.set_aspect("equal", "box")
     ax.set_xlabel(opts.xlabel)
     ax.set_ylabel(opts.ylabel)
     ax.set_title(opts.title)
@@ -53,17 +52,36 @@ def plot_jicf_flowfield(jicf: JICModel, plot_dir: Path = Path("plots/jicf")) -> 
     z = jicf.z_3D_data
     Z = jicf.Z_3D_data
 
-    # Generate plot along injector centerline
+    # Generate plot along injector centerlines
     z_inj = jicf.analytic.z_inj
-    k_center = np.argmin(np.abs(z - z_inj[0]))
 
     opts = PlotOptions(
         "Centerline Mixture Fraction",
         "x [m]",
         "y [m]",
         plot_dir / "Z_centerline.png",
-        (19.2, 6.4),
+        (38.4, 3.2),
     )
-    for iJ in range(jicf.nJ):
-        opts.title = f"Centerline Mixture Fraction, J={jicf.analytic.J[iJ]}"
-        _contour_plot(x, y, Z[:, :, k_center, iJ], opts)
+    for i in range(len(z_inj)):
+        iz_inj = np.argmin(np.abs(z - z_inj[i]))
+        for iJ in range(jicf.nJ):
+            opts.title = f"Jet Centerline Mixture Fraction at z={z_inj[i]:.3f}, J={jicf.analytic.J[iJ]:.2f}"
+            opts.filename = plot_dir / f"Z_cl_z{i:02d}_J{iJ:02d}.png"
+            _contour_plot(x, y, Z[:, :, iz_inj, iJ].T, opts)
+
+    # Generate plots in transverse slices
+    nx = len(x)
+    ix_inj = np.argmin(np.abs(x - jicf.x_inj))
+    n_plot = 5
+    di = (nx - ix_inj) // (n_plot - 1)
+    if n_plot * di + ix_inj > nx - 1:
+        di -= 1
+
+    opts.xlabel = "z [m]"
+    opts.figsize = (38.4, 6.4)
+    for i in range(n_plot):
+        ix = ix_inj + i * di
+        for iJ in range(jicf.nJ):
+            opts.title = f"Mixture Fraction at x={x[ix]:.3f}, J={jicf.analytic.J[iJ]:.2f}"
+            opts.filename = plot_dir / f"Z_x{i:02d}_J{iJ:02d}.png"
+            _contour_plot(z, y, Z[ix, :, :, iJ], opts)

--- a/src/stanshock/models/jicf/plot.py
+++ b/src/stanshock/models/jicf/plot.py
@@ -60,7 +60,14 @@ def _contour_plot(
     plt.close(fig)
 
 
-def plot_jicf_flowfield(jicf: JICModel, plot_dir: Path = Path("figures/jicf")) -> None:
+def plot_jicf_flowfield(
+    jicf: JICModel,
+    plot_dir: Path = Path("figures/jicf"),
+    plot_all_inj: bool = False,
+    plot_all_J: bool = True,
+    plot_centerlines: bool = True,
+    truncate_plot: bool = True,
+) -> None:
     """Generate contour plots of the JICF flow field"""
     plot_dir.mkdir(parents=True, exist_ok=True)
     x = jicf.x_3D_data
@@ -71,12 +78,17 @@ def plot_jicf_flowfield(jicf: JICModel, plot_dir: Path = Path("figures/jicf")) -
     # Get injector location info for constraining the plots
     x_min = 0.9 * jicf.x_inj + 0.1 * x[0]
     ix_min = np.argmin(np.abs(x - x_min))
-    x_max = 0.6 * jicf.x_inj + 0.4 * x[-1]
+    r = 0.9 if truncate_plot else 0.6
+    x_max = r * jicf.x_inj + (1.0 - r) * x[-1]
     ix_max = np.argmin(np.abs(x - x_max))
     x = x[ix_min:ix_max]
     Z = Z[ix_min:ix_max]
 
     z_inj = jicf.analytic.z_inj
+    if not plot_all_inj:
+        # Keep center injector
+        i_mid = len(z_inj) // 2
+        z_inj = z_inj[[i_mid]]
     nx = len(x)
     ix_inj = np.argmin(np.abs(x - jicf.x_inj))
 
@@ -87,26 +99,39 @@ def plot_jicf_flowfield(jicf: JICModel, plot_dir: Path = Path("figures/jicf")) -
     x_cl += jicf.x_inj
     y_cl[y_cl > y[-1]] = np.nan
 
+    # Get the momentum flux ratios to plot over
+    nJ = jicf.nJ
+    J = jicf.analytic.J
+    if not plot_all_J:
+        nstep = max(len(J) // 5, 1)
+        J = J[::nstep]
+        nJ = len(J)
+        x_cl = x_cl[:, ::nstep]
+        y_cl = y_cl[:, ::nstep]
+
     # Generate plot along injector centerlines
     opts = PlotOptions(
         "Centerline Mixture Fraction",
         "x [m]",
         "y [m]",
         plot_dir / "Z_centerline.png",
-        (38.4, 4.0),
+        (19.2, 6.4) if truncate_plot else (38.4, 4.0),
     )
 
     for i in range(len(z_inj)):
         iz_inj = np.argmin(np.abs(z - z_inj[i]))
-        for iJ in range(jicf.nJ):
-            opts.title = f"Jet Centerline Mixture Fraction at z={z_inj[i]:.3f}, J={jicf.analytic.J[iJ]:.2f}"
-            opts.filename = plot_dir / f"Z_z{i:02d}_J{iJ:02d}.png"
-            _contour_plot(x, y, Z[:, :, iz_inj, iJ].T, opts)
-
-            opts.filename = plot_dir / f"Z_z{i:02d}_J{iJ:02d}_cl.png"
-            _contour_plot(
-                x, y, Z[:, :, iz_inj, iJ].T, opts, extra={"": (x_cl, y_cl[:, iJ])}
+        for iJ in range(nJ):
+            opts.title = (
+                f"Jet Centerline Mixture Fraction at z={z_inj[i]:.3f}, J={J[iJ]:.2f}"
             )
+            if plot_centerlines:
+                opts.filename = plot_dir / f"Z_z{i:02d}_J{iJ:02d}_cl.png"
+                _contour_plot(
+                    x, y, Z[:, :, iz_inj, iJ].T, opts, extra={"": (x_cl, y_cl[:, iJ])}
+                )
+            else:
+                opts.filename = plot_dir / f"Z_z{i:02d}_J{iJ:02d}.png"
+                _contour_plot(x, y, Z[:, :, iz_inj, iJ].T, opts)
 
     # Generate plots in transverse slices
     n_plot = 5

--- a/src/stanshock/system/backend.py
+++ b/src/stanshock/system/backend.py
@@ -22,6 +22,7 @@ __all__: list[str] = [
 
 # Define the Array type for use in type hints to make future changes easier
 Array: TypeAlias = np.ndarray[tuple[int, ...], np.dtype[np.float64]]
-Index: TypeAlias = np.ndarray[tuple[int, ...], np.dtype[np.int64]] | slice
+IntArray: TypeAlias = np.ndarray[tuple[int, ...], np.dtype[np.int64]]
+Index: TypeAlias = IntArray | slice
 
 Composition: TypeAlias = dict[str, float]

--- a/src/stanshock/system/backend.py
+++ b/src/stanshock/system/backend.py
@@ -6,15 +6,16 @@ from typing import TypeAlias
 import numpy as np
 
 if sys.version_info >= (3, 13):
-    from typing import NotRequired, Unpack
+    from typing import NotRequired, Self, Unpack
 else:
-    from typing_extensions import NotRequired, Unpack
+    from typing_extensions import NotRequired, Self, Unpack
 
 __all__: list[str] = [
     "Array",
     "Composition",
     "Index",
     "NotRequired",
+    "Self",
     "TypeAlias",
     "Unpack",
     "np",

--- a/src/stanshock/utils/h5.py
+++ b/src/stanshock/utils/h5.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Self
+
+from h5py import Dataset, File, Group, string_dtype
+
+from stanshock.system.backend import Array, IntArray, np
+
+
+def h5_has(filename: Path, key: str) -> bool:
+    """Return True if the model file exists and contains the given dataset."""
+    if not filename.exists():
+        return False
+    with File(str(filename), "r") as f:
+        return key in f
+
+
+def h5_getarray(h: File | Group, key: str) -> Array:
+    """Load array data from h5 file in a way that respects type checking."""
+    data_handle = h[key]
+    assert isinstance(data_handle, Dataset)
+    return np.asarray(data_handle[...], dtype=float)
+
+
+def h5_write(filename: Path, group: str, data: dict[str, Array]) -> None:
+    """Write (overwriting if present) a group of named arrays to the model file."""
+    with File(str(filename), "a") as f:
+        grp = f.require_group(group)
+        for name, array in data.items():
+            if name in grp:
+                del grp[name]
+            grp[name] = array
+
+
+class RectilinearVtkhdf:
+    def __init__(
+        self,
+        x: Array,
+        y: Array,
+        z: Array,
+        vals: dict[str, Array],
+        filename: Path,
+        t: Array | None = None,
+    ) -> None:
+        self.x = x
+        self.y = y
+        self.z = z
+        self.t = t
+        self.vals = vals
+        self.filename = filename
+
+        self.nx = len(self.x)
+        self.ny = len(self.y)
+        self.nz = len(self.z)
+        self.nt = len(self.t) if self.t is not None else 0
+
+        ts = (self.nt,) if self.t is not None else ()
+        self.shape = (self.nx, self.ny, self.nz, *ts)
+        # Verify data shape
+        for val in self.vals.values():
+            assert self.shape == val.shape
+
+    @classmethod
+    def from_vtkhdf(cls, filename: Path) -> Self:
+        with File(str(filename), "r") as f:
+            root = f.require_group("VTKHDF")
+            x = h5_getarray(root, "XCoordinates")
+            y = h5_getarray(root, "YCoordinates")
+            z = h5_getarray(root, "ZCoordinates")
+
+            t: Array | None = None
+            move_time = False
+            if "Steps" in root:
+                steps = root.require_group("Steps")
+                t = h5_getarray(steps, "Values")
+                move_time = True
+
+            data = root.require_group("PointData")
+            vals: dict[str, Array] = {}
+            for key in data:
+                val = h5_getarray(data, key)
+                if move_time:
+                    val = np.moveaxis(val, 0, -1)
+                vals[key] = np.swapaxes(val, 0, 2)
+
+        return cls(x, y, z, vals, filename, t)
+
+    def save(self) -> None:
+        with File(str(self.filename), "w") as f:
+            root = f.require_group("VTKHDF")
+            root.attrs["Version"] = (2, 8)
+            ascii_type = "RectilinearGrid".encode("ascii")
+            root.attrs.create(  # type: ignore[attr-defined]
+                "Type", ascii_type, dtype=string_dtype("ascii", len(ascii_type))
+            )
+            dimensions = (self.nx, self.ny, self.nz)
+            root.attrs.create("Dimensions", dimensions, dtype="i4")  # type: ignore[attr-defined]
+
+            move_time = False
+            if self.t is not None and self.nt > 0:
+                steps = root.require_group("Steps")
+                steps.attrs["NSteps"] = self.nt
+                steps.create_dataset("Values", data=self.t)
+
+                offsets: IntArray = np.arange(self.nt + 1, dtype=np.int64)
+                point_offsets = steps.require_group("PointDataOffsets")
+                for key in self.vals:
+                    point_offsets.create_dataset(key, data=offsets, maxshape=(None,))
+
+                offsets = np.zeros((self.nt,), dtype=np.int64)
+                for dim in ["X", "Y", "Z"]:
+                    steps.create_dataset(
+                        f"{dim}CoordinatesOffsets", data=offsets, maxshape=(None,)
+                    )
+                move_time = True
+
+            root.create_dataset("XCoordinates", data=self.x, maxshape=(None,))
+            root.create_dataset("YCoordinates", data=self.y, maxshape=(None,))
+            root.create_dataset("ZCoordinates", data=self.z, maxshape=(None,))
+
+            data = root.require_group("PointData")
+            for key, val in self.vals.items():
+                # write_val = np.asarray(val, dtype=np.float32)
+                write_val = np.swapaxes(val, 0, 2)
+                if move_time:
+                    # Move time axis to first dimension
+                    write_val = np.copy(np.moveaxis(write_val, -1, 0))
+                data.create_dataset(
+                    key,
+                    data=write_val,
+                    maxshape=(None, *dimensions[::-1]),
+                    chunks=(1, *dimensions[::-1]),
+                )

--- a/src/stanshock/utils/h5.py
+++ b/src/stanshock/utils/h5.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Self
 
 from h5py import Dataset, File, Group, string_dtype
 
-from stanshock.system.backend import Array, IntArray, np
+from stanshock.system.backend import Array, IntArray, Self, np
 
 
 def h5_has(filename: Path, key: str) -> bool:


### PR DESCRIPTION
This commit adds utilities for verifying and visually inspecting the jet-in-crossflow models, including contour plots of mixture fraction along axial and transverse slices of the domain with the theoretical jet centerline overlaid. It also modifies the format of the HDF5 data file to follow the VTKHDF standard for a RectilinearGrid, enabling direct loading and visualization within ParaView>=6.1.2.