### PR TITLE
[#104] Vectorize and Annotate JICF Functions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,10 +64,11 @@ repos:
   #         - numba
   #         - cantera
   #         - joblib
+  #         - joblib-stubs
   #         - tqdm
-  #         - tqdm_joblib
   #         - types-tqdm
   #         - h5py
+  #         - h5py-stubs
 
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,12 +41,9 @@ dependencies = [
   "cantera",
   "joblib",
   "tqdm",
-  "tqdm_joblib",
-  # "types-tqdm",
   "h5py",
   "imageio",
   # Conditional:
-  "scipy-stubs>=1.18.0; python_version>='3.12'",
   "cantera>=3.2.0; python_version>='3.14'",
   "numba>=0.63.0rc1; python_version>='3.14'",
 ]
@@ -67,8 +64,16 @@ test = [
   "pytest >=6",
   "pytest-cov >=3",
 ]
+type-check = [
+  "mypy",
+  "h5py-stubs",
+  "scipy-stubs>=1.18.0; python_version>='3.12'",
+  "types-tqdm",
+  "joblib-stubs",
+]
 dev = [
   { include-group = "test" },
+  { include-group = "type-check" },
 ]
 docs = [
   "sphinx>=7.0",
@@ -88,15 +93,12 @@ build.hooks.vcs.version-file = "src/stanshock/_version.py"
 dependencies = [
   "numpy",
   "scipy",
-  # "scipy-stubs",
   "scikit-learn",
   "matplotlib",
   "numba",
   "cantera",
   "joblib",
   "tqdm",
-  "tqdm_joblib",
-  # "types-tqdm",
   "h5py",
   "imageio",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.26", "hatch-vcs"]
+requires = ["hatchling>=1.26,<1.32", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dynamic = ["version"]
 dependencies = [
   "numpy",
   "scipy",
-  # "scipy-stubs",
   "scikit-learn",
   "matplotlib",
   "numba",
@@ -47,9 +46,14 @@ dependencies = [
   "h5py",
   "imageio",
   # Conditional:
+  "scipy-stubs>=1.18.0; python_version>='3.12'",
   "cantera>=3.2.0; python_version>='3.14'",
   "numba>=0.63.0rc1; python_version>='3.14'",
 ]
+
+[tool.pyrefly.errors]
+redundant-condition = "error"
+redundant-cast = "warn"
 
 [project.urls]
 Homepage = "https://github.com/IhmeGroup/StanShock"
@@ -121,14 +125,14 @@ report.exclude_also = [
 
 [tool.mypy]
 files = ["src", "tests"]
-python_version = "3.10"
+python_version = "3.12"
 warn_unused_configs = true
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
-mypy_path = ["src", "stubs", "tests"]
+mypy_path = ["src", "tests"]
 
 [[tool.mypy.overrides]]
 module = "stanshock.*"
@@ -200,4 +204,20 @@ messages_control.disable = [
   "missing-module-docstring",
   "missing-function-docstring",
   "wrong-import-position",
+]
+
+[tool.pyrefly]
+project-includes = [
+    "src",
+    "tests",
+]
+search-path = [
+    "src",
+    "tests",
+]
+python-version = "3.12.0"
+preset = "legacy"
+ignore-missing-imports = [
+    "numba.*",
+    "h5py.*",
 ]

--- a/src/stanshock/models/jicf/generate.py
+++ b/src/stanshock/models/jicf/generate.py
@@ -8,7 +8,8 @@ import cantera as ct
 import h5py
 import numpy as np
 from joblib import Parallel, delayed
-from scipy import integrate, interpolate, special, stats
+from scipy import integrate, special, stats
+from scipy.interpolate import RegularGridInterpolator, make_interp_spline
 from tqdm import tqdm
 from tqdm_joblib import tqdm_joblib
 
@@ -37,11 +38,11 @@ class JICModel:
         rho: float,
         u: float,
         T: float,
-        alpha: float,
         geometry: Box,
         physics: FPVTable,
         datadir: Path | str = "./data",
         theta_inj: float = 0.0,
+        alpha: float = 1e6,
         model_file: str = "jicf_model.h5",
         x_profile: Array | None = None,
     ) -> None:
@@ -112,7 +113,7 @@ class JICModel:
         self.h = float(self.geometry.h(0.0, np.array(self.x_inj)))
         self.n_inj = n_inj
         self.d_inj = d_inj
-        self.theta_inj = theta_inj if theta_inj is not None else 0.0
+        self.theta_inj = theta_inj
 
         self.rho_inj = rho_inj
         self.u_inj = u_inj
@@ -120,7 +121,7 @@ class JICModel:
 
         self.rho = rho
 
-        self.alpha = alpha if alpha is not None else 1e6
+        self.alpha = alpha
         self.datadir = Path(datadir)
         self.datadir.mkdir(exist_ok=True)
         self.model_file = self.datadir / model_file
@@ -171,12 +172,8 @@ class JICModel:
         self.p_inj_unique = self.p_inj[self.mdot_inj_unique_idx]
 
         # Mass flow rate and equivalence ratio schedules
-        self.mdot_f_interp = interpolate.interp1d(
-            self.t_inj, self.mdot_inj, bounds_error=False, fill_value=0.0
-        )
-        self.phi_f_interp = interpolate.interp1d(
-            self.t_inj, self.phi_inj, bounds_error=False, fill_value=0.0
-        )
+        self.mdot_f_interp = make_interp_spline(self.t_inj, self.mdot_inj, k=1)
+        self.phi_f_interp = make_interp_spline(self.t_inj, self.phi_inj, k=1)
 
         # Set up the analytic JICF model
         self.analytic = AnalyticJICF(
@@ -221,13 +218,13 @@ class JICModel:
         # simulation mesh decouples the profiles from the simulation grid, so the
         # model does not need to be regenerated when the mesh changes. Out-of-range
         # query points (e.g. ghost cells) are linearly extrapolated.
-        self.Z_avg_profile_interp = interpolate.RegularGridInterpolator(
+        self.Z_avg_profile_interp = RegularGridInterpolator(
             (self.mdot_inj_unique, self.x_profile),
             self.Z_avg_profile,
             bounds_error=False,
             fill_value=None,
         )
-        self.Z_var_profile_interp = interpolate.RegularGridInterpolator(
+        self.Z_var_profile_interp = RegularGridInterpolator(
             (self.mdot_inj_unique, self.x_profile),
             self.Z_var_profile,
             bounds_error=False,
@@ -242,7 +239,7 @@ class JICModel:
                 self.Lbar_vec = group["Lbar"][:]
                 self.logsigma2_vec = group["logsigma2"][:]
                 self.omega_C_int = group["omega_C_int"][:]
-            self.omega_C_int_interp = interpolate.RegularGridInterpolator(
+            self.omega_C_int_interp = RegularGridInterpolator(
                 (self.Zbar_vec, self.Lbar_vec, self.logsigma2_vec), self.omega_C_int
             )
         else:
@@ -264,7 +261,14 @@ class JICModel:
                     del grp[name]
                 grp[name] = array
 
-    def __stretched_grid(self, x_start, x_end, dx, growth_rate, target_x):
+    def __stretched_grid(
+        self,
+        x_start: float,
+        x_end: float,
+        dx: float,
+        growth_rate: float,
+        target_x: float,
+    ) -> Array:
         x_grid = [x_start, x_end]
         for direction in [-1, 1]:
             x, spacing = target_x, dx
@@ -274,7 +278,7 @@ class JICModel:
                 spacing *= growth_rate
         return np.sort(np.unique(x_grid))
 
-    def calc_Z_3D_interp(self, write=False):
+    def calc_Z_3D_interp(self, write: bool = False) -> None:
         print("Computing Z 3D array...")
         dx = 5.0e-4
         Ny = int(np.ceil(self.h / dx))
@@ -312,53 +316,54 @@ class JICModel:
     def _build_Z_3D_interp(self) -> None:
         self.Z_3D_interp = []
         for i_m in range(len(self.mdot_inj_unique)):
-            interp = interpolate.RegularGridInterpolator(
+            interp = RegularGridInterpolator(
                 (self.x_3D_data, self.y_3D_data, self.z_3D_data),
                 self.Z_3D_data[i_m],
                 method="cubic",
             )
             self.Z_3D_interp.append(interp)
 
-    def eval_Z_3D_interp(self, x, y, z):
+    def eval_Z_3D_interp(self, x: Array, y: Array, z: Array) -> Array:
         Z_arr = np.zeros_like(self.mdot_inj_unique)
         for i_m in range(len(self.mdot_inj_unique)):
             Z_arr[i_m] = self.Z_3D_interp[i_m]((x, y, z))
         return Z_arr
 
-    def Z_avg_var(self, x):
-        Z_avg = np.zeros_like(self.mdot_inj_unique)
-        Z_var = np.zeros_like(self.mdot_inj_unique)
-        x_local = x - self.x_inj
-        for i_m in range(len(self.mdot_inj_unique)):
-            if np.isnan(self.rho_inj_unique[i_m]):
+    def Z_avg_var(self, x: Array) -> tuple[Array, Array]:
+        Z_avg = np.zeros_like(self.mdot_inj)
+        Z_var = np.zeros_like(self.mdot_inj)
+        for i_m in range(len(self.mdot_inj)):
+            if np.isnan(self.rho_inj[i_m]):
                 Z_avg[i_m] = 0.0
                 Z_var[i_m] = 0.0
                 continue
 
-            def func(z, y, i_m=i_m):
-                return self.analytic.Z_3D(x_local, y, z)[i_m]
+            def mu_Z(z: Array, y: Array, i_m: int = i_m) -> Array:
+                return self.analytic.Z_3D(x, y, z)[i_m]
 
             Z_avg[i_m] = (
                 2.0
                 * integrate.dblquad(
-                    func, 0, self.h, lambda y: 0 * y, lambda y: self.w / 2 + 0 * y
+                    mu_Z, 0, self.h, lambda y: 0 * y, lambda y: self.w / 2 + 0 * y
                 )[0]
                 / (self.w * self.h)
             )
 
-            def func(z, y, i_m=i_m):
-                return (self.analytic.Z_3D(x_local, y, z)[i_m] - Z_avg[i_m]) ** 2
+            def sigma_Z(
+                z: Array, y: Array, i_m: int = i_m, Z_avg: Array = Z_avg
+            ) -> Array:
+                return (self.analytic.Z_3D(x, y, z)[i_m] - Z_avg[i_m]) ** 2
 
             Z_var[i_m] = (
                 2.0
                 * integrate.dblquad(
-                    func, 0, self.h, lambda y: 0 * y, lambda y: self.w / 2 + 0 * y
+                    sigma_Z, 0, self.h, lambda y: 0 * y, lambda y: self.w / 2 + 0 * y
                 )[0]
                 / (self.w * self.h)
             )
         return Z_avg, Z_var
 
-    def Z_avg_var_adjusted(self, x):
+    def Z_avg_var_adjusted(self, x: Array) -> tuple[Array, Array]:
         Z_avg = np.zeros_like(self.mdot_inj_unique)
         Z_var = np.zeros_like(self.mdot_inj_unique)
         for i_m in range(len(self.mdot_inj_unique)):
@@ -368,31 +373,33 @@ class JICModel:
                 continue
 
             # func = lambda z, y: self.Z_3D_adjusted(x, y, z)[i_m]
-            def func(z, y, i_m=i_m):
+            def mu_Z(z: Array, y: Array, i_m: int = i_m) -> Array:
                 return self.Z_3D_interp[i_m]((x, y, z))
 
             Z_avg[i_m] = (
                 2.0
                 * integrate.dblquad(
-                    func, 0, self.h, lambda y: 0 * y, lambda y: self.w / 2 + 0 * y
+                    mu_Z, 0, self.h, lambda y: 0 * y, lambda y: self.w / 2 + 0 * y
                 )[0]
                 / (self.w * self.h)
             )
 
             # func = lambda z, y: (self.Z_3D_adjusted(x, y, z)[i_m] - Z_avg[i_m])**2
-            def func(z, y, i_m=i_m):
+            def sigma_Z(
+                z: Array, y: Array, i_m: int = i_m, Z_avg: Array = Z_avg
+            ) -> Array:
                 return (self.Z_3D_interp[i_m]((x, y, z)) - Z_avg[i_m]) ** 2
 
             Z_var[i_m] = (
                 2.0
                 * integrate.dblquad(
-                    func, 0, self.h, lambda y: 0 * y, lambda y: self.w / 2 + 0 * y
+                    sigma_Z, 0, self.h, lambda y: 0 * y, lambda y: self.w / 2 + 0 * y
                 )[0]
                 / (self.w * self.h)
             )
         return Z_avg, Z_var
 
-    def calc_Z_avg_var_profiles(self, write=False):
+    def calc_Z_avg_var_profiles(self, write: bool = False) -> None:
         print("Computing Z average and variance profiles...")
         # Record the mesh the profiles are generated on so the interpolators can
         # be rebuilt independently of the simulation mesh. Use the caller-supplied
@@ -424,34 +431,34 @@ class JICModel:
                 },
             )
 
-    def estimate_p_Z(self, x, Z):
+    def estimate_p_Z(self, x: Array, Z: Array) -> Array:
         """
         This method estimates the PDF of the mixture fraction at a given point
         using a Beta distribution.
-        x: float
+        x: Array
             The query x-coordinate
-        Z: float
+        Z: Array
             The query mixture fraction
         """
         Z_avg, Z_var = self.Z_avg_var_adjusted(x)
-        if Z_avg == 0.0:
-            return 0.0
+        if np.all(Z_avg == 0.0):
+            return Z_avg
         a = ((Z_avg * (1 - Z_avg) / Z_var) - 1) * Z_avg
         b = a * (1 - Z_avg) / Z_avg
-        return stats.beta.pdf(Z, a, b)
+        return np.asarray(stats.beta.pdf(Z, a, b))
 
     @staticmethod
     def _compute_omega_C_int(
-        i_Zbar,
-        i_Lbar,
-        i_S,
-        Zbar_vec,
-        Lbar_vec,
-        logsigma2_vec,
-        uv_vec,
-        W_vec,
-        omega_C_interp,
-    ):
+        i_Zbar: int,
+        i_Lbar: int,
+        i_S: int,
+        Zbar_vec: Array,
+        Lbar_vec: Array,
+        logsigma2_vec: Array,
+        uv_vec: Array,
+        W_vec: Array,
+        omega_C_interp: RegularGridInterpolator[np.float64],
+    ) -> tuple[int, int, int, float]:
         Zbar = Zbar_vec[i_Zbar]
         Lbar = Lbar_vec[i_Lbar]
         logsigma2 = logsigma2_vec[i_S]
@@ -459,8 +466,7 @@ class JICModel:
 
         eps = 1.0e-6
         if (Zbar < eps) or (Zbar > 1 - eps) or (Lbar < eps) or (Lbar > 1 - eps):
-            result = omega_C_interp((Zbar, Lbar))
-            return (i_Zbar, i_Lbar, i_S, result)
+            return (i_Zbar, i_Lbar, i_S, float(omega_C_interp((Zbar, Lbar))))
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -482,11 +488,11 @@ class JICModel:
             integrand = omega_C_interp((Z_int_mesh, L_int_mesh))
 
             # Perform the integration
-            result = np.sum(integrand * W_mesh)
+            result = float(np.sum(integrand * W_mesh))
 
         return (i_Zbar, i_Lbar, i_S, result)
 
-    def calc_chemical_sources(self, write=False):
+    def calc_chemical_sources(self, write: bool = False) -> None:
         """
         This method precomputes the chemical source terms as a function of x, mdot_f, and L.
         """
@@ -499,7 +505,7 @@ class JICModel:
         omega_C = self.physics.lookup_direct(
             "SRC_PROG", Z_sample_mesh, 0.0, L_sample_mesh
         )
-        omega_C_interp = interpolate.RegularGridInterpolator(
+        omega_C_interp = RegularGridInterpolator(
             (Z_sample, L_sample), omega_C, bounds_error=False, fill_value=0.0
         )
 
@@ -553,6 +559,6 @@ class JICModel:
             )
 
         # Build 3D table interpolator
-        self.omega_C_int_interp = interpolate.RegularGridInterpolator(
+        self.omega_C_int_interp = RegularGridInterpolator(
             (self.Zbar_vec, self.Lbar_vec, self.logsigma2_vec), self.omega_C_int
         )

--- a/src/stanshock/models/jicf/generate.py
+++ b/src/stanshock/models/jicf/generate.py
@@ -12,7 +12,6 @@ from scipy import special, stats
 from scipy.integrate import cubature
 from scipy.interpolate import RegularGridInterpolator, make_interp_spline
 from tqdm import tqdm
-from tqdm_joblib import tqdm_joblib
 
 from stanshock.models.jicf.profile import AnalyticJICF
 from stanshock.physics.flamelet import FPVTable
@@ -150,7 +149,7 @@ class JICModel:
         self.t_inj = t_inj
         self.phi_inj = phi_inj
         sol = ct.SolutionArray(gas, shape=self.t_inj.shape)
-        sol.TDX = self.T_inj, self.rho_inj, self.fuel_def
+        sol.TDX = self.T_inj, self.rho_inj, self.fuel_def  # type: ignore[assignment]
         self.p_inj = sol.P
         self.E_inj = sol.int_energy_mass + 0.5 * self.u_inj**2
         self.W_inj = sol.mean_molecular_weight
@@ -193,12 +192,13 @@ class JICModel:
 
         # Precompute a 3D array of the mixture fraction and generate an interpolator
         if self._h5_has("Z_3D/Z"):
-            with h5py.File(self.model_file, "r") as f:
+            with h5py.File(str(self.model_file), "r") as f:
                 group = f["Z_3D"]
-                self.x_3D_data = group["x"][:]
-                self.y_3D_data = group["y"][:]
-                self.z_3D_data = group["z"][:]
-                self.Z_3D_data = group["Z"][:]
+                assert isinstance(group, h5py.Group)
+                self.x_3D_data = self._h5_getarray(group, "x")
+                self.y_3D_data = self._h5_getarray(group, "y")
+                self.z_3D_data = self._h5_getarray(group, "z")
+                self.Z_3D_data = self._h5_getarray(group, "Z")
             self._build_Z_3D_interp()
         else:
             self.calc_Z_3D_interp(write=True)
@@ -206,11 +206,12 @@ class JICModel:
         # Precompute the axial mean and variance profiles of Z, along with the
         # mesh they were generated on.
         if self._h5_has("Z_profiles/Z_avg"):
-            with h5py.File(self.model_file, "r") as f:
+            with h5py.File(str(self.model_file), "r") as f:
                 group = f["Z_profiles"]
-                self.x_profile = group["x"][:]
-                self.Z_avg_profile = group["Z_avg"][:]
-                self.Z_var_profile = group["Z_var"][:]
+                assert isinstance(group, h5py.Group)
+                self.x_profile = self._h5_getarray(group, "x")
+                self.Z_avg_profile = self._h5_getarray(group, "Z_avg")
+                self.Z_var_profile = self._h5_getarray(group, "Z_var")
         else:
             self.calc_Z_avg_var_profiles(write=True)
 
@@ -220,13 +221,13 @@ class JICModel:
         # model does not need to be regenerated when the mesh changes. Out-of-range
         # query points (e.g. ghost cells) are linearly extrapolated.
         self.Z_avg_profile_interp = RegularGridInterpolator(
-            (self.mdot_inj_unique, self.x_profile),
+            (self.x_profile, self.mdot_inj_unique),
             self.Z_avg_profile,
             bounds_error=False,
             fill_value=None,
         )
         self.Z_var_profile_interp = RegularGridInterpolator(
-            (self.mdot_inj_unique, self.x_profile),
+            (self.x_profile, self.mdot_inj_unique),
             self.Z_var_profile,
             bounds_error=False,
             fill_value=None,
@@ -234,12 +235,13 @@ class JICModel:
 
         # Precompute and tabulate chemical source terms
         if self._h5_has("chemical_sources/omega_C_int"):
-            with h5py.File(self.model_file, "r") as f:
+            with h5py.File(str(self.model_file), "r") as f:
                 group = f["chemical_sources"]
-                self.Zbar_vec = group["Zbar"][:]
-                self.Lbar_vec = group["Lbar"][:]
-                self.logsigma2_vec = group["logsigma2"][:]
-                self.omega_C_int = group["omega_C_int"][:]
+                assert isinstance(group, h5py.Group)
+                self.Zbar_vec = self._h5_getarray(group, "Zbar")
+                self.Lbar_vec = self._h5_getarray(group, "Lbar")
+                self.logsigma2_vec = self._h5_getarray(group, "logsigma2")
+                self.omega_C_int = self._h5_getarray(group, "omega_C_int")
             self.omega_C_int_interp = RegularGridInterpolator(
                 (self.Zbar_vec, self.Lbar_vec, self.logsigma2_vec), self.omega_C_int
             )
@@ -250,12 +252,18 @@ class JICModel:
         """Return True if the model file exists and contains the given dataset."""
         if not self.model_file.exists():
             return False
-        with h5py.File(self.model_file, "r") as f:
+        with h5py.File(str(self.model_file), "r") as f:
             return key in f
+
+    def _h5_getarray(self, h: h5py.File | h5py.Group, key: str) -> Array:
+        """Load array data from h5 file in a way that respects type checking."""
+        data_handle = h[key]
+        assert isinstance(data_handle, h5py.Dataset)
+        return np.asarray(data_handle[...], dtype=float)
 
     def _h5_write(self, group: str, data: dict[str, Array]) -> None:
         """Write (overwriting if present) a group of named arrays to the model file."""
-        with h5py.File(self.model_file, "a") as f:
+        with h5py.File(str(self.model_file), "a") as f:
             grp = f.require_group(group)
             for name, array in data.items():
                 if name in grp:
@@ -313,7 +321,7 @@ class JICModel:
         self._build_Z_3D_interp()
 
     def _build_Z_3D_interp(self) -> None:
-        self.Z_3D_interp = []
+        self.Z_3D_interp: list[RegularGridInterpolator[np.float64]] = []
         for i_m in range(len(self.mdot_inj_unique)):
             interp = RegularGridInterpolator(
                 (self.x_3D_data, self.y_3D_data, self.z_3D_data),
@@ -352,10 +360,11 @@ class JICModel:
             args=(x,),
             # workers=-1,
         )
-        Z_avg = (
+        Z_avg: Array = np.asarray(
             2.0
             * np.reshape(res.estimate, (*x.shape, *self.mdot_inj_unique.shape))
-            / self.A
+            / self.A,
+            dtype=float,
         )
 
         res = cubature(
@@ -365,10 +374,11 @@ class JICModel:
             args=(x, Z_avg),
             # workers=-1,
         )
-        Z_var = (
+        Z_var: Array = np.asarray(
             2.0
             * np.reshape(res.estimate, (*x.shape, *self.mdot_inj_unique.shape))
-            / self.A
+            / self.A,
+            dtype=float,
         )
 
         return Z_avg, Z_var
@@ -558,11 +568,10 @@ class JICModel:
         ]
 
         # Parallel version
-        with tqdm_joblib(tqdm(desc="Assembling table", total=len(tasks))):
-            results = Parallel(n_jobs=-1)(
-                delayed(compute_func)(i_Zbar, i_Lbar, i_S)
-                for i_Zbar, i_Lbar, i_S in tasks
-            )
+        gen = Parallel(n_jobs=-1, return_as="generator")(
+            delayed(compute_func)(i_Zbar, i_Lbar, i_S) for i_Zbar, i_Lbar, i_S in tasks
+        )
+        results = list(tqdm(gen, total=len(tasks)))
 
         for i_Zbar, i_Lbar, i_S, value in results:
             self.omega_C_int[i_Zbar, i_Lbar, i_S] = value

--- a/src/stanshock/models/jicf/generate.py
+++ b/src/stanshock/models/jicf/generate.py
@@ -8,7 +8,8 @@ import cantera as ct
 import h5py
 import numpy as np
 from joblib import Parallel, delayed
-from scipy import integrate, special, stats
+from scipy import special, stats
+from scipy.integrate import cubature
 from scipy.interpolate import RegularGridInterpolator, make_interp_spline
 from tqdm import tqdm
 from tqdm_joblib import tqdm_joblib
@@ -288,17 +289,15 @@ class JICModel:
         self.x_3D_data = self.__stretched_grid(
             self.xc[0], self.xc[-1], dx, 1.1, self.x_inj
         )
-        Nx = len(self.x_3D_data)
-        self.Z_3D_data = np.zeros([len(self.mdot_inj_unique), Nx, Ny, Nz])
-        for i in tqdm(range(Nx)):
-            for j in range(Ny):
-                for k in range(Nz):
-                    self.Z_3D_data[:, i, j, k] = self.analytic.Z_3D_adjusted(
-                        self.x_3D_data[i] - self.x_inj,
-                        self.y_3D_data[j],
-                        self.z_3D_data[k],
-                    )
-        self.Z_3D_data[np.isnan(self.rho_inj_unique)] = 0.0
+        self.analytic.i_m = slice(None)
+        self.Z_3D_data = self.analytic.Z_3D_adjusted(
+            self.x_3D_data[:, None, None] - self.x_inj,
+            self.y_3D_data[None, :, None],
+            self.z_3D_data[None, None, :],
+        )
+        self.Z_3D_data[..., np.isnan(self.rho_inj_unique)] = 0.0
+        self.Z_3D_data[..., self.u_inj_unique == 0.0] = 0.0
+        self.Z_3D_data[np.isnan(self.Z_3D_data)] = 0.0
 
         if write:
             self._h5_write(
@@ -318,85 +317,106 @@ class JICModel:
         for i_m in range(len(self.mdot_inj_unique)):
             interp = RegularGridInterpolator(
                 (self.x_3D_data, self.y_3D_data, self.z_3D_data),
-                self.Z_3D_data[i_m],
+                self.Z_3D_data[..., i_m],
                 method="cubic",
             )
             self.Z_3D_interp.append(interp)
 
-    def eval_Z_3D_interp(self, x: Array, y: Array, z: Array) -> Array:
-        Z_arr = np.zeros_like(self.mdot_inj_unique)
-        for i_m in range(len(self.mdot_inj_unique)):
-            Z_arr[i_m] = self.Z_3D_interp[i_m]((x, y, z))
-        return Z_arr
+    def _mu_Z(self, yz: Array, x: Array) -> Array:
+        """Vectorized evaluation of mixture fraction over set of y + z points.
+
+        Returns flattened Z array for all [nyz * nx * nm] points.
+        """
+        y: Array
+        z: Array
+        y, z = yz[:, 0, None], yz[:, 1, None]
+        return np.reshape(self.analytic.Z_3D_adjusted(x, y, z), (y.shape[0], -1))
+
+    def _sigma_Z(self, yz: Array, x: Array, Z_avg: Array) -> Array:
+        """Vectorized evaluation of mixture fraction variance over set of y + z points.
+
+        Returns flattened Z variance array for all [nyz * nx * nm] points.
+        """
+        Z = self._mu_Z(yz, x)
+        return (Z - np.reshape(Z_avg, (1, -1))) ** 2
 
     def Z_avg_var(self, x: Array) -> tuple[Array, Array]:
-        Z_avg = np.zeros_like(self.mdot_inj)
-        Z_var = np.zeros_like(self.mdot_inj)
-        for i_m in range(len(self.mdot_inj)):
-            if np.isnan(self.rho_inj[i_m]):
-                Z_avg[i_m] = 0.0
-                Z_var[i_m] = 0.0
-                continue
+        """Compute the mean and variance of the mixture fraction profiles at given axial locations.
 
-            def mu_Z(z: Array, y: Array, i_m: int = i_m) -> Array:
-                return self.analytic.Z_3D(x, y, z)[i_m]
+        Returns axial mean and variance profiles for all mass flow rates.
+        """
+        res = cubature(
+            self._mu_Z,
+            a=[0.0, 0.0],
+            b=[self.h, 0.5 * self.w],
+            args=(x,),
+            # workers=-1,
+        )
+        Z_avg = (
+            2.0
+            * np.reshape(res.estimate, (*x.shape, *self.mdot_inj_unique.shape))
+            / self.A
+        )
 
-            Z_avg[i_m] = (
-                2.0
-                * integrate.dblquad(
-                    mu_Z, 0, self.h, lambda y: 0 * y, lambda y: self.w / 2 + 0 * y
-                )[0]
-                / (self.w * self.h)
-            )
+        res = cubature(
+            self._sigma_Z,
+            a=[0.0, 0.0],
+            b=[self.h, 0.5 * self.w],
+            args=(x, Z_avg),
+            # workers=-1,
+        )
+        Z_var = (
+            2.0
+            * np.reshape(res.estimate, (*x.shape, *self.mdot_inj_unique.shape))
+            / self.A
+        )
 
-            def sigma_Z(
-                z: Array, y: Array, i_m: int = i_m, Z_avg: Array = Z_avg
-            ) -> Array:
-                return (self.analytic.Z_3D(x, y, z)[i_m] - Z_avg[i_m]) ** 2
-
-            Z_var[i_m] = (
-                2.0
-                * integrate.dblquad(
-                    sigma_Z, 0, self.h, lambda y: 0 * y, lambda y: self.w / 2 + 0 * y
-                )[0]
-                / (self.w * self.h)
-            )
         return Z_avg, Z_var
 
+    def _mu_Z_adjusted(self, yz: Array, x: Array, i_m: int) -> Array:
+        """Vectorized evaluation of mixture fraction over set of y + z points.
+
+        Returns flattened Z array for all [nyz * nx * nm] points.
+        """
+        y: Array
+        z: Array
+        y, z = yz[:, 0, None], yz[:, 1, None]
+        return np.reshape(self.Z_3D_interp[i_m]((x, y, z)), (y.shape[0], -1))
+
+    def _sigma_Z_adjusted(self, yz: Array, x: Array, Z_avg: Array, i_m: int) -> Array:
+        """Vectorized evaluation of mixture fraction variance over set of y + z points.
+
+        Returns flattened Z variance array for all [nyz * nx * nm] points.
+        """
+        Z = self._mu_Z_adjusted(yz, x, i_m)
+        return (Z - np.reshape(Z_avg, (1, -1))) ** 2
+
     def Z_avg_var_adjusted(self, x: Array) -> tuple[Array, Array]:
-        Z_avg = np.zeros_like(self.mdot_inj_unique)
-        Z_var = np.zeros_like(self.mdot_inj_unique)
+        """Compute the mean and variance of the mixture fraction profiles at given axial locations.
+
+        Returns axial mean and variance profiles for all mass flow rates.
+        """
+        Z_avg = np.zeros((*x.shape, len(self.mdot_inj_unique)))
+        Z_var = np.zeros((*x.shape, len(self.mdot_inj_unique)))
         for i_m in range(len(self.mdot_inj_unique)):
-            if np.isnan(self.rho_inj_unique[i_m]):
-                Z_avg[i_m] = 0.0
-                Z_var[i_m] = 0.0
-                continue
-
-            # func = lambda z, y: self.Z_3D_adjusted(x, y, z)[i_m]
-            def mu_Z(z: Array, y: Array, i_m: int = i_m) -> Array:
-                return self.Z_3D_interp[i_m]((x, y, z))
-
-            Z_avg[i_m] = (
-                2.0
-                * integrate.dblquad(
-                    mu_Z, 0, self.h, lambda y: 0 * y, lambda y: self.w / 2 + 0 * y
-                )[0]
-                / (self.w * self.h)
+            res = cubature(
+                self._mu_Z_adjusted,
+                a=[0.0, 0.0],
+                b=[self.h, 0.5 * self.w],
+                args=(x, i_m),
+                # workers=-1,
             )
+            Z_avg[..., i_m] = 2.0 * res.estimate / self.A
 
-            # func = lambda z, y: (self.Z_3D_adjusted(x, y, z)[i_m] - Z_avg[i_m])**2
-            def sigma_Z(
-                z: Array, y: Array, i_m: int = i_m, Z_avg: Array = Z_avg
-            ) -> Array:
-                return (self.Z_3D_interp[i_m]((x, y, z)) - Z_avg[i_m]) ** 2
-
-            Z_var[i_m] = (
-                2.0
-                * integrate.dblquad(
-                    sigma_Z, 0, self.h, lambda y: 0 * y, lambda y: self.w / 2 + 0 * y
-                )[0]
-                / (self.w * self.h)
+            res = cubature(
+                self._sigma_Z_adjusted,
+                a=[0.0, 0.0],
+                b=[self.h, 0.5 * self.w],
+                args=(x, Z_avg[..., i_m], i_m),
+                # workers=-1,
             )
+            Z_var[..., i_m] = 2.0 * res.estimate / self.A
+
         return Z_avg, Z_var
 
     def calc_Z_avg_var_profiles(self, write: bool = False) -> None:
@@ -408,18 +428,19 @@ class JICModel:
         self.x_profile = (
             self.x_3D_data if self._x_profile_input is None else self._x_profile_input
         )
-        n_mdot = len(self.mdot_inj_unique)
-        self.Z_avg_profile = np.zeros([n_mdot, len(self.x_profile)])
-        self.Z_var_profile = np.zeros([n_mdot, len(self.x_profile)])
-        for i in tqdm(range(len(self.x_profile))):
-            if self.x_profile[i] > self.x_noz:
-                # Freeze the profiles in the nozzle
-                self.Z_avg_profile[:, i] = self.Z_avg_profile[:, i - 1]
-                self.Z_var_profile[:, i] = self.Z_var_profile[:, i - 1]
-            else:
-                self.Z_avg_profile[:, i], self.Z_var_profile[:, i] = (
-                    self.Z_avg_var_adjusted(self.x_profile[i])
-                )
+
+        # Compute profiles between injector and nozzle
+        idx = np.logical_and(self.x_profile > self.x_inj, self.x_profile < self.x_noz)
+        self.Z_avg_profile[:, idx], self.Z_var_profile[:, idx] = (
+            # self.Z_avg_var_adjusted(self.xc[idx])
+            self.Z_avg_var(self.x_profile[idx])
+        )
+
+        # Freeze profiles downstream of the nozzle
+        ifreeze = len(idx) - 1 - np.argmax(idx[::-1])
+        idx = self.x_profile >= self.x_noz
+        self.Z_avg_profile[:, idx] = self.Z_avg_profile[:, ifreeze]
+        self.Z_var_profile[:, idx] = self.Z_var_profile[:, ifreeze]
 
         if write:
             self._h5_write(

--- a/src/stanshock/models/jicf/generate.py
+++ b/src/stanshock/models/jicf/generate.py
@@ -170,6 +170,7 @@ class JICModel:
         self.rho_inj_unique = self.rho_inj[self.mdot_inj_unique_idx]
         self.u_inj_unique = self.u_inj[self.mdot_inj_unique_idx]
         self.p_inj_unique = self.p_inj[self.mdot_inj_unique_idx]
+        self.nJ = len(self.mdot_inj_unique)
 
         # Mass flow rate and equivalence ratio schedules
         self.mdot_f_interp = make_interp_spline(self.t_inj, self.mdot_inj, k=1)
@@ -322,7 +323,7 @@ class JICModel:
 
     def _build_Z_3D_interp(self) -> None:
         self.Z_3D_interp: list[RegularGridInterpolator[np.float64]] = []
-        for i_m in range(len(self.mdot_inj_unique)):
+        for i_m in range(self.nJ):
             interp = RegularGridInterpolator(
                 (self.x_3D_data, self.y_3D_data, self.z_3D_data),
                 self.Z_3D_data[..., i_m],
@@ -353,33 +354,43 @@ class JICModel:
 
         Returns axial mean and variance profiles for all mass flow rates.
         """
-        res = cubature(
-            self._mu_Z,
-            a=[0.0, 0.0],
-            b=[self.h, 0.5 * self.w],
-            args=(x,),
-            # workers=-1,
-        )
-        Z_avg: Array = np.asarray(
-            2.0
-            * np.reshape(res.estimate, (*x.shape, *self.mdot_inj_unique.shape))
-            / self.A,
-            dtype=float,
-        )
+        # res = cubature(
+        #     self._mu_Z,
+        #     a=[0.0, 0.0],
+        #     b=[self.h, 0.5 * self.w],
+        #     args=(x,),
+        #     # workers=-1,
+        # )
+        # Z_avg: Array = np.asarray(
+        #     2.0
+        #     * np.reshape(res.estimate, (*x.shape, *self.mdot_inj_unique.shape))
+        #     / self.A,
+        #     dtype=float,
+        # )
+        #
+        # res = cubature(
+        #     self._sigma_Z,
+        #     a=[0.0, 0.0],
+        #     b=[self.h, 0.5 * self.w],
+        #     args=(x, Z_avg),
+        #     # workers=-1,
+        # )
+        # Z_var: Array = np.asarray(
+        #     2.0
+        #     * np.reshape(res.estimate, (*x.shape, *self.mdot_inj_unique.shape))
+        #     / self.A,
+        #     dtype=float,
+        # )
 
-        res = cubature(
-            self._sigma_Z,
-            a=[0.0, 0.0],
-            b=[self.h, 0.5 * self.w],
-            args=(x, Z_avg),
-            # workers=-1,
-        )
-        Z_var: Array = np.asarray(
-            2.0
-            * np.reshape(res.estimate, (*x.shape, *self.mdot_inj_unique.shape))
-            / self.A,
-            dtype=float,
-        )
+        dx = 5.0e-4
+        Ny = int(np.ceil(self.h / dx))
+        Nz = int(np.ceil(self.w / dx))
+        y = np.linspace(0.0, self.h, Ny)[None, :, None]
+        z = np.linspace(0.0, 0.5 * self.w, Nz)[None, None, :]
+        self.analytic.i_m = slice(None)
+        Z = self.analytic.Z_3D_adjusted(x[:, None, None] - self.x_inj, y, z)
+        Z_avg = np.mean(Z, axis=(1, 2))
+        Z_var = np.mean((Z - Z_avg[:, None, None, :]) ** 2, axis=(1, 2))
 
         return Z_avg, Z_var
 
@@ -406,9 +417,9 @@ class JICModel:
 
         Returns axial mean and variance profiles for all mass flow rates.
         """
-        Z_avg = np.zeros((*x.shape, len(self.mdot_inj_unique)))
-        Z_var = np.zeros((*x.shape, len(self.mdot_inj_unique)))
-        for i_m in range(len(self.mdot_inj_unique)):
+        Z_avg = np.zeros((*x.shape, self.nJ))
+        Z_var = np.zeros((*x.shape, self.nJ))
+        for i_m in range(self.nJ):
             res = cubature(
                 self._mu_Z_adjusted,
                 a=[0.0, 0.0],
@@ -438,19 +449,21 @@ class JICModel:
         self.x_profile = (
             self.x_3D_data if self._x_profile_input is None else self._x_profile_input
         )
+        self.Z_avg_profile = np.zeros((self.x_profile.shape[0], self.nJ))
+        self.Z_var_profile = np.zeros((self.x_profile.shape[0], self.nJ))
 
         # Compute profiles between injector and nozzle
         idx = np.logical_and(self.x_profile > self.x_inj, self.x_profile < self.x_noz)
-        self.Z_avg_profile[:, idx], self.Z_var_profile[:, idx] = (
-            # self.Z_avg_var_adjusted(self.xc[idx])
+        self.Z_avg_profile[idx, :], self.Z_var_profile[idx, :] = (
+            # self.Z_avg_var_adjusted(self.x_profile[idx])
             self.Z_avg_var(self.x_profile[idx])
         )
 
         # Freeze profiles downstream of the nozzle
         ifreeze = len(idx) - 1 - np.argmax(idx[::-1])
         idx = self.x_profile >= self.x_noz
-        self.Z_avg_profile[:, idx] = self.Z_avg_profile[:, ifreeze]
-        self.Z_var_profile[:, idx] = self.Z_var_profile[:, ifreeze]
+        self.Z_avg_profile[idx, :] = self.Z_avg_profile[ifreeze, :]
+        self.Z_var_profile[idx, :] = self.Z_var_profile[ifreeze, :]
 
         if write:
             self._h5_write(

--- a/src/stanshock/models/jicf/profile.py
+++ b/src/stanshock/models/jicf/profile.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import numpy as np
-from scipy import integrate, interpolate, optimize, special
+from scipy import interpolate, special
+from scipy.optimize.elementwise import find_minimum
 from tqdm import tqdm
 
 from stanshock.physics.flamelet import FPVTable
@@ -112,7 +115,7 @@ class AnalyticJICF:
         # Precompute the adjustment factor for the boundary clipping
         self.calc_adjustment_factor()
 
-    def y_cl(self, x_cl: Array | float) -> Array:
+    def y_cl(self, x_cl: Array) -> Array:
         # SUBSONIC VERSION - CHECK THESE FOR CORRECTNESS
         # return self.d_inj * 1.6 * (x_cl / self.d_inj)**(1.0/3.0) * self.r_u**(2.0/3.0) # Torrez 2011 (Same as Margason 1968)
         # return 1.6 * x_cl**(1.0/3.0) * (self.d_inj * self.r_u)**(2.0/3.0) # Margason 1968
@@ -129,7 +132,7 @@ class AnalyticJICF:
         # return self.d_inj * self.J * 1.20 * ((x_cl + self.d_inj/2) / (self.d_inj * self.J))**0.344 # Gruber 1997 Phys. Fluids
         # return self.d_inj * 2.173 / self.J**0.276 * (x_cl / self.d_inj)**0.281 # Rothstein and Wantuck 1992
 
-    def x_cl_from_y_cl(self, y_cl: Array | float) -> Array:
+    def x_cl_from_y_cl(self, y_cl: Array) -> Array:
         # SUBSONIC VERSION - CHECK THESE FOR CORRECTNESS
         # return (y_cl / (self.r_u * self.d_inj * 1.6))**(3.0) * self.r_u * self.d_inj # Hasselbrink and Mungal 2001 Pt. 2
 
@@ -140,7 +143,7 @@ class AnalyticJICF:
         return (y_cl * denom) ** (1.0 / 0.344) * self.d_inj * self.J  # Gruber 1995 JPP
         # return (y_cl / (self.d_inj * self.J * 1.20))**(1.0 / 0.344) * self.d_inj * self.J - self.d_inj/2 # Gruber 1997 Phys. Fluids
 
-    def dy_cl_dx(self, x_cl: Array | float) -> Array:
+    def dy_cl_dx(self, x_cl: Array) -> Array:
         # SUBSONIC VERSION - CHECK THESE FOR CORRECTNESS
         # return (self.r_u * self.d_inj)**(2.0/3.0) * 1.6 * (1.0/3.0) * x_cl**(-2.0/3.0) # Hasselbrink and Mungal 2001 Pt. 2
 
@@ -155,50 +158,43 @@ class AnalyticJICF:
         #         self.d_inj * self.J * 1.20 * ((x_cl + self.d_inj/2) / (self.d_inj * self.J))**(0.344 - 1.0) *
         #         (1.0 / (self.d_inj * self.J))) # Gruber 1997 Phys. Fluids
 
-    def __nearest_on_cl_single(self, x, y, dz, i_m):
+    def nearest_on_cl(
+        self, x: Array, y: Array, dz: Array
+    ) -> tuple[Array, Array, Array]:
         # Define the centerline
         # Note: dz makes no difference in the minimization, but it's more convenient to include it here
         # so that the n2 is correct
-        def n2_func_x_cl(x_cl):
-            return (x - x_cl) ** 2 + (y - self.y_cl(x_cl)[i_m]) ** 2 + dz**2
+        def n2_func_x_cl(x_cl: Array, x: Array, y: Array, dz: Array) -> Array:
+            return (x - x_cl) ** 2 + (y - self.y_cl(x_cl)) ** 2 + dz**2
 
-        def n2_func_y_cl(y_cl):
-            return (x - self.x_cl_from_y_cl(y_cl)[i_m]) ** 2 + (y - y_cl) ** 2 + dz**2
+        def n2_func_y_cl(y_cl: Array, x: Array, y: Array, dz: Array) -> Array:
+            return (x - self.x_cl_from_y_cl(y_cl)) ** 2 + (y - y_cl) ** 2 + dz**2
 
         # Compute the x_cl which minimizes n2
-        x_cl = optimize.fminbound(n2_func_x_cl, self.x[0], self.x[-1], disp=False)
-        y_cl = self.y_cl(x_cl)[i_m]
-        n2 = n2_func_x_cl(x_cl)
+        x_bracket: tuple[float, float, float] = (
+            self.x[0],
+            0.5 * (self.x[0] + self.x[-1]),
+            self.x[-1],
+        )
+        res = find_minimum(n2_func_x_cl, x_bracket, args=(x, y, dz))
+        x_cl = res.x
+        n2 = res.f_x
+        y_cl = self.y_cl(x_cl)
 
-        if self.dy_cl_dx(x_cl)[i_m] > 1:
-            # Compute the y_cl which minimizes n2
-            y_cl = optimize.fminbound(n2_func_y_cl, 0.0, self.h, disp=False)
-            x_cl = self.x_cl_from_y_cl(y_cl)[i_m]
-            n2 = n2_func_y_cl(y_cl)
+        # For points where dy_cl/dx > 1
+        dy_cl_dx = self.dy_cl_dx(x_cl)
+        idx = dy_cl_dx > 1
+
+        # Compute the y_cl which minimizes n2
+        y_bracket: tuple[float, float, float] = (0.0, 0.5 * self.h, self.h)
+        res = find_minimum(n2_func_y_cl, y_bracket, args=(x[idx], y[idx], dz[idx]))
+        y_cl[idx] = res.x
+        n2[idx] = res.f_x
+        x_cl[idx] = self.x_cl_from_y_cl(y_cl[idx])
 
         return x_cl, y_cl, n2
 
-    def nearest_on_cl(self, x, y, dz, i_m):
-        x_match, y_match, dz_match = np.broadcast_arrays(x, y, dz)
-
-        if isinstance(x_match, np.ndarray):
-            x_flat = x_match.flatten()
-            y_flat = y_match.flatten()
-            dz_flat = dz_match.flatten()
-            x_cl = np.zeros_like(x_flat)
-            y_cl = np.zeros_like(x_flat)
-            n2 = np.zeros_like(x_flat)
-            for i in range(len(x_flat)):
-                x_cl[i], y_cl[i], n2[i] = self.__nearest_on_cl_single(
-                    x_flat[i], y_flat[i], dz_flat[i], i_m
-                )
-            x_cl = x_cl.reshape(x_match.shape)
-            y_cl = y_cl.reshape(x_match.shape)
-            n2 = n2.reshape(x_match.shape)
-            return x_cl, y_cl, n2
-        return self.__nearest_on_cl_single(x, y, dz)
-
-    def Z_cl(self, x_cl: Array | float) -> Array:
+    def Z_cl(self, x_cl: Array) -> Array:
         denom = np.divide(
             1.0, self.r_u, out=np.zeros_like(self.r_u), where=self.r_u > 0
         )
@@ -209,9 +205,9 @@ class AnalyticJICF:
         )  # Hasselbrink and Mungal 2001 Pt. 1
         return np.clip(Z, self.Z_gl, 1.0)
 
-    def calc_adjustment_factor(self):
+    def calc_adjustment_factor(self) -> None:
         print("Computing adjustment factor...")
-        self.adjustment_factor_interp = []
+        self.adjustment_factor_interp: list[Callable[[Array], Array]] = []
         y_cl_max = self.y_cl(self.x[-1])
 
         # Create grid along the centerline
@@ -231,12 +227,14 @@ class AnalyticJICF:
 
             # Interpolate over y because the most rapid variation is near the injection point
             self.adjustment_factor_interp.append(
-                interpolate.CubicSpline(y_cl_arr[:, i_m], adjustment_factor_arr, axis=1)
+                interpolate.CubicSpline(
+                    y_cl_arr[..., i_m], adjustment_factor_arr, axis=1
+                )
             )
 
-    def calc_adjustment_factor_xy(self, x_cl, y_cl, i_m):
+    def calc_adjustment_factor_xy(self, x_cl: Array, y_cl: Array, i_m: int) -> Array:
         # Compute the normal to the centerline
-        dy_cl_dx = self.dy_cl_dx(x_cl[:, np.newaxis])[:, i_m]
+        dy_cl_dx = self.dy_cl_dx(x_cl[:, None])[:, i_m]
         ds = np.stack([np.full_like(x_cl, 1.0), dy_cl_dx], axis=0)
         ds /= np.linalg.norm(ds, axis=0)
         dn = np.array([-ds[1], ds[0]])
@@ -249,7 +247,7 @@ class AnalyticJICF:
 
         Z_int_nobound = self.n_inj * self.Z_cl_int[i_m]
 
-        Z_cl = self.Z_cl(x_cl[:, np.newaxis])[:, i_m]
+        Z_cl = self.Z_cl(x_cl[:, None])[:, i_m]
         sigma2 = self.Z_cl_int[i_m] / (2 * np.pi * Z_cl)
         s2s = np.sqrt(2 * sigma2)
 
@@ -266,69 +264,57 @@ class AnalyticJICF:
                 )
             )
 
-        return Z_int_nobound / Z_int_bound
+        return np.asarray(Z_int_nobound / Z_int_bound)
 
-    def get_adjustment_factor(self, x, y):
-        if np.isscalar(x):
-            x_arr = np.array([x])
-            y_arr = np.array([y])
-        else:
-            x_arr = x
-            y_arr = y
-
-        fac = np.zeros([len(x_arr), len(self.mdot_inj)])
+    def get_adjustment_factor(self, x: Array, y: Array) -> Array:
+        fac = np.zeros([*x.shape, len(self.mdot_inj)])
+        _, y_cl, _ = self.nearest_on_cl(x, y, np.zeros_like(x))
         for i_m in range(len(self.mdot_inj)):
-            _, y_cl, _ = self.nearest_on_cl(x_arr, y_arr, np.zeros_like(x_arr), i_m)
-            fac[:, i_m] = self.adjustment_factor_interp[i_m](y_cl)
+            fac[..., i_m] = self.adjustment_factor_interp[i_m](y_cl)
 
-        if np.isscalar(x):
-            return fac[0]
         return fac
 
-    def Z_3D(self, x, y, z):
+    def Z_3D(self, x: Array, y: Array, z: Array) -> Array:
         """
         This method computes the mixture fraction for the Jet-in-Crossflow
         model in 3D for all injectors (summed).
-        x: float
+        x: Array
             The query x-coordinate
-        y: float
+        y: Array
             The query y-coordinate
-        z: float
+        z: Array
             The query z-coordinate
         """
-        Z = 0.0
+        Z: Array = np.zeros_like(x)
         for z_inj in self.z_inj:
-            Z_temp = self.Z_3D_single_inj(x, y, z, z_inj)
-            if isinstance(Z_temp, np.ndarray):
-                Z_temp = Z_temp[0]
-            Z += Z_temp
+            Z = Z + self.Z_3D_single_inj(x, y, z, float(z_inj))
         return Z
 
-    def grad_Z_3D(self, x, y, z):
+    def grad_Z_3D(self, x: Array, y: Array, z: Array) -> Array:
         """
         This method computes the gradient of the mixture fraction for the Jet-in-Crossflow
         model in 3D for all injectors (summed).
-        x: float
+        x: Array
             The query x-coordinate
-        y: float
+        y: Array
             The query y-coordinate
-        z: float
+        z: Array
             The query z-coordinate
         """
         grad_Z = np.zeros((3, *y.shape))
         for z_inj in self.z_inj:
-            grad_Z += self.grad_Z_3D_single_inj(x, y, z, z_inj)
+            grad_Z += self.grad_Z_3D_single_inj(x, y, z, float(z_inj))
         return grad_Z
 
-    def Z_3D_adjusted(self, x, y, z):
+    def Z_3D_adjusted(self, x: Array, y: Array, z: Array) -> Array:
         """
         This method computes the mixture fraction for the Jet-in-Crossflow
         model in 3D for all injectors (summed) with the boundary clipping adjustment.
-        x: float
+        x: Array
             The query x-coordinate
-        y: float
+        y: Array
             The query y-coordinate
-        z: float
+        z: Array
             The query z-coordinate
         """
         Z_adjusted = self.Z_3D(x, y, z) * self.get_adjustment_factor(x, y)
@@ -337,49 +323,36 @@ class AnalyticJICF:
             Z_adjusted, 1.0
         )  # TODO: This cap introduces error in the integral. Distribute somehow?
 
-    def grad_Z_3D_adjusted(self, x, y, z):
+    def grad_Z_3D_adjusted(self, x: Array, y: Array, z: Array) -> Array:
         """
         This method computes the gradient of the mixture fraction for the Jet-in-Crossflow
         model in 3D for all injectors (summed) with the boundary clipping adjustment.
-        x: float
+        x: Array
             The query x-coordinate
-        y: float
+        y: Array
             The query y-coordinate
-        z: float
+        z: Array
             The query z-coordinate
         """
         return self.grad_Z_3D(x, y, z) * self.get_adjustment_factor(x, y)
 
-    def Z_3D_single_inj(self, x, y, z, z_inj):
+    def Z_3D_single_inj(self, x: Array, y: Array, z: Array, z_inj: float) -> Array:
         """
         This method computes the mixture fraction for the Jet-in-Crossflow
         model in 3D for a single injector at (x_inj, 0, z_inj).
-        x: float
+        x: Array
             The query x-coordinate
-        y: float
+        y: Array
             The query y-coordinate
-        z: float
+        z: Array
             The query z-coordinate
         z_inj: float
             The injector z-coordinate
         """
-        if np.isscalar(x):
-            x_arr = np.array([x])
-            y_arr = np.array([y])
-            z_arr = np.array([z])
-        else:
-            x_arr = x
-            y_arr = y
-            z_arr = z
-
         # Compute the nearest point on the centerline and the distance squared
-        x_cl = np.zeros([len(x_arr), len(self.mdot_inj)])
-        n2 = np.zeros_like(x_cl)
-        for i_m in range(len(self.mdot_inj)):
-            x_cl[:, i_m], _, n2[:, i_m] = self.nearest_on_cl(
-                x_arr, y_arr, z_arr - z_inj, i_m
-            )
+        x_cl, _, n2 = self.nearest_on_cl(x, y, z - z_inj)
 
+        # Compute the centerline fuel mass fraction
         Z_cl = self.Z_cl(x_cl)
 
         sigma2 = np.divide(
@@ -389,15 +362,15 @@ class AnalyticJICF:
             np.divide(-n2, 2 * sigma2, out=np.zeros_like(sigma2), where=sigma2 > 0)
         )
 
-    def grad_Z_3D_single_inj(self, x, y, z, z_inj):
+    def grad_Z_3D_single_inj(self, x: Array, y: Array, z: Array, z_inj: float) -> Array:
         """
         This method computes the gradient of the mixture fraction for the Jet-in-Crossflow
         model in 3D for a single injector at (x_inj, 0, z_inj).
-        x: float
+        x: Array
             The query x-coordinate
-        y: float
+        y: Array
             The query y-coordinate
-        z: float
+        z: Array
             The query z-coordinate
         z_inj: float
             The injector z-coordinate
@@ -412,41 +385,5 @@ class AnalyticJICF:
         # (Assume gaussian, rho_inj * u_inj * Z_inj * A_inj = rho * u * int(Z * dA))
         # where int(Z * dA) = 2 * pi * sigma^2 * Z_cl
         sigma2 = self.Z_cl_int / (Z_cl * 2 * np.pi)
-        return (
-            -Z_cl
-            * np.array([x - x_cl, y - y_cl, z - z_inj])
-            / (2 * sigma2)
-            * np.exp(-n2 / (2 * sigma2))
-        )
-
-    def Z_avg_var(self, x):
-        Z_avg = np.zeros_like(self.mdot_inj)
-        Z_var = np.zeros_like(self.mdot_inj)
-        for i_m in range(len(self.mdot_inj)):
-            if np.isnan(self.rho_inj[i_m]):
-                Z_avg[i_m] = 0.0
-                Z_var[i_m] = 0.0
-                continue
-
-            def func(z, y, i_m=i_m):
-                return self.Z_3D(x, y, z)[i_m]
-
-            Z_avg[i_m] = (
-                2.0
-                * integrate.dblquad(
-                    func, 0, self.h, lambda y: 0 * y, lambda y: self.w / 2 + 0 * y
-                )[0]
-                / (self.w * self.h)
-            )
-
-            def func(z, y, i_m=i_m):
-                return (self.Z_3D(x, y, z)[i_m] - Z_avg[i_m]) ** 2
-
-            Z_var[i_m] = (
-                2.0
-                * integrate.dblquad(
-                    func, 0, self.h, lambda y: 0 * y, lambda y: self.w / 2 + 0 * y
-                )[0]
-                / (self.w * self.h)
-            )
-        return Z_avg, Z_var
+        dxyz = np.stack((x - x_cl, y - y_cl, z - z_inj), axis=0)
+        return -Z_cl * dxyz / (2 * sigma2) * np.exp(-n2 / (2 * sigma2))

--- a/src/stanshock/models/jicf/profile.py
+++ b/src/stanshock/models/jicf/profile.py
@@ -171,12 +171,8 @@ class AnalyticJICF:
         def n2_func_y_cl(y_cl: Array, x: Array, y: Array, dz: Array) -> Array:
             return (x - self.x_cl_from_y_cl(y_cl)) ** 2 + (y - y_cl) ** 2 + dz**2
 
-        x_bracket: tuple[float, float, float] = (
-            self.x[0],
-            0.5 * (self.x[0] + self.x[-1]),
-            self.x[-1],
-        )
-        y_bracket: tuple[float, float, float] = (0.0, 0.5 * self.h, self.h)
+        x_guess = np.maximum(0.0, x)
+        x_bracket: tuple[float, Array, float] = (0.0, x_guess, self.x[-1])
 
         x, y, dz = np.broadcast_arrays(x, y, dz)
         x_cl = np.zeros((*x.shape, self.nJ))
@@ -196,10 +192,15 @@ class AnalyticJICF:
             idx = dy_cl_dx > 1
 
             # Compute the y_cl which minimizes n2
+            y_bracket: tuple[float, Array, float] = (0.0, y_cl[idx, i_m], self.h)
             res = find_minimum(n2_func_y_cl, y_bracket, args=(x[idx], y[idx], dz[idx]))
             y_cl[idx, i_m] = res.x
             n2[idx, i_m] = res.f_x
             x_cl[idx, i_m] = self.x_cl_from_y_cl(y_cl[idx, i_m])
+
+        x_cl[np.isnan(x_cl)] = 0.0
+        y_cl[np.isnan(y_cl)] = 0.0
+        n2[np.isnan(n2)] = 0.0
 
         return x_cl, y_cl, n2
 
@@ -208,9 +209,8 @@ class AnalyticJICF:
         denom = np.divide(1.0, r_u, out=np.zeros_like(r_u), where=r_u > 0)
         term = x_cl * denom / self.d_inj
         term = np.power(term, -2.0 / 3.0, out=np.zeros_like(term), where=term > 0)
-        Z = (
-            0.85 * denom * np.sqrt(self.rho_inj[self.i_m] / self.rho) * term
-        )  # Hasselbrink and Mungal 2001 Pt. 1
+        # Hasselbrink and Mungal 2001 Pt. 1
+        Z = 0.85 * denom * np.sqrt(self.rho_inj[self.i_m] / self.rho) * term
         return np.clip(Z, self.Z_gl[self.i_m], 1.0)
 
     def calc_adjustment_factor(self) -> None:

--- a/src/stanshock/models/jicf/profile.py
+++ b/src/stanshock/models/jicf/profile.py
@@ -85,8 +85,12 @@ class AnalyticJICF:
 
         # Properties of the injected fluid
         self.mdot_inj = self.rho_inj * self.u_inj * self.A_inj
+        self.nJ = len(self.mdot_inj)
         gas.X = self.fuel_def
         self.Y_fuel = gas.Y
+
+        # Index into the mass flux array
+        self.i_m: slice | int = slice(None)
 
         # Integral of Z across centerline normal plane
         A_inj = np.pi * (self.d_inj / 2.0) ** 2
@@ -97,7 +101,7 @@ class AnalyticJICF:
         mdot_a = self.rho * self.u * self.A
         self.phi_gl = np.zeros_like(self.mdot_inj)
         self.Z_gl = np.zeros_like(self.mdot_inj)
-        for i_m in range(len(self.mdot_inj)):
+        for i_m in range(self.nJ):
             Y_ox = mdot_a / (mdot_a + self.mdot_inj[i_m])
             gas.Y = Y_ox * self.Y_ox + (1.0 - Y_ox) * self.Y_fuel
             self.phi_gl[i_m] = gas.equivalence_ratio(self.fuel_def, self.ox_def)
@@ -123,12 +127,11 @@ class AnalyticJICF:
         # return self.d_inj * 0.527 * self.r_u**1.178 * (x_cl / self.d_inj)**0.314 # Karagozian 1986
 
         # SONIC VERSION
-        denom = np.divide(
-            1.0, self.d_inj * self.J, out=np.zeros_like(self.J), where=self.J > 0
-        )
+        J = self.J[self.i_m]
+        denom = np.divide(1.0, self.d_inj * J, out=np.zeros_like(J), where=J > 0)
         term = x_cl * denom
         term = np.power(term, 0.344, out=np.zeros_like(term), where=term > 0)
-        return self.d_inj * self.J * 1.23 * term  # Gruber 1995 JPP
+        return self.d_inj * J * 1.23 * term  # Gruber 1995 JPP
         # return self.d_inj * self.J * 1.20 * ((x_cl + self.d_inj/2) / (self.d_inj * self.J))**0.344 # Gruber 1997 Phys. Fluids
         # return self.d_inj * 2.173 / self.J**0.276 * (x_cl / self.d_inj)**0.281 # Rothstein and Wantuck 1992
 
@@ -137,10 +140,9 @@ class AnalyticJICF:
         # return (y_cl / (self.r_u * self.d_inj * 1.6))**(3.0) * self.r_u * self.d_inj # Hasselbrink and Mungal 2001 Pt. 2
 
         # SONIC VERSION
-        denom = np.divide(
-            1.0, self.d_inj * self.J * 1.23, out=np.zeros_like(self.J), where=self.J > 0
-        )
-        return (y_cl * denom) ** (1.0 / 0.344) * self.d_inj * self.J  # Gruber 1995 JPP
+        J = self.J[self.i_m]
+        denom = np.divide(1.0, self.d_inj * J * 1.23, out=np.zeros_like(J), where=J > 0)
+        return (y_cl * denom) ** (1.0 / 0.344) * self.d_inj * J  # Gruber 1995 JPP
         # return (y_cl / (self.d_inj * self.J * 1.20))**(1.0 / 0.344) * self.d_inj * self.J - self.d_inj/2 # Gruber 1997 Phys. Fluids
 
     def dy_cl_dx(self, x_cl: Array) -> Array:
@@ -148,12 +150,11 @@ class AnalyticJICF:
         # return (self.r_u * self.d_inj)**(2.0/3.0) * 1.6 * (1.0/3.0) * x_cl**(-2.0/3.0) # Hasselbrink and Mungal 2001 Pt. 2
 
         # SONIC VERSION
-        denom = np.divide(
-            1.0, self.d_inj * self.J, out=np.zeros_like(self.J), where=self.J > 0
-        )
+        J = self.J[self.i_m]
+        denom = np.divide(1.0, self.d_inj * J, out=np.zeros_like(J), where=J > 0)
         term = x_cl * denom
         term = np.power(term, 0.344 - 1.0, out=np.zeros_like(term), where=term > 0)
-        return 0.344 * self.d_inj * self.J * 1.23 * term * denom  # Gruber 1995 JPP
+        return 0.344 * self.d_inj * J * 1.23 * term * denom  # Gruber 1995 JPP
         # return (0.344 *
         #         self.d_inj * self.J * 1.20 * ((x_cl + self.d_inj/2) / (self.d_inj * self.J))**(0.344 - 1.0) *
         #         (1.0 / (self.d_inj * self.J))) # Gruber 1997 Phys. Fluids
@@ -170,40 +171,47 @@ class AnalyticJICF:
         def n2_func_y_cl(y_cl: Array, x: Array, y: Array, dz: Array) -> Array:
             return (x - self.x_cl_from_y_cl(y_cl)) ** 2 + (y - y_cl) ** 2 + dz**2
 
-        # Compute the x_cl which minimizes n2
         x_bracket: tuple[float, float, float] = (
             self.x[0],
             0.5 * (self.x[0] + self.x[-1]),
             self.x[-1],
         )
-        res = find_minimum(n2_func_x_cl, x_bracket, args=(x, y, dz))
-        x_cl = res.x
-        n2 = res.f_x
-        y_cl = self.y_cl(x_cl)
-
-        # For points where dy_cl/dx > 1
-        dy_cl_dx = self.dy_cl_dx(x_cl)
-        idx = dy_cl_dx > 1
-
-        # Compute the y_cl which minimizes n2
         y_bracket: tuple[float, float, float] = (0.0, 0.5 * self.h, self.h)
-        res = find_minimum(n2_func_y_cl, y_bracket, args=(x[idx], y[idx], dz[idx]))
-        y_cl[idx] = res.x
-        n2[idx] = res.f_x
-        x_cl[idx] = self.x_cl_from_y_cl(y_cl[idx])
+
+        x, y, dz = np.broadcast_arrays(x, y, dz)
+        x_cl = np.zeros((*x.shape, self.nJ))
+        y_cl = np.zeros((*x.shape, self.nJ))
+        n2 = np.zeros((*x.shape, self.nJ))
+        for i_m in range(self.nJ):
+            self.i_m = i_m
+
+            # Compute the x_cl which minimizes n2
+            res = find_minimum(n2_func_x_cl, x_bracket, args=(x, y, dz))
+            x_cl[..., i_m] = res.x
+            n2[..., i_m] = res.f_x
+            y_cl[..., i_m] = self.y_cl(x_cl[..., i_m])
+
+            # For points where dy_cl/dx > 1
+            dy_cl_dx = self.dy_cl_dx(x_cl[..., i_m])
+            idx = dy_cl_dx > 1
+
+            # Compute the y_cl which minimizes n2
+            res = find_minimum(n2_func_y_cl, y_bracket, args=(x[idx], y[idx], dz[idx]))
+            y_cl[idx, i_m] = res.x
+            n2[idx, i_m] = res.f_x
+            x_cl[idx, i_m] = self.x_cl_from_y_cl(y_cl[idx, i_m])
 
         return x_cl, y_cl, n2
 
     def Z_cl(self, x_cl: Array) -> Array:
-        denom = np.divide(
-            1.0, self.r_u, out=np.zeros_like(self.r_u), where=self.r_u > 0
-        )
+        r_u = self.r_u[self.i_m]
+        denom = np.divide(1.0, r_u, out=np.zeros_like(r_u), where=r_u > 0)
         term = x_cl * denom / self.d_inj
         term = np.power(term, -2.0 / 3.0, out=np.zeros_like(term), where=term > 0)
         Z = (
-            0.85 * denom * np.sqrt(self.rho_inj / self.rho) * term
+            0.85 * denom * np.sqrt(self.rho_inj[self.i_m] / self.rho) * term
         )  # Hasselbrink and Mungal 2001 Pt. 1
-        return np.clip(Z, self.Z_gl, 1.0)
+        return np.clip(Z, self.Z_gl[self.i_m], 1.0)
 
     def calc_adjustment_factor(self) -> None:
         print("Computing adjustment factor...")
@@ -212,29 +220,28 @@ class AnalyticJICF:
 
         # Create grid along the centerline
         y_cl_arr = np.linspace(0, y_cl_max, 1000, axis=0)
-        x_cl_arr = self.x_cl_from_y_cl(y_cl_arr)
 
-        for i_m in tqdm(range(len(self.mdot_inj))):
+        for i_m in tqdm(range(self.nJ)):
             if self.u_inj[i_m] == 0.0:
                 self.adjustment_factor_interp.append(np.ones_like)
                 continue
 
             # Iterate over the centerline
+            self.i_m = i_m
+            x_cl_arr = self.x_cl_from_y_cl(y_cl_arr[:, i_m])
             adjustment_factor_arr = self.calc_adjustment_factor_xy(
-                x_cl_arr[:, i_m], y_cl_arr[:, i_m], i_m
+                x_cl_arr, y_cl_arr[:, i_m]
             )
             adjustment_factor_arr[np.isnan(adjustment_factor_arr)] = 1.0
 
             # Interpolate over y because the most rapid variation is near the injection point
             self.adjustment_factor_interp.append(
-                interpolate.CubicSpline(
-                    y_cl_arr[..., i_m], adjustment_factor_arr, axis=1
-                )
+                interpolate.CubicSpline(y_cl_arr[:, i_m], adjustment_factor_arr)
             )
 
-    def calc_adjustment_factor_xy(self, x_cl: Array, y_cl: Array, i_m: int) -> Array:
+    def calc_adjustment_factor_xy(self, x_cl: Array, y_cl: Array) -> Array:
         # Compute the normal to the centerline
-        dy_cl_dx = self.dy_cl_dx(x_cl[:, None])[:, i_m]
+        dy_cl_dx = self.dy_cl_dx(x_cl)
         ds = np.stack([np.full_like(x_cl, 1.0), dy_cl_dx], axis=0)
         ds /= np.linalg.norm(ds, axis=0)
         dn = np.array([-ds[1], ds[0]])
@@ -245,10 +252,10 @@ class AnalyticJICF:
         xi_lo = -np.sqrt((x_bot - x_cl) ** 2 + (0 - y_cl) ** 2)
         xi_hi = np.sqrt((x_top - x_cl) ** 2 + (self.h - y_cl) ** 2)
 
-        Z_int_nobound = self.n_inj * self.Z_cl_int[i_m]
+        Z_int_nobound = self.n_inj * self.Z_cl_int[self.i_m]
 
-        Z_cl = self.Z_cl(x_cl[:, None])[:, i_m]
-        sigma2 = self.Z_cl_int[i_m] / (2 * np.pi * Z_cl)
+        Z_cl = self.Z_cl(x_cl)
+        sigma2 = self.Z_cl_int[self.i_m] / (2 * np.pi * Z_cl)
         s2s = np.sqrt(2 * sigma2)
 
         Z_int_bound = 0.0
@@ -267,10 +274,11 @@ class AnalyticJICF:
         return np.asarray(Z_int_nobound / Z_int_bound)
 
     def get_adjustment_factor(self, x: Array, y: Array) -> Array:
-        fac = np.zeros([*x.shape, len(self.mdot_inj)])
+        shape = np.broadcast_shapes(x.shape, y.shape)
+        fac = np.zeros((*shape, self.nJ))
         _, y_cl, _ = self.nearest_on_cl(x, y, np.zeros_like(x))
-        for i_m in range(len(self.mdot_inj)):
-            fac[..., i_m] = self.adjustment_factor_interp[i_m](y_cl)
+        for i_m in range(self.nJ):
+            fac[..., i_m] = self.adjustment_factor_interp[i_m](y_cl[..., i_m])
 
         return fac
 
@@ -285,7 +293,7 @@ class AnalyticJICF:
         z: Array
             The query z-coordinate
         """
-        Z: Array = np.zeros_like(x)
+        Z: Array = np.zeros((*x.shape, self.nJ))
         for z_inj in self.z_inj:
             Z = Z + self.Z_3D_single_inj(x, y, z, float(z_inj))
         return Z
@@ -301,7 +309,7 @@ class AnalyticJICF:
         z: Array
             The query z-coordinate
         """
-        grad_Z = np.zeros((3, *y.shape))
+        grad_Z = np.zeros((3, *y.shape, self.nJ))
         for z_inj in self.z_inj:
             grad_Z += self.grad_Z_3D_single_inj(x, y, z, float(z_inj))
         return grad_Z

--- a/src/stanshock/models/jicf/profile.py
+++ b/src/stanshock/models/jicf/profile.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 
 import numpy as np
 from scipy import interpolate, special
-from scipy.optimize.elementwise import find_minimum
+from scipy.optimize.elementwise import find_root
 from tqdm import tqdm
 
 from stanshock.physics.flamelet import FPVTable
@@ -153,54 +153,79 @@ class AnalyticJICF:
         J = self.J[self.i_m]
         denom = np.divide(1.0, self.d_inj * J, out=np.zeros_like(J), where=J > 0)
         term = x_cl * denom
-        term = np.power(term, 0.344 - 1.0, out=np.zeros_like(term), where=term > 0)
-        return 0.344 * self.d_inj * J * 1.23 * term * denom  # Gruber 1995 JPP
+        term = np.power(term, 0.344 - 1.0, out=np.full_like(term, 1e20), where=term > 0)
+        return 0.344 * 1.23 * term  # Gruber 1995 JPP
         # return (0.344 *
         #         self.d_inj * self.J * 1.20 * ((x_cl + self.d_inj/2) / (self.d_inj * self.J))**(0.344 - 1.0) *
         #         (1.0 / (self.d_inj * self.J))) # Gruber 1997 Phys. Fluids
 
+    def dx_cl_dy(self, y_cl: Array) -> Array:
+        # SONIC VERSION
+        J = self.J[self.i_m]
+        denom = np.divide(1.0, self.d_inj * J * 1.23, out=np.zeros_like(J), where=J > 0)
+        term = y_cl * denom
+        c = 1.0 / 0.344
+        term = np.power(term, c - 1.0, out=np.zeros_like(term), where=term > 0)
+        return c / 1.23 * term
+
     def nearest_on_cl(
         self, x: Array, y: Array, dz: Array
     ) -> tuple[Array, Array, Array]:
-        # Define the centerline
-        # Note: dz makes no difference in the minimization, but it's more convenient to include it here
-        # so that the n2 is correct
-        def n2_func_x_cl(x_cl: Array, x: Array, y: Array, dz: Array) -> Array:
-            return (x - x_cl) ** 2 + (y - self.y_cl(x_cl)) ** 2 + dz**2
+        # Define distance to the centerline as function of x or y
+        def n2_func_x_cl(x_cl: Array, x: Array, y: Array) -> Array:
+            return (x - x_cl) ** 2 + (y - self.y_cl(x_cl)) ** 2
 
-        def n2_func_y_cl(y_cl: Array, x: Array, y: Array, dz: Array) -> Array:
-            return (x - self.x_cl_from_y_cl(y_cl)) ** 2 + (y - y_cl) ** 2 + dz**2
+        def n2_func_y_cl(y_cl: Array, x: Array, y: Array) -> Array:
+            return (x - self.x_cl_from_y_cl(y_cl)) ** 2 + (y - y_cl) ** 2
 
-        x_guess = np.maximum(0.0, x)
-        x_bracket: tuple[float, Array, float] = (0.0, x_guess, self.x[-1])
+        def distance_derivative_x(x_cl: Array, x: Array, y: Array) -> Array:
+            """Derivative of the squared Euclidean distance w.r.t. x_cl"""
+            dydx = self.dy_cl_dx(x_cl)
+            # return (x - x_cl) + (self.y_cl(x_cl) - y)*dydx
+            return x_cl - x + (self.y_cl(x_cl) - y) * dydx
 
-        x, y, dz = np.broadcast_arrays(x, y, dz)
+        def distance_derivative_y(y_cl: Array, x: Array, y: Array) -> Array:
+            """Derivative of the squared Euclidean distance w.r.t. y_cl"""
+            dxdy = self.dx_cl_dy(y_cl)
+            # return (self.x_cl_from_y_cl(y_cl) - x)*dxdy + (y - y_cl)
+            return y_cl - y + (self.x_cl_from_y_cl(y_cl) - x) * dxdy
+
+        x_bracket: tuple[float, float] = (0.0, self.x[-1])
+
+        x, y = np.broadcast_arrays(x, y)
         x_cl = np.zeros((*x.shape, self.nJ))
         y_cl = np.zeros((*x.shape, self.nJ))
         n2 = np.zeros((*x.shape, self.nJ))
         for i_m in range(self.nJ):
+            if self.J[i_m] == 0.0:
+                continue
+
             self.i_m = i_m
 
             # Compute the x_cl which minimizes n2
-            res = find_minimum(n2_func_x_cl, x_bracket, args=(x, y, dz))
+            res = find_root(distance_derivative_x, x_bracket, args=(x, y))
             x_cl[..., i_m] = res.x
-            n2[..., i_m] = res.f_x
+            n2[..., i_m] = n2_func_x_cl(x_cl[..., i_m], x, y)
             y_cl[..., i_m] = self.y_cl(x_cl[..., i_m])
 
-            # For points where dy_cl/dx > 1
-            dy_cl_dx = self.dy_cl_dx(x_cl[..., i_m])
-            idx = dy_cl_dx > 1
+            # Retry points where root solve failed
+            # idx = res.status < 0
+            idx = np.logical_or(res.status < 0, x == 0.0)
 
             # Compute the y_cl which minimizes n2
-            y_bracket: tuple[float, Array, float] = (0.0, y_cl[idx, i_m], self.h)
-            res = find_minimum(n2_func_y_cl, y_bracket, args=(x[idx], y[idx], dz[idx]))
+            y_bracket: tuple[float, float] = (0.0, self.h)
+            res = find_root(distance_derivative_y, y_bracket, args=(x[idx], y[idx]))
             y_cl[idx, i_m] = res.x
-            n2[idx, i_m] = res.f_x
             x_cl[idx, i_m] = self.x_cl_from_y_cl(y_cl[idx, i_m])
+            n2[idx, i_m] = n2_func_y_cl(y_cl[idx, i_m], x[idx], y[idx])
 
         x_cl[np.isnan(x_cl)] = 0.0
         y_cl[np.isnan(y_cl)] = 0.0
         n2[np.isnan(n2)] = 0.0
+
+        # Add z-offset to the Euclidean distance
+        n2 = n2 + dz[..., None] ** 2
+        n2, x_cl, y_cl = np.broadcast_arrays(n2, x_cl, y_cl)
 
         return x_cl, y_cl, n2
 
@@ -208,7 +233,7 @@ class AnalyticJICF:
         r_u = self.r_u[self.i_m]
         denom = np.divide(1.0, r_u, out=np.zeros_like(r_u), where=r_u > 0)
         term = x_cl * denom / self.d_inj
-        term = np.power(term, -2.0 / 3.0, out=np.zeros_like(term), where=term > 0)
+        term = np.power(term, -2.0 / 3.0, out=np.full_like(term, 1e20), where=term > 0)
         # Hasselbrink and Mungal 2001 Pt. 1
         Z = 0.85 * denom * np.sqrt(self.rho_inj[self.i_m] / self.rho) * term
         return np.clip(Z, self.Z_gl[self.i_m], 1.0)

--- a/src/stanshock/models/jicf/source.py
+++ b/src/stanshock/models/jicf/source.py
@@ -115,11 +115,18 @@ class JICFChemistrySource(RightHandSide):
         self, injector: FuelInjector, **precompute_steps: Unpack[PrecomputeSteps]
     ) -> None:
         super().__init__(**precompute_steps)
+        assert self.geometry is not None
         self.injector = injector
+        xc = self.geometry.xc
+        idx_inj = np.nonzero(xc > self.injector.jicf.x_inj)[0][0] - 1
+        idx_noz = np.nonzero(xc > self.injector.jicf.x_noz)[0][0] + 1
+        self.idx_input = slice(idx_inj, idx_noz)
+        self.xc = xc[self.idx_input]
 
         # Reactions only directly affect progress variable
         self.idx_source = np.array([4])
-        self.shape_output = (self.shape_output[0], 1)
+        self.shape_input = (idx_noz - idx_inj, -1)
+        self.shape_output = (idx_noz - idx_inj, 1)
 
     def source_implementation(
         self,
@@ -144,8 +151,9 @@ class JICFChemistrySource(RightHandSide):
             np.flip(self.injector.fluid_tips, axis=0)[:, 0],
             np.flip(self.injector.fluid_tips, axis=0)[:, 1],
             k=1,
-        )(self.injector.xc)
-        Zvar = self.injector.jicf.Z_var_profile_interp((mdot_inj, self.injector.xc))
+        )(self.xc)
+
+        Zvar = self.injector.jicf.Z_var_profile_interp((self.xc, mdot_inj))
         Zvar = np.maximum(Zvar, 10 ** self.injector.jicf.logsigma2_vec.min())
 
         return (

--- a/src/stanshock/models/jicf/source.py
+++ b/src/stanshock/models/jicf/source.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+from scipy.interpolate import make_interp_spline
 
 from stanshock.models.jicf.generate import JICModel
 from stanshock.physics.flamelet import FPVTable
@@ -38,7 +39,7 @@ class FuelInjector(RightHandSide):
         # Position of the first injected fluid particle
         self.fluid_tips = np.array([[self.jicf.x_inj, self.jicf.mdot_inj[0]]])
 
-    def update_fluid_tip_positions(self, dt, t, u):
+    def update_fluid_tip_positions(self, dt: float, t: float, u: Array) -> None:
         """
         This method updates the position of the fluid tips based on the velocity
         of the fluid.
@@ -46,16 +47,16 @@ class FuelInjector(RightHandSide):
             The current time
         dt: float
             The time step
-        x: float
-            The current x-coordinate of the fluid tips
-        u: float
+        u: Array
             The current velocity of the fluid
         """
         # Update the fluid tip positions
-        self.fluid_tips[:, 0] += dt * np.interp(self.fluid_tips[:, 0], self.xc, u)
+        self.fluid_tips[:, 0] += dt * make_interp_spline(self.xc, u, k=1)(
+            self.fluid_tips[:, 0]
+        )
 
         # Emit a new fluid tip
-        mdot = np.interp(t, self.jicf.t_inj, self.jicf.mdot_inj)
+        mdot = self.jicf.mdot_f_interp(t)
         next_tip = np.array([[self.jicf.x_inj, mdot]])
         self.fluid_tips = np.concatenate([self.fluid_tips, next_tip], axis=0)
 
@@ -75,7 +76,7 @@ class FuelInjector(RightHandSide):
         state_array_local = np.reshape(state_array_local, self.shape_input)
         rhs = np.zeros_like(state_array_local)
 
-        mdot = np.interp(time, self.jicf.t_inj, self.jicf.mdot_inj)
+        mdot: Array | float = self.jicf.mdot_f_interp(time)
         u_inj = np.interp(time, self.jicf.t_inj, self.jicf.u_inj)
         E_inj = np.interp(time, self.jicf.t_inj, self.jicf.E_inj)
         L_src = 3e-2
@@ -139,11 +140,11 @@ class JICFChemistrySource(RightHandSide):
         factor = self.physics.get_source_progress_variable_compressibility_factor(state)
 
         # Get the mixture fraction variance profile
-        mdot_inj = np.interp(
-            self.injector.xc,
+        mdot_inj = make_interp_spline(
             np.flip(self.injector.fluid_tips, axis=0)[:, 0],
             np.flip(self.injector.fluid_tips, axis=0)[:, 1],
-        )
+            k=1,
+        )(self.injector.xc)
         Zvar = self.injector.jicf.Z_var_profile_interp((mdot_inj, self.injector.xc))
         Zvar = np.maximum(Zvar, 10 ** self.injector.jicf.logsigma2_vec.min())
 

--- a/src/stanshock/system/base.py
+++ b/src/stanshock/system/base.py
@@ -353,7 +353,10 @@ class CombinedSource(RightHandSide):
         super().__init__(**precompute_steps)
 
         # Don't modify the shapes, as the sources will handle that internally
-        self.shape_full = max(source.shape_full for source in self.sources)
+        self.shape_full = (
+            max(source.shape_full[0] for source in self.sources),
+            max(source.shape_full[1] for source in self.sources),
+        )
         self.shape_input = self.shape_output = self.shape_full
         self.idx_input = self.idx_output = np.s_[:]
 
@@ -364,21 +367,22 @@ class CombinedSource(RightHandSide):
         gamma_star: Array | None = None,
         e0_star: Array | None = None,
     ) -> Array:
-        rhs: Array = np.zeros_like(state_array_local)
-
-        state_array_local, state, face_states, avg_face_states, face_gradients = (
+        state_array_temp, state, face_states, avg_face_states, face_gradients = (
             self.precompute_for_source(time, state_array_local, gamma_star, e0_star)
         )
+        state_array_temp = np.reshape(state_array_temp, self.shape_input)
+        rhs: Array = np.zeros_like(state_array_temp)
 
         for source in self.sources:
+            rhs_flat = np.ravel(rhs[source.idx_input])
             dydt = source.source_implementation(
                 time=time,
-                state_array_local=state_array_local,
-                state=state,
+                state_array_local=state_array_temp[source.idx_input],
+                state=state[source.idx_input] if state is not None else state,
                 face_states=face_states,
                 avg_face_states=avg_face_states,
                 face_gradients=face_gradients,
             )
-            rhs = source.add_source(rhs, dydt)
+            rhs_flat[:] = source.add_source(rhs_flat, dydt)
 
-        return rhs
+        return np.ravel(rhs)

--- a/tests/test_time_integration.py
+++ b/tests/test_time_integration.py
@@ -173,7 +173,7 @@ class TimeIntegrationCase:
 
         if self.analytical_function is None:
             ode_result = solve_ivp(
-                fun=rhs.source,
+                fun=rhs.source_full,
                 t_span=self.t_span,
                 y0=self.y_init,
                 t_eval=t_eval,


### PR DESCRIPTION
This commit reworks the JICF calculations to be vectorized as much as possible in order to speed them up and simplify the logic, and adds type annotations throughout.